### PR TITLE
Added -h as an additional default help option

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -222,8 +222,9 @@ class Command(object):
                    help page after everything else.
     :param short_help: the short help to use for this command.  This is
                        shown on the command listing of the parent command.
-    :param add_help_option: by default each command registers a ``--help``
-                            option.  This can be disabled by this parameter.
+    :param add_help_option: by default each command registers ``--h`` and
+                            ``--help`` options.  These can be disabled by this
+                            parameter.
     """
     allow_extra_args = False
 
@@ -442,8 +443,8 @@ class MultiCommand(Command):
                             provided.  This option is enabled by default if
                             `invoke_without_command` is disabled or disabled
                             if it's enabled.  If enabled this will add
-                            ``--help`` as argument if no arguments are
-                            passed.
+                            ``-h`` and ``--help`` as arguments if no arguments
+                            are passed.
     :param subcommand_metavar: the string that is used in the documentation
                                to indicate the subcommand place.
     """

--- a/click/decorators.py
+++ b/click/decorators.py
@@ -238,7 +238,7 @@ def version_option(version, *param_decls, **attrs):
 
 
 def help_option(*param_decls, **attrs):
-    """Adds a ``--help`` option which immediately ends the program
+    """Adds ``-h`` and ``--help`` options which immediately end the program
     printing out the help page.  This is usually unnecessary to add as
     this is added by default to all commands unless supressed.
 
@@ -257,7 +257,7 @@ def help_option(*param_decls, **attrs):
         attrs.setdefault('help', 'Show this message and exit.')
         attrs.setdefault('is_eager', True)
         attrs['callback'] = callback
-        return option(*(param_decls or ('--help',)), **attrs)(f)
+        return option(*(param_decls or ('-h', '--help')), **attrs)(f)
     return decorator
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,12 +8,13 @@ def test_basic_functionality(runner):
         """Hello World!"""
         click.echo('I EXECUTED')
 
-    result = runner.invoke(cli, ['--help'])
-    assert not result.exception
-    assert 'Hello World!' in result.output
-    assert 'Show this message and exit.' in result.output
-    assert result.exit_code == 0
-    assert 'I EXECUTED' not in result.output
+    for help_option in ['-h', '--help']:
+        result = runner.invoke(cli, [help_option])
+        assert not result.exception
+        assert 'Hello World!' in result.output
+        assert 'Show this message and exit.' in result.output
+        assert result.exit_code == 0
+        assert 'I EXECUTED' not in result.output
 
     result = runner.invoke(cli, [])
     assert not result.exception


### PR DESCRIPTION
Hello! :smile: 

It would be really great to have -h as a default help option too as this is the standard with argparse and most Python users are accustomed to having it available for Python CLI scripts.

Thanks heaps
Fotis
