### PR TITLE
A first draft of tab-completion for prompts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Version 3.0
   whitespace stripped.
 - added a way to disable the standalone mode of the `main`
   method on a Click command to be able to handle errors better.
+- Click supports tab-completion for prompts now.
 
 Version 2.6
 -----------

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -34,7 +34,7 @@ from .utils import echo, get_binary_stream, get_text_stream, \
 # Terminal functions
 from .termui import prompt, confirm, get_terminal_size, echo_via_pager, \
      progressbar, clear, style, unstyle, secho, edit, launch, getchar, \
-     pause
+     pause, file_completer
 
 # Exceptions
 from .exceptions import ClickException, UsageError, BadParameter, \

--- a/click/core.py
+++ b/click/core.py
@@ -1375,10 +1375,10 @@ class Option(Parameter):
         if self.is_bool_flag:
             return confirm(self.prompt, default)
 
-        return prompt(self.prompt, default=default,
-                      hide_input=self.hide_input,
+        return prompt(self.prompt, default=default, hide_input=self.hide_input,
                       confirmation_prompt=self.confirmation_prompt,
-                      value_proc=lambda x: self.process_value(ctx, x))
+                      value_proc=lambda x: self.process_value(ctx, x),
+                      completer=self.type.completer)
 
     def resolve_envvar_value(self, ctx):
         rv = Parameter.resolve_envvar_value(self, ctx)

--- a/click/types.py
+++ b/click/types.py
@@ -32,6 +32,9 @@ class ParamType(object):
     #: Windows).
     envvar_list_splitter = None
 
+    #: A completer function for :py:func:`click.prompt`.
+    completer = None
+
     def __call__(self, value, param=None, ctx=None):
         if value is not None:
             return self.convert(value, param, ctx)
@@ -272,6 +275,9 @@ class File(ParamType):
         self.errors = errors
         self.lazy = lazy
         self.atomic = atomic
+
+        from click import file_completer  # avoid circular imports
+        self.completer = file_completer
 
     def resolve_lazy_flag(self, value):
         if self.lazy is not None:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,6 +70,11 @@ Utilities
 
 .. autofunction:: format_filename
 
+Completers
+----------
+
+.. autofunction:: file_completer
+
 Commands
 --------
 

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -32,6 +32,20 @@ provided.  For instance, the following will only accept floats::
 
     value = click.prompt('Please enter a number', default=42.0)
 
+Input completion
+----------------
+
+.. versionadded:: 3.0
+
+To offer completion of user input, the ``completer`` parameter can be used.  It
+takes a function which is called with the current input value when the user
+first presses tab. The function should return a list (or another indexable
+object) with the possible completion values.
+
+Click provides one completer for your convenience:
+
+.. autoclass:: file_completer
+
 Confirmation Prompts
 --------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,7 @@ def test_filename_formatting():
         == u'foo\ufffd.txt'
 
 
-def test_prompts(runner):
+def test_confirmation_prompts(runner):
     @click.command()
     def test():
         if click.confirm('Foo'):


### PR DESCRIPTION
See #173. This is not ready for merge yet.
- Missing tests, changelog entry, and isn't yet used in click.Path/File.
- Is a very myopic implementation. Users will ask for custom completion
  functions, which bash's read of course doesn't support.
