### PR TITLE
Allow non linear progress

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -226,7 +226,9 @@ class ProgressBar(object):
 
         self.eta_known = self.length_known
 
-    def update(self, n_steps):
+    def update(self, n_steps, label=None):
+        if label is not None:
+            self.label = label
         self.make_step(n_steps)
         self.render_progress()
 

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -226,9 +226,7 @@ class ProgressBar(object):
 
         self.eta_known = self.length_known
 
-    def update(self, n_steps, label=None):
-        if label is not None:
-            self.label = label
+    def update(self, n_steps):
         self.make_step(n_steps)
         self.render_progress()
 

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -213,8 +213,8 @@ class ProgressBar(object):
         self.file.write(' ' * (clear_width - line_len))
         self.file.flush()
 
-    def make_step(self):
-        self.pos += 1
+    def make_step(self, n_steps):
+        self.pos += n_steps
         if self.length_known and self.pos >= self.length:
             self.finished = True
 
@@ -225,6 +225,10 @@ class ProgressBar(object):
         self.avg = self.avg[-6:] + [-(self.start - time.time()) / (self.pos)]
 
         self.eta_known = self.length_known
+
+    def update(self, n_steps):
+        self.make_step(n_steps)
+        self.render_progress()
 
     def finish(self):
         self.eta_known = 0
@@ -242,8 +246,7 @@ class ProgressBar(object):
             self.render_progress()
             raise StopIteration()
         else:
-            self.make_step()
-            self.render_progress()
+            self.update(1)
             return rv
 
     if not PY2:

--- a/click/termui.py
+++ b/click/termui.py
@@ -227,8 +227,8 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
 
     .. versionadded:: 2.0
 
-    .. versionadded:: 2.1
-        the update ProgressBar object `update` method.
+    .. versionadded:: 3.0
+        the ProgressBar `update` method.
 
     :param iterable: an iterable to iterate over.  If not provided the length
                      is required.

--- a/click/termui.py
+++ b/click/termui.py
@@ -215,6 +215,10 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
     No printing must happen or the progress bar will be unintentionally
     destroyed.
 
+    Alternatively, if no iterable is specified, one can manually update the
+    progress bar through the update method instead of directly iterating over
+    the progress bar.
+
     Example usage::
 
         with progressbar(items) as bar:
@@ -222,6 +226,9 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 do_something_with(item)
 
     .. versionadded:: 2.0
+
+    .. versionadded:: 2.1
+        the update ProgressBar object `update` method.
 
     :param iterable: an iterable to iterate over.  If not provided the length
                      is required.

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -334,3 +334,14 @@ will be shown preceding the progress bar::
                            length=number_of_users) as bar:
         for user in bar:
             modify_the_user(user)
+
+Sometimes, one may need to iterate over an external iterator, and advance the
+progress bar iregularly. To do so, you need to speficy the length (and no
+iterable), and use the update method on the context return value instead of
+iterating directly over it::
+
+    with click.progressbar(length=total_size,
+                           label='Unzipping archive') as bar:
+        for archive in zip_file:
+            archive.extract()
+            bar.update(archive.size)

--- a/examples/termui/termui.py
+++ b/examples/termui/termui.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import click
+import math
 import time
 import random
 
@@ -74,6 +75,16 @@ def progress(count):
                            fill_char=click.style('#', fg='magenta')) as bar:
         for item in bar:
             process_slowly(item)
+
+    # 'Non-linear progress bar'
+    steps = [math.exp( x * 1. / 20) - 1 for x in range(20)]
+    count = int(sum(steps))
+    with click.progressbar(length=count, show_percent=False,
+                           label='Slowing progress bar',
+                           fill_char=click.style(u'█', fg='green')) as bar:
+        for item in steps:
+            time.sleep(item)
+            bar.update(item)
 
 
 @cli.command()


### PR DESCRIPTION
I sometimes need to use a progress bar without having an underlying iterable, or more exactly when the progress as a function of iterable position is not linear. In this car, one may want to manually update the progressbar with custom steps.

This small PR allows doing this. I also added the ability to change the label, though I don't really like the API. It is in a separate commit so that it can be easily discarded.

``` python
# Example: unzipping an archive with lots of small files and a few large files:
filename = "some_large_zip_file.zip"
with zipfile.ZipFile(filename) as fp:
    archives = [fp.getinfo(member) for member in fp.namelist()]
    total_size = sum(archive.file_size for archive in archives)

    bar = progressbar(length=total_size, bar_template='%(bar)s - %(label)s')
    with bar:
        for archive in archives:
            fp.extract(archive.filename, "tmp")
            bar.update(archive.file_size, "extracting {}".format(archive.filename))
```
