### PR TITLE
Documentation Fixes

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,13 @@
 $ click_
 
   Click is a Python package for creating beautiful command line interfaces
-  in a composable way with as little amount of code as necessary.  It's the
-  "Command Line Interface Creation Kit".  It's highly configurable but comes
-  with good defaults out of the box.
+  in a composable way with as little code as necessary.  It's the "Command
+  Line Interface Creation Kit".  It's highly configurable but comes with
+  sensible defaults out of the box.
 
-  It aims to make writing command line tools quick and fun without causing
-  user frustration from the inability to implement a desired CLI API.
+  It aims to make the process of writing command line tools quick and fun
+  while also preventing any frustration caused by the inability to implement
+  an intended CLI API.
 
   Click in three points:
 
@@ -16,4 +17,4 @@ $ click_
 
   Read the docs at http://click.pocoo.org/
 
-  This library is work in progress.  Please give feedback!
+  This library is a work in progress.  Please give feedback!

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,9 +4,8 @@ Advanced Patterns
 .. currentmodule:: click
 
 In addition to common functionality that is implemented in the library
-itself, there are countless of patterns that can be implemented by extending
-click.  This page should give some inspiration of what can be
-accomplished.
+itself, there are countless patterns that can be implemented by extending
+click.  This page should give some insight into what can be accomplished.
 
 .. _aliases:
 
@@ -15,9 +14,9 @@ Command Aliases
 
 Many tools support aliases for commands.  For instance, you can configure
 ``git`` to accept ``git ci`` as alias for ``git commit``.  Other tools
-also support auto discovery for aliases by automatically shortening them.
+also support auto-discovery for aliases by automatically shortening them.
 
-Click does not support this out of the box but it's very easy to customize
+Click does not support this out of the box, but it's very easy to customize
 the :class:`Group` or any other :class:`MultiCommand` to provide this
 functionality.
 
@@ -28,8 +27,8 @@ to override the latter as you generally don't want to enumerate the
 aliases on the help page in order to avoid confusion.
 
 This following example implements a subclass of :class:`Group` that
-accepts a prefix for a command.  If there were a command called
-``push``, it would accept ``pus`` as an alias if it was unique:
+accepts a prefix for a command.  If there were a command called ``push``,
+it would accept ``pus`` as an alias (so long as it was unique):
 
 .. click:example::
 
@@ -68,14 +67,14 @@ Token Normalization
 
 .. versionadded:: 2.0
 
-Starting with click 2.0 it's possible to provide a function that is used
-for normalizing tokens.  Tokens are option names, choice values or command
-values.  This can be used to implement case insensitive options for
+Starting with click 2.0, it's possible to provide a function that is used
+for normalizing tokens.  Tokens are option names, choice values, or command
+values.  This can be used to implement case insensitive options, for
 instance.
 
-In order to use this feature you need to implement a function that
-performs the normalization of the token.  For instance you could have a
-function that converts the token to lowercase.  Example:
+In order to use this feature, the context needs to be passed a function that
+performs the normalization of the token.  For instance, you could have a
+function that converts the token to lowercase:
 
 .. click:example::
 
@@ -86,7 +85,7 @@ function that converts the token to lowercase.  Example:
     def cli(name):
         click.echo('Name: %s' % name)
 
-And how it works on the UI:
+And how it works on the command line:
 
 .. click:run::
 

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -3,7 +3,7 @@ Arguments
 
 .. currentmodule:: click
 
-Arguments work similarly to options, but are positional.  They also only
+Arguments work similarly to options but are positional.  They also only
 support a subset of the features of options due to their syntactical nature.
 Click will also not attempt to document arguments for you and wants you to
 document them manually in order to avoid ugly help pages.
@@ -66,7 +66,7 @@ this, see the next sections.
 
 .. admonition:: Note on Non-Empty Variadic Arguments
 
-   If you come from ``argparse`` you might be missing support for setting
+   If you come from ``argparse``, you might be missing support for setting
    ``nargs`` to ``+`` to indicate that at least one argument is required.
 
    This is supported by setting ``required=True``.  However, this should
@@ -116,15 +116,15 @@ And what it does:
 File Path Arguments
 -------------------
 
