### PR TITLE
Add support for different categories to get_app_dir

### DIFF
--- a/click/utils.py
+++ b/click/utils.py
@@ -314,7 +314,7 @@ def format_filename(filename, shorten=False):
     return filename_to_ui(filename)
 
 
-def get_app_dir(app_name, roaming=True, force_posix=False):
+def get_app_dir(app_name, roaming=True, force_posix=False, category='CONFIG'):
     r"""Returns the config folder for the application.  The default behavior
     is to return whatever is most appropriate for the operating system.
 
@@ -348,6 +348,8 @@ def get_app_dir(app_name, roaming=True, force_posix=False):
                         folder will be stored in the home folder with a leading
                         dot instead of the XDG config home or darwin's
                         application support folder.
+    :param category: the type of directory to return.  Valid values are CONFIG,
+                     CACHE, DATA, or STATE.
     """
     if WIN:
         key = roaming and 'APPDATA' or 'LOCALAPPDATA'
@@ -360,6 +362,12 @@ def get_app_dir(app_name, roaming=True, force_posix=False):
     if sys.platform == 'darwin':
         return os.path.join(os.path.expanduser(
             '~/Library/Application Support'), app_name)
+    XDG = {
+        'CONFIG': os.path.expanduser('~/.config'),
+        'CACHE': os.path.expanduser('~/.cache'),
+        'DATA': os.path.expanduser('~/.local/share'),
+        'STATE': os.path.expanduser('~/.local/state')
+    }
     return os.path.join(
-        os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')),
+        os.environ.get('XDG_' + category + '_HOME', XDG.get(category)),
         _posixify(app_name))


### PR DESCRIPTION
This will improve support of the [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html), including the proposed [STATE directory](https://wiki.debian.org/XDGBaseDirectorySpecification#state).  Since the default for **category** is CONFIG, the default behavior of get_app_dir is still the same.  However, users can override the category to get a different type of directory.

Examples:

```
>>> APP_NAME = 'foo'
>>> get_app_dir(APP_NAME)
'/home/carl/.config/foo'
>>> get_app_dir(APP_NAME, category='CONFIG')
'/home/carl/.config/foo'
>>> get_app_dir(APP_NAME, category='CACHE')
'/home/carl/.cache/foo'
>>> get_app_dir(APP_NAME, category='DATA')
'/home/carl/.local/share/foo'
>>> get_app_dir(APP_NAME, category='STATE')
'/home/carl/.local/state/foo'
```
