### PR TITLE
ENH: support for --foo=~/bar

### DIFF
--- a/click/_optparse.py
+++ b/click/_optparse.py
@@ -15,6 +15,7 @@
     generated and optparse in the stdlib uses gettext for no good reason
     and might cause us issues.
 """
+import os
 import sys
 import textwrap
 
@@ -210,6 +211,8 @@ class Option(object):
 
     def process(self, opt, value, values, parser):
         if self.action == 'store':
+            if value.startswith('~/'):
+                value = os.path.join(os.environ['HOME'], value[2:])
             values[self.dest] = value
         elif self.action == 'store_const':
             values[self.dest] = self.const

--- a/click/_optparse.py
+++ b/click/_optparse.py
@@ -15,7 +15,6 @@
     generated and optparse in the stdlib uses gettext for no good reason
     and might cause us issues.
 """
-import os
 import sys
 import textwrap
 
@@ -211,8 +210,6 @@ class Option(object):
 
     def process(self, opt, value, values, parser):
         if self.action == 'store':
-            if value.startswith('~/'):
-                value = os.path.join(os.environ['HOME'], value[2:])
             values[self.dest] = value
         elif self.action == 'store_const':
             values[self.dest] = self.const

--- a/click/types.py
+++ b/click/types.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from ._compat import open_stream, text_type
@@ -171,6 +172,9 @@ class File(ParamType):
         try:
             if hasattr(value, 'read') or hasattr(value, 'write'):
                 return value
+            elif isinstance(value, str) and value.startswith('~/'):
+                value = os.path.join(os.environ['HOME'], value[2:])
+
             f, was_opened = open_stream(value, self.mode, self.encoding,
                                         self.errors)
             # If a context is provided we automatically close the file


### PR DESCRIPTION
One thing that has always frustrated me with `optparse` is that `~/` is not handled. This light PR is one approach to supporting `~/`, though it wasn't clear to me if this was the best place in code to handle it
