### PR TITLE
Typos in why.rst

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -21,7 +21,7 @@ from the standard library.
 
 click is actually implemented as a wrapper around ``optparse`` and does
 not implement any parsing itself.  The reason it's not based on
-``argparse`` is that ``argparse``\'s design does not allow proper nesting
+``argparse`` is that ``argparse`` does not allow proper nesting
 of commands by design and has some deficiencies when it comes to POSIX
 compliant argument handling.
 
@@ -32,7 +32,7 @@ Click is designed to be fun to work with and at the same time not stand in
 your way.  It's not overly flexible at the same time either.  Currently
 for instance it does not allow you to customize the help pages too much.
 This is intentional because click is desigend to allow you to nest command
-line utilities.  The idae is that you can have a system that works
+line utilities.  The idea is that you can have a system that works
 together with another system by tacking two click instances together and
 they will continue working as they should.
 


### PR DESCRIPTION
double use of word design
idae -> idea
