### PR TITLE
Fix editor failing with Python 3

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -358,7 +358,7 @@ class Editor(object):
                and os.path.getmtime(name) == timestamp:
                 return None
 
-            f = open(name)
+            f = open(name, 'rb')
             try:
                 rv = f.read()
             finally:


### PR DESCRIPTION
b mode has no effect with Python 2, but gives us binary IO with Python 3