-In the previous example the files were opened immediately.  But what if
-we just want the filename?  The naive way is to use the default string
+In the previous example, the files were opened immediately.  But what if
+we just want the filename?  The naïve way is to use the default string
 argument type.  However, remember that click is Unicode-based, so the string
 will always be a Unicode value.  Unfortunately, filenames can be Unicode or
 bytes depending on which operating system is being used.  As such, the type
 is insufficient.
 
-Instead, you should be using the :class:`Path` type, which handles this
-complexity for you.  Not only will it return either bytes or Unicode
+Instead, you should be using the :class:`Path` type, which automatically
+handles this ambiguity.  Not only will it return either bytes or Unicode
 depending on what makes more sense, but it will also be able to do some
 basic checks for you such as existence checks.
 
@@ -214,7 +214,7 @@ Generally, this feature is not recommended because it can cause the user
 a lot of confusion.
 
 Argument-Like Options
-------------------------------
+---------------------
 
 Sometimes, you want to process arguments that look like options.  For
 instance, imagine you have a file named ``-foo.txt``.  If you pass this as

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -5,13 +5,14 @@ Documenting Scripts
 
 Click makes it very easy to document your command line tools.  First of
 all, it automatically generates help pages for you.  While these are
-currently not customizable in layout, all of the text can be changed.
+currently not customizable in terms of their layout, all of the text
+can be changed.
 
 Help Texts
 ----------
 
-Commands and options accept help arguments.  In the case of commands, the doc
-string of the function is automatically used if provided.
+Commands and options accept help arguments.  In the case of commands, the
+docstring of the function is automatically used if provided.
 
 Simple example:
 
@@ -39,9 +40,9 @@ by name.
 Preventing Rewrapping
 ---------------------
 
-The default behavior of click is to rewrap text to work correctly for the
-width of the terminal.  In some circumstances, this can become a problem.
-The main issue is showing code examples where newlines are significant.
+The default behavior of click is to rewrap text based on the width of the
+terminal.  In some circumstances, this can become a problem. The main issue
+is when showing code examples, where newlines are significant.
 
 Rewrapping can be disabled on a per-paragraph basis by adding a line with
 solely the ``\b`` escape marker in it.  This line will be removed from the
@@ -135,16 +136,16 @@ Help Parameter Customization
 
 .. versionadded:: 2.0
 
-The help parameter is very special in how it's implemented in click.
+The help parameter is implemented in click in a very special manner.
 Unlike regular parameters it's automatically added by click for any
 command and it performs automatic conflict resolution.  By default it's
-called ``--help`` but this can be changed.  If a command itself implements
-a parameter with the same name the default help parameter stops accepting
+called ``--help``, but this can be changed.  If a command itself implements
+a parameter with the same name, the default help parameter stops accepting
 it.  There is a context setting that can be used to override the names of
 the help parameters called :attr:`~Context.help_option_names`.
 
 This example changes the default parameters to ``-h`` and ``--help``
-instad of just ``--help``:
+instead of just ``--help``:
 
 .. click:example::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,12 +2,13 @@ Welcome to the Click Documentation
 ==================================
 
 Click is a Python package for creating beautiful command line interfaces
-in a composable way with as little amount of code as necessary.  It's the
-"Command Line Interface Creation Kit".  It's highly configurable but comes
-with good defaults out of the box.
+in a composable way with as little code as necessary.  It's the "Command
+Line Interface Creation Kit".  It's highly configurable but comes with
+sensible defaults out of the box.
 
-It aims at making writing command line tools fun and quick without causing
-user frustration at not being able to implement an intended CLI API.
+It aims to make the process of writing command line tools quick and fun
+while also preventing frustration caused by the inability to implement an
+intended CLI API.
 
 Click in three points:
 
@@ -15,7 +16,7 @@ Click in three points:
 -   automatic help page generation
 -   supports lazy loading of subcommands at runtime
 
-What does it look like?  A simple example can be this:
+What does it look like?  Here is an example of a simple click program:
 
 .. click:example::
 
@@ -33,13 +34,13 @@ What does it look like?  A simple example can be this:
     if __name__ == '__main__':
         hello()
 
-And what it looks like:
+And what it looks like when run:
 
 .. click:run::
 
     invoke(hello, ['--count=3'], input='John\n')
 
-And it gives you nicely formatted help pages:
+It automatically generates nicely formatted help pages:
 
 .. click:run::
 
