### PR TITLE
progressbar: add automatic full-width mode

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -192,7 +192,7 @@ class ProgressBar(object):
             old_width = self.width
             self.width = 0
             clutter_length = len(strip_ansi(self.format_progress_line()))
-            new_width = get_terminal_size()[0] - clutter_length
+            new_width = max(0, get_terminal_size()[0] - clutter_length)
             if new_width < old_width:
                 self.file.write(BEFORE_BAR)
                 self.file.write(' ' * self.max_width)
@@ -485,4 +485,3 @@ else:
             pass
         _translate_ch_to_exc(ch)
         return ch.decode(get_best_encoding(sys.stdin), 'replace')
-

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -187,9 +187,13 @@ class ProgressBar(object):
 
         # Update width in case the terminal has been resized
         if self.autowidth:
-            new_width = get_terminal_size()[0] - 20
-            if new_width < self.width:
-                self.file.write("\n")
+            old_width = self.width
+            self.width = 0
+            clutter_length = len(self.format_progress_line())
+            new_width = get_terminal_size()[0] - clutter_length
+            if new_width < old_width:
+                self.file.write('\r')
+                self.file.write(' ' * self.max_width)
                 self.max_width = new_width
             self.width = new_width
 

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -180,6 +180,8 @@ class ProgressBar(object):
         }).strip()
 
     def render_progress(self):
+        from .termui import get_terminal_size
+
         if self.is_hidden:
             echo(self.label, file=self.file)
             self.file.flush()
@@ -484,36 +486,3 @@ else:
         _translate_ch_to_exc(ch)
         return ch.decode(get_best_encoding(sys.stdin), 'replace')
 
-def get_terminal_size():
-    # If shutil has get_terminal_size() (Python 3.3 and later) use that
-    if sys.version_info >= (3, 3):
-        import shutil
-        shutil_get_terminal_size = getattr(shutil, 'get_terminal_size', None)
-        if shutil_get_terminal_size:
-            sz = shutil_get_terminal_size()
-            return sz.columns, sz.lines
-
-    def ioctl_gwinsz(fd):
-        try:
-            import fcntl
-            import termios
-            cr = struct.unpack(
-                'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
-        except Exception:
-            return
-        return cr
-
-    cr = ioctl_gwinsz(0) or ioctl_gwinsz(1) or ioctl_gwinsz(2)
-    if not cr:
-        try:
-            fd = os.open(os.ctermid(), os.O_RDONLY)
-            try:
-                cr = ioctl_gwinsz(fd)
-            finally:
-                os.close(fd)
-        except Exception:
-            pass
-    if not cr or not cr[0] or not cr[1]:
-        cr = (os.environ.get('LINES', 25),
-              os.environ.get('COLUMNS', 80))
-    return int(cr[1]), int(cr[0])

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -192,7 +192,7 @@ class ProgressBar(object):
             clutter_length = len(self.format_progress_line())
             new_width = get_terminal_size()[0] - clutter_length
             if new_width < old_width:
-                self.file.write('\r')
+                self.file.write(BEFORE_BAR)
                 self.file.write(' ' * self.max_width)
                 self.max_width = new_width
             self.width = new_width

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -191,7 +191,7 @@ class ProgressBar(object):
         if self.autowidth:
             old_width = self.width
             self.width = 0
-            clutter_length = len(self.format_progress_line())
+            clutter_length = len(strip_ansi(self.format_progress_line()))
             new_width = get_terminal_size()[0] - clutter_length
             if new_width < old_width:
                 self.file.write(BEFORE_BAR)

--- a/click/termui.py
+++ b/click/termui.py
@@ -138,8 +138,38 @@ def get_terminal_size():
     """Returns the current size of the terminal as tuple in the form
     ``(width, height)`` in columns and rows.
     """
-    from ._termui_impl import get_terminal_size
-    return get_terminal_size()
+    # If shutil has get_terminal_size() (Python 3.3 and later) use that
+    if sys.version_info >= (3, 3):
+        import shutil
+        shutil_get_terminal_size = getattr(shutil, 'get_terminal_size', None)
+        if shutil_get_terminal_size:
+            sz = shutil_get_terminal_size()
+            return sz.columns, sz.lines
+
+    def ioctl_gwinsz(fd):
+        try:
+            import fcntl
+            import termios
+            cr = struct.unpack(
+                'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+        except Exception:
+            return
+        return cr
+
+    cr = ioctl_gwinsz(0) or ioctl_gwinsz(1) or ioctl_gwinsz(2)
+    if not cr:
+        try:
+            fd = os.open(os.ctermid(), os.O_RDONLY)
+            try:
+                cr = ioctl_gwinsz(fd)
+            finally:
+                os.close(fd)
+        except Exception:
+            pass
+    if not cr or not cr[0] or not cr[1]:
+        cr = (os.environ.get('LINES', 25),
+              os.environ.get('COLUMNS', 80))
+    return int(cr[1]), int(cr[0])
 
 
 def echo_via_pager(text):

--- a/click/termui.py
+++ b/click/termui.py
@@ -158,7 +158,7 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 show_percent=None, show_pos=False,
                 item_show_func=None, fill_char='#', empty_char='-',
                 bar_template='%(label)s  [%(bar)s]  %(info)s',
-                info_sep='  ', width=0, file=None):
+                info_sep='  ', width=36, file=None):
     """This function creates an iterable context manager that can be used
     to iterate over something while showing a progress bar.  It will
     either iterate over the `iterable` or `length` items (that are counted


### PR DESCRIPTION
This change required moving get_terminal_size to _termui_impl,
which should not have a too large impact as get_terminal_size
is used inside click as far as I can see (ag'd it) by HelpFormatter.

I added a API wrapper inside termui that imports _termui_impl
only on-demand as with the other functions.

The default width has been changed to automatic width.
