### PR TITLE
Logic typo and bug fix

### DIFF
--- a/click.py
+++ b/click.py
@@ -1322,7 +1322,7 @@ class Argument(Parameter):
         if not found:
             value = self.value_from_envvar(ctx)
             if self.nargs != 1:
-                value = (value,)
+                value = (value or ()) and (value,)
         return value, args
 
 

--- a/click.py
+++ b/click.py
@@ -1311,14 +1311,14 @@ class Argument(Parameter):
                 found = False
         elif self.nargs < 0:
             value = tuple(args)
-            found = not value
+            found = value
             args = []
         else:
             values = args[:self.nargs]
             values += [None] * (self.nargs - len(values))
             args = args[self.nargs:]
             value = tuple(values)
-            found = not value
+            found = value
         if not found:
             value = self.value_from_envvar(ctx)
             if self.nargs != 1:


### PR DESCRIPTION
If we can find values from args, we will not find from envs;

And we can't get value from args and envs, we should set value to () rather than (None,)
