### PR TITLE
updating calls to click.echo to be click.utils.echo in docs

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -84,7 +84,7 @@ Example:
     @cli.command()
     @click.option('--count', default=1)
     def test(count):
-        click.echo('Count: %d' % count)
+        click.utils.echo('Count: %d' % count)
 
     @cli.command()
     @click.option('--count', default=1)

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -22,7 +22,7 @@ Example:
     @click.command()
     @click.argument('filename')
     def touch(filename):
-        click.echo(filename)
+        click.utils.echo(filename)
 
 And what it looks like:
 
@@ -49,7 +49,7 @@ Example:
     @click.argument('files', nargs=-1)
     def touch(files):
         for file in files:
-            click.echo(file)
+            click.utils.echo(file)
 
 And what it looks like:
 
@@ -108,7 +108,7 @@ Example usage:
     @click.command()
     @click.argument('src', envvar='SRC', type=click.File('r'))
     def echo(src):
-        click.echo(src.read())
+        click.utils.echo(src.read())
 
 And from the command line:
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -25,11 +25,11 @@ when an inner command runs:
     @click.group()
     @click.option('--debug/--no-debug', default=False)
     def cli(debug):
-        click.echo('Debug mode is %s' % ('on' if debug else 'off'))
+        click.utils.echo('Debug mode is %s' % ('on' if debug else 'off'))
 
     @cli.command()
     def sync():
-        click.echo('Synching')
+        click.utils.echo('Synching')
 
 Here is what this looks like:
 
@@ -72,7 +72,7 @@ script like this:
     @cli.command()
     @click.pass_context
     def sync(ctx):
-        click.echo('Debug is %s' % (ctx.obj['DEBUG'] and 'on' or 'off'))
+        click.utils.echo('Debug is %s' % (ctx.obj['DEBUG'] and 'on' or 'off'))
 
     if __name__ == '__main__':
         cli(obj={})
@@ -140,13 +140,13 @@ Example:
     @click.pass_context
     def cli(ctx):
         if ctx.invoked_subcommand is None:
-            click.echo('I was invoked without subcommand')
+            click.utils.echo('I was invoked without subcommand')
         else:
-            click.echo('I am about to invoke %s' % ctx.invoked_subcommand)
+            click.utils.echo('I am about to invoke %s' % ctx.invoked_subcommand)
 
     @cli.command()
     def sync():
-        click.echo('The subcommand')
+        click.utils.echo('The subcommand')
 
 And how it works in practice::
 

--- a/docs/complex.rst
+++ b/docs/complex.rst
@@ -210,7 +210,7 @@ As such it runs standalone:
     @click.command()
     @pass_repo
     def cp(repo):
-        click.echo(repo)
+        click.utils.echo(repo)
 
 As you can see:
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -21,7 +21,7 @@ Simple example:
     def hello(count, name):
         """This script prints hello NAME COUNT times."""
         for x in range(count):
-            click.echo('Hello %s!' % name)
+            click.utils.echo('Hello %s!' % name)
 
 And what it looks like:
 
@@ -51,7 +51,7 @@ optional.  This can be customized at all levels:
     def hello(count, name):
         """This script prints hello <name> <int> times."""
         for x in range(count):
-            click.echo('Hello %s!' % name)
+            click.utils.echo('Hello %s!' % name)
 
 Example:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ What does it look like?  A simple example can be this:
                   help='the person to greet', required=True)
     def hello(count, name):
         for x in range(count):
-            click.echo('Hello %s!' % name)
+            click.utils.echo('Hello %s!' % name)
 
     if __name__ == '__main__':
         hello()

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -20,7 +20,7 @@ value is used.  If no default value is provided the type is assumed to be
     @click.command()
     @click.option('--n', default=1)
     def dots(n):
-        click.echo('.' * n)
+        click.utils.echo('.' * n)
 
 And on the command line:
 
@@ -43,7 +43,7 @@ the ``nargs`` parameter.  The values are then stored as a tuple.
     @click.command()
     @click.option('--pos', nargs=2, type=float)
     def findme(pos):
-        click.echo('%s / %s' % pos)
+        click.utils.echo('%s / %s' % pos)
 
 And on the command line:
 
@@ -67,7 +67,7 @@ Example:
     @click.command()
     @click.option('--message', '-m', multiple=True)
     def commit(message):
-        click.echo('\n'.join(message))
+        click.utils.echo('\n'.join(message))
 
 And on the command line:
 
@@ -89,7 +89,7 @@ using the multiple flag and taking the length of the end result:
     @click.option('-v', '--verbose', is_flag=True, multiple=True)
     def log(verbose):
         verbosity = len(verbose)
-        click.echo('Verbosity: %s' % verbosity)
+        click.utils.echo('Verbosity: %s' % verbosity)
 
 And on the command line:
 
@@ -117,7 +117,7 @@ Example:
         rv = os.uname()[0]
         if shout:
             rv = rv.upper() + '!!!!111'
-        click.echo(rv)
+        click.utils.echo(rv)
 
 And on the command line:
 
@@ -139,7 +139,7 @@ manually inform click that something is a flag:
         rv = os.uname()[0]
         if shout:
             rv = rv.upper() + '!!!!111'
-        click.echo(rv)
+        click.utils.echo(rv)
 
 And on the command line:
 
@@ -164,7 +164,7 @@ the flag that should be the default.
                   default=True)
     @click.option('--lower', 'transformation', flag_value='lower')
     def info(transformation):
