### PR TITLE
Add links from options -> arguments and back again

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -1,12 +1,15 @@
+.. _arguments:
+
 Arguments
 =========
 
 .. currentmodule:: click
 
-Arguments work similarly to options but are positional.  They also only
-support a subset of the features of options due to their syntactical nature.
-Click will also not attempt to document arguments for you and wants you to
-document them manually in order to avoid ugly help pages.
+Arguments work similarly to :ref:`options <options>` but are positional.
+They also only support a subset of the features of options due to their
+syntactical nature. Click will also not attempt to document arguments for
+you and wants you to document them manually in order to avoid ugly help
+pages.
 
 Basic Arguments
 ---------------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -1,3 +1,5 @@
+.. _options:
+
 Options
 =======
 
@@ -5,7 +7,8 @@ Options
 
 Adding options to commands can be accomplished by the :func:`option`
 decorator.  Since options can come in various different versions, there
-are a ton of parameters to configure their behavior.
+are a ton of parameters to configure their behavior. Options in click are
+distinct from :ref:`positional arguments <arguments>`.
 
 Basic Value Options
 -------------------


### PR DESCRIPTION
This helps draw the distinction between arguments and options, which
probably isn't familiar to people coming from argparse.

I tried to make the change as minimal as possible, reflowing the text makes the change look much larger than it actually is.

Let me know if this is appealing, or if you'd like me to re-word it, or if there are other more fundamental problems with it.