@@ -52,8 +53,8 @@ You can get the library directly from PyPI::
 Documentation Contents
 ----------------------
 
-This part of the documentation guides you through all the usage patterns
-of the library.
+This part of the documentation guides you through all of the library's
+usage patterns.
 
 .. toctree::
    :maxdepth: 2
@@ -77,7 +78,7 @@ of the library.
 API Reference
 -------------
 
-If you are looking for information on a specific function, class or
+If you are looking for information on a specific function, class, or
 method, this part of the documentation is for you.
 
 .. toctree::
@@ -85,8 +86,8 @@ method, this part of the documentation is for you.
 
    api
 
-Other Documents
----------------
+Miscellaneous Pages
+-------------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,8 @@ Line Interface Creation Kit".  It's highly configurable but comes with
 sensible defaults out of the box.
 
 It aims to make the process of writing command line tools quick and fun
-while also preventing frustration caused by the inability to implement an
-intended CLI API.
+while also preventing any frustration caused by the inability to implement
+an intended CLI API.
 
 Click in three points:
 

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -16,19 +16,19 @@ Option Prompts
 
 Option prompts are integrated into the option interface.  See
 :ref:`option-prompting` for more information.  Internally, it
-automatically calls into :func:`prompt` or :func:`confirm` as necessary.
+automatically calls either :func:`prompt` or :func:`confirm` as necessary.
 
 Input Prompts
 -------------
 
 To manually ask for user input, you can use the :func:`prompt` function.
 By default, it accepts any Unicode string, but you can ask for any other
-type.  For instance you can ask for a valid integer::
+type.  For instance, you can ask for a valid integer::
 
     value = click.prompt('Please enter a valid integer', type=int)
 
-The type is also automatically detected if a default is provided.  For
-instance, the following will only accept floats::
+Additionally, the type will be determined automatically if a default value is
+provided.  For instance, the following will only accept floats::
 
     value = click.prompt('Please enter a number', default=42.0)
 
@@ -42,6 +42,7 @@ as a boolean value::
     if click.confirm('Do you want to continue?'):
         click.echo('Well done!')
 
-There is also the option to make it automatically abort the execution::
+There is also the option to make the function automatically abort the
+execution of the program if it does not return ``True``::
 
     click.confirm('Do you want to continue?', abort=True)

--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -3,12 +3,12 @@ Python 3 Support
 
 .. currentmodule:: click
 
-Click supports Python 3 but like all other command line utility libraries,
+Click supports Python 3, but like all other command line utility libraries,
 it suffers from the Unicode text model in Python 3.  All examples in the
-documentation were written so that they run on both Python 2.x and
+documentation were written so that they could run on both Python 2.x and
 Python 3.3 or higher.
 
-At the moment the strong recommendation is to use Python 2 for these
+At the moment, it is strongly recommended is to use Python 2 for click
 utilities unless Python 3 is a hard requirement.
 
 .. _python3-limitations:
@@ -58,7 +58,7 @@ Python 2 and 3 Differences
 Click attempts to minimize the differences between Python 2 and Python 3
 by following the best practices for both languages.
 
-in Python 2, the following is true:
+In Python 2, the following is true:
 
 *   ``sys.stdin``, ``sys.stdout``, and ``sys.stderr`` are opened in binary
     mode, but under some circumstances they support Unicode output.  Click
@@ -72,7 +72,7 @@ in Python 2, the following is true:
     and will instead use the operating system's byte APIs to open the
     files.
 
-in Python 3, the following is true:
+In Python 3, the following is true:
 
 *   ``sys.stdin``, ``sys.stdout`` and ``sys.stderr`` are by default
     text-based.  When click needs a binary stream, it attempts to discover
@@ -127,20 +127,20 @@ You are dealing with an environment where Python 3 thinks you are
 restricted to ASCII data.  The solution to these problems is different
 depending on which locale your computer is running in.
 
-For instance if you have a German Linux machine you can fix the problem
+For instance, if you have a German Linux machine, you can fix the problem
 by exporting the locale to ``de_DE.utf-8``::
 
     export LC_ALL=de_DE.utf-8
     export LANG=de_DE.utf-8
 
 If you are on a US machine, ``en_EN.utf-8`` is the encoding of choice.  On
