### PR TITLE
Repaired incorrect call to fail function in optparse

### DIFF
--- a/click/_optparse.py
+++ b/click/_optparse.py
@@ -470,7 +470,7 @@ class OptionParser(OptionContainer):
             i += 1                      # we have consumed a character
 
             if not option:
-                self.fail('no such option: %s' % opt)
+                self.error('no such option: %s' % opt)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.


### PR DESCRIPTION
Hello, just fixing a little error in the optparse module :smile: 

I came across this while typing an invalid option to my click script and getting the following exception:

```
Traceback (most recent call last):
  File "./clicker3.py", line 15, in <module>
    hello()
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/core.py", line 390, in __call__
    return self.main(*args, **kwargs)
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/core.py", line 373, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/core.py", line 309, in make_context
    opts, args = ctx._parser.parse_args(args=args)
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/_optparse.py", line 358, in parse_args
    self._process_args(largs, rargs, values)
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/_optparse.py", line 378, in _process_args
    self._process_short_opts(rargs, values)
  File "/home/fots/.pyenv/versions/flaskage/lib/python2.6/site-packages/click/_optparse.py", line 473, in _process_short_opts
    self.fail('no such option: %s' % opt)
AttributeError: '_SimplifiedOptionParser' object has no attribute 'fail'
```

Cheers
Fotis
