### PR TITLE
Change cmd_status's command name to status

### DIFF
--- a/examples/complex/complex/commands/cmd_status.py
+++ b/examples/complex/complex/commands/cmd_status.py
@@ -2,7 +2,7 @@ import click
 from complex.cli import pass_context
 
 
-@click.command('init', short_help='Shows file changes.')
+@click.command('status', short_help='Shows file changes.')
 @pass_context
 def cli(ctx):
     """Shows file changes in the current working directory."""


### PR DESCRIPTION
Does not matter in this context since the command gets it name from the filename.
But probably better to have it aligned with the filename etc.