-some newer Linux systems you can also try ``C.UTF-8`` as locale::
+some newer Linux systems, you could also try ``C.UTF-8`` as the locale::
 
     export LC_ALL=C.UTF-8
     export LANG=C.UTF-8
 
 You need to do this before you invoke your Python script.  If you are
-curious about the reasons for this you can join the discussions in the
+curious about the reasons for this, you can join the discussions in the
 Python 3 bug tracker:
 
 *   `ASCII is a bad filesystem default encoding

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -17,8 +17,8 @@ commands with subcommands.
 *   `Building Command Line Applications with Click
     <https://www.youtube.com/watch?v=kNke39OZ2k0>`_
 
-Examples of Click applications can be found in the documentation as well
-as in the github repository together with readme files:
+Examples of click applications can be found in the documentation as well
+as in the GitHub repository together with readme files:
 
 *   ``inout``: `File input and output
     <https://github.com/mitsuhiko/click/tree/master/examples/inout>`_
@@ -26,7 +26,7 @@ as in the github repository together with readme files:
     <https://github.com/mitsuhiko/click/tree/master/examples/naval>`_
 *   ``aliases``: `Command alias example
     <https://github.com/mitsuhiko/click/tree/master/examples/aliases>`_
-*   ``repo``: `Git/hg like command line interface
+*   ``repo``: `Git-/Mercurial-like command line interface
     <https://github.com/mitsuhiko/click/tree/master/examples/repo>`_
 *   ``complex``: `Complex example with plugin loading
     <https://github.com/mitsuhiko/click/tree/master/examples/complex>`_

--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -67,14 +67,14 @@ That's it.
 Testing The Script
 ------------------
 
-To test the script you can make a new virtualenv and then install your
+To test the script, you can make a new virtualenv and then install your
 package::
 
     $ virtualenv venv
     $ . venv/bin/activate
     $ pip install --editable .
 
-Afterwards your command should be available:
+Afterwards, your command should be available:
 
 .. click:run::
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -29,12 +29,12 @@ nesting of commands by design and has some deficiencies when it comes to
 POSIX compliant argument handling.
 
 Click is designed to be fun to work with and at the same time not stand in
-your way.  It's not overly flexible at the same time either.  Currently
-for instance it does not allow you to customize the help pages too much.
-This is intentional because click is designed to allow you to nest command
-line utilities.  The idea is that you can have a system that works
-together with another system by tacking two click instances together and
-they will continue working as they should.
+your way.  It's not overly flexible either.  Currently, for instance, it
+does not allow you to customize the help pages too much. This is intentional
+because click is designed to allow you to nest command line utilities.  The
+idea is that you can have a system that works together with another system by
+tacking two click instances together and they will continue working as they
+should.
 
 Too much customizability would break this promise.
 
@@ -42,7 +42,7 @@ Click was written to support the `Flask <http://flask.pocoo.org/>`_
 microframework ecosystem because no tool could provide it with the
 functionality it needed.
 
-To get an understanding of what click is all about I strongly recommend
+To get an understanding of what click is all about, I strongly recommend
 looking at the :ref:`complex-guide` chapter to see what it's useful for.
 
 Why not Argparse?
@@ -67,13 +67,13 @@ hard:
 Why not Docopt etc.?
 --------------------
 
-Docopt and many tools like it are cool in how they work but very few of
+Docopt and many tools like it are cool in how they work, but very few of
 these tools deal with nesting of commands and composability in a way like
 click.  To the best of the developer's knowledge, click is the first
-Python library that tries to aim for composability of applications that
-goes beyond what the system itself supports.
+Python library that aims to create a level of composability of applications
+that goes beyond what the system itself supports.
 
-Docopt for instance acts by parsing your help pages and then parsing
+Docopt, for instance, acts by parsing your help pages and then parsing
 according to those rules.  The side effect of this is that docopt is quite
 rigid in how it handles the command line interface.  The upside of docopt
 is that it gives you strong control over your help page; the downside is


### PR DESCRIPTION
Also, having read through the documentation a few times, I was wondering about capitalizing Click when being referenced in the documentation, but keeping the library's name stylized as `click` (in the logo and the in first line of the readme, for instance). It seems slightly confusing (in my opinion at least) to have the casing swap depending on the position of the word in the sentence.
