### PR TITLE
Use Python 3 Compatible Range in Textwrapper

### DIFF
--- a/click/_textwrap.py
+++ b/click/_textwrap.py
@@ -1,13 +1,13 @@
 import textwrap
 from contextlib import contextmanager
-from ._compat import term_len
+from ._compat import term_len, range_type
 
 
 class TextWrapper(textwrap.TextWrapper):
 
     def _cutdown(self, ucstr, space_left):
         l = 0
-        for i in xrange(len(ucstr)):
+        for i in range_type(len(ucstr)):
             l += term_len(ucstr[i])
             if space_left < l:
                 return (ucstr[:i], ucstr[i:])


### PR DESCRIPTION
This has already been fixed in the v3 branch, but it would be great if this fix could be released as a quick fix for the v2. I raised the problem in issue #195 
