### PR TITLE
Windows compatibility

### DIFF
--- a/click.py
+++ b/click.py
@@ -20,8 +20,6 @@ import inspect
 import getpass
 import optparse
 import textwrap
-import fcntl
-import termios
 import struct
 from itertools import chain
 
@@ -75,6 +73,8 @@ def get_terminal_size():
     """
     def ioctl_gwinsz(fd):
         try:
+            import fcntl
+            import termios
             cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
         except Exception:
             return


### PR DESCRIPTION
Importing fcntl and termios outside a try block in Windows would cause an error.
These modules are only used inside ioctl_gwinsz, so we can import them there.
