### PR TITLE
Rename CliRunner -> CLIRunner as per PEP8

### DIFF
--- a/click/testing.py
+++ b/click/testing.py
@@ -88,7 +88,7 @@ class Result(object):
         )
 
 
-class CliRunner(object):
+class CLIRunner(object):
     """The CLI runner provides functionality to invoke a click command line
     script for unittesting purposes in a isolated environment.  This only
     works in single-threaded systems without any concurrency as it changes the
@@ -266,3 +266,6 @@ class CliRunner(object):
                 shutil.rmtree(t)
             except (OSError, IOError):
                 pass
+
+# For backwards compatibility
+CLIRunner = CLIRunner

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -160,7 +160,7 @@ Testing
 
 .. currentmodule:: click.testing
 
-.. autoclass:: CliRunner
+.. autoclass:: CLIRunner
    :members:
 
 .. autoclass:: Result

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -15,8 +15,8 @@ Basic Testing
 -------------
 
 The basic functionality for testing click applications is the
-:class:`CliRunner` which can invoke commands as command line scripts.  The
-:meth:`CliRunner.invoke` method runs the command line script in isolation
+:class:`CLIRunner` which can invoke commands as command line scripts.  The
+:meth:`CLIRunner.invoke` method runs the command line script in isolation
 and captures the output as both bytes and binary data.
 
 The return value is a :class:`Result` object, which has the captured output
@@ -25,7 +25,7 @@ data, exit code, and optional exception attached.
 Example::
 
     import click
-    from click.testing import CliRunner
+    from click.testing import CLIRunner
 
     def test_hello_world():
         @click.command()
@@ -33,7 +33,7 @@ Example::
         def hello(name):
             click.echo('Hello %s!' % name)
 
-        runner = CliRunner()
+        runner = CLIRunner()
         result = runner.invoke(hello, ['Peter'])
         assert result.exit_code == 0
         assert result.output == 'Hello Peter!\n'
@@ -42,13 +42,13 @@ File System Isolation
 ---------------------
 
 For basic command line tools that want to operate with the file system, the
-:meth:`CliRunner.isolated_filesystem` method comes in useful which sets up
+:meth:`CLIRunner.isolated_filesystem` method comes in useful which sets up
 an empty folder and changes the current working directory to.
 
 Example::
 
     import click
-    from click.testing import CliRunner
+    from click.testing import CLIRunner
 
     def test_cat():
         @click.command()
@@ -56,7 +56,7 @@ Example::
         def cat(f):
             click.echo(f.read())
 
-        runner = CliRunner()
+        runner = CLIRunner()
         with runner.isolated_filesystem():
             with open('hello.txt') as f:
                 f.write('Hello World!')
@@ -72,7 +72,7 @@ The test wrapper can also be used to provide input data for the input
 stream (stdin).  This is very useful for testing prompts, for instance::
 
     import click
-    from click.testing import CliRunner
+    from click.testing import CLIRunner
 
     def test_prompts():
         @click.command()
@@ -80,7 +80,7 @@ stream (stdin).  This is very useful for testing prompts, for instance::
         def test(foo):
             click.echo('foo=%s' % foo)
 
-        runner = CliRunner()
+        runner = CLIRunner()
         result = runner.invoke(test, input='wau wau\n')
         assert not result.exception
         assert result.output == 'Foo: wau wau\nfoo=wau wau\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
-from click.testing import CliRunner
+from click.testing import CLIRunner
 
 import pytest
 
 
 @pytest.fixture(scope='function')
 def runner(request):
-    return CliRunner()
+    return CLIRunner()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,6 +1,6 @@
 import click
 
-from click.testing import CliRunner
+from click.testing import CLIRunner
 
 from click._compat import PY2
 
@@ -23,12 +23,12 @@ def test_runner():
             o.write(chunk)
             o.flush()
 
-    runner = CliRunner()
+    runner = CLIRunner()
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\n'
 
-    runner = CliRunner(echo_stdin=True)
+    runner = CLIRunner(echo_stdin=True)
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\nHello World!\n'
@@ -46,12 +46,12 @@ def test_runner_with_stream():
             o.write(chunk)
             o.flush()
 
-    runner = CliRunner()
+    runner = CLIRunner()
     result = runner.invoke(test, input=ReasonableBytesIO(b'Hello World!\n'))
     assert not result.exception
     assert result.output == 'Hello World!\n'
 
-    runner = CliRunner(echo_stdin=True)
+    runner = CLIRunner(echo_stdin=True)
     result = runner.invoke(test, input=ReasonableBytesIO(b'Hello World!\n'))
     assert not result.exception
     assert result.output == 'Hello World!\nHello World!\n'
@@ -63,7 +63,7 @@ def test_prompts():
     def test(foo):
         click.echo('foo=%s' % foo)
 
-    runner = CliRunner()
+    runner = CLIRunner()
     result = runner.invoke(test, input='wau wau\n')
     assert not result.exception
     assert result.output == 'Foo: wau wau\nfoo=wau wau\n'
@@ -73,7 +73,7 @@ def test_prompts():
     def test(foo):
         click.echo('foo=%s' % foo)
 
-    runner = CliRunner()
+    runner = CLIRunner()
     result = runner.invoke(test, input='wau wau\n')
     assert not result.exception
     assert result.output == 'Foo: \nfoo=wau wau\n'
@@ -84,7 +84,7 @@ def test_getchar():
     def continue_it():
         click.echo(click.getchar())
 
-    runner = CliRunner()
+    runner = CLIRunner()
     result = runner.invoke(continue_it, input='y')
     assert not result.exception
     assert result.output == 'y\n'


### PR DESCRIPTION
Renames `click.testing.CliRunner` to `click.testing.CLIRunner` as per [PEP8's recommendation](http://legacy.python.org/dev/peps/pep-0008/#descriptive-naming-styles). Retains backwards compatibility.