-        click.echo(getattr(os.uname()[0], transformation)())
+        click.utils.echo(getattr(os.uname()[0], transformation)())
 
 And on the command line:
 
@@ -190,7 +190,7 @@ Example:
     @click.command()
     @click.option('--hash-type', type=click.Choice(['md5', 'sha1']))
     def digest(hash_type):
-        click.echo(hash_type)
+        click.utils.echo(hash_type)
 
 What it looks like:
 
@@ -218,7 +218,7 @@ Example:
     @click.command()
     @click.option('--name', prompt=True)
     def hello(name):
-        click.echo('Hello %s!' % name)
+        click.utils.echo('Hello %s!' % name)
 
 And what it looks like:
 
@@ -235,7 +235,7 @@ a different one:
     @click.command()
     @click.option('--name', prompt='Your name please')
     def hello(name):
-        click.echo('Hello %s!' % name)
+        click.utils.echo('Hello %s!' % name)
 
 What it looks like:
 
@@ -255,7 +255,7 @@ useful for password input:
     @click.option('--password', prompt=True, hide_input=True,
                   confirmation_prompt=True)
     def encrypt(password):
-        click.echo('Encrypting password to %s' % password.encode('rot13'))
+        click.utils.echo('Encrypting password to %s' % password.encode('rot13'))
 
 What it looks like:
 
@@ -271,7 +271,7 @@ replaced with the :func:`password_option` decorator:
     @click.command()
     @click.password_option()
     def encrypt(password):
-        click.echo('Encrypting password to %s' % password.encode('rot13'))
+        click.utils.echo('Encrypting password to %s' % password.encode('rot13'))
 
 Callbacks and Eager Options
 ---------------------------
@@ -300,14 +300,14 @@ Here an example for a ``--version`` flag:
     def print_version(ctx, value):
         if not value:
             return
-        click.echo('Version 1.0')
+        click.utils.echo('Version 1.0')
         ctx.exit()
 
     @click.command()
     @click.option('--version', is_flag=True, callback=print_version,
                   expose_value=False, is_eager=True)
     def hello():
-        click.echo('Hello World!')
+        click.utils.echo('Hello World!')
 
 The `expose_value` parameter prevents the now pretty pointless ``version``
 parameter to be passed to the callback.  If that was not specified a
@@ -339,7 +339,7 @@ callback:
                   expose_value=False,
                   prompt='Are you sure you want to drop the db?')
     def dropdb():
-        click.echo('Dropped all tables!')
+        click.utils.echo('Dropped all tables!')
 
 And what it looks like on the command line:
 
@@ -356,7 +356,7 @@ replaced with the :func:`confirmation_option` decorator:
     @click.command()
     @click.confirmation_option('Are you sure you want to drop the db?')
     def dropdb():
-        click.echo('Dropped all tables!')
+        click.utils.echo('Dropped all tables!')
 
 Values from Environment Variables
 ---------------------------------
@@ -383,7 +383,7 @@ Example usage:
     @click.command()
     @click.option('--username')
     def greet(username):
-        click.echo('Hello %s!' % username)
+        click.utils.echo('Hello %s!' % username)
 
     if __name__ == '__main__':
         greet(auto_envvar_prefix='GREETER')
@@ -405,7 +405,7 @@ Example usage:
     @click.command()
     @click.option('--username', envvar='USERNAME')
     def greet(username):
-        click.echo('Hello %s!' % username)
+        click.utils.echo('Hello %s!' % username)
 
     if __name__ == '__main__':
         greet()

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -40,7 +40,7 @@ function comes in handy.  By default it returns the result of the prompt
 as boolean value::
 
     if click.confirm('Do you want to continue?'):
-        click.echo('Well done!')
+        click.utils.echo('Well done!')
 
 There is also the option to make it automatically abort the execution::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -24,7 +24,7 @@ function with this decorator will make it into a callable script:
 
     @click.command()
     def hello():
-        click.echo('Hello World!')
+        click.utils.echo('Hello World!')
 
 What's happening is that the decorator converts the function into a
 :class:`Command` which then can be invoked::
@@ -76,11 +76,11 @@ implements two commands for managing databases:
 
     @click.command()
     def initdb():
-        click.echo('Initialized the database')
+        click.utils.echo('Initialized the database')
 
     @click.command()
     def dropdb():
-        click.echo('Dropped the database')
+        click.utils.echo('Dropped the database')
 
     cli.add_command(initdb)
     cli.add_command(dropdb)
@@ -102,11 +102,11 @@ script can be written like this then:
 
     @cli.command()
     def initdb():
-        click.echo('Initialized the database')
+        click.utils.echo('Initialized the database')
 
     @cli.command()
     def dropdb():
-        click.echo('Dropped the database')
+        click.utils.echo('Dropped the database')
 
 Adding Parameters
 -----------------
@@ -120,7 +120,7 @@ To add parameters the :func:`option` and :func:`argument` decorators:
     @click.argument('name')
     def hello(count, name):
         for x in range(count):
-            click.echo('Hello %s!' % name)
+            click.utils.echo('Hello %s!' % name)
 
 What it looks like:
 

--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -34,7 +34,7 @@ Contents of ``cli.py``:
     @click.command()
     def cli():
         """Example script."""
-        click.echo('Hello World!')
+        click.utils.echo('Hello World!')
 
 Contents of ``setup.py``::
 


### PR DESCRIPTION
When going through the quickstart I tried to run the hello.py example and found that click.echo() is not a valid method. This PR is to replace instances of this with click.utils.echo() in all of the docs.
