### PR TITLE
Fix typo error in Merging Multi Commands example.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -238,7 +238,7 @@ Example usage:
     def cli2():
         pass
 
-    @cli1.command()
+    @cli2.command()
     def cmd2():
         """Command on cli2"""
 


### PR DESCRIPTION
Possible typo error on the documentation example.
