### PR TITLE
Fix a minor typo in docs

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -216,7 +216,7 @@ where the first one is picked.
 Generally, this feature is not recommended because it can cause the user
 a lot of confusion.
 
-Argument-Like Options
+Option-Like Arguments
 ---------------------
 
 Sometimes, you want to process arguments that look like options.  For


### PR DESCRIPTION
Arguments that are like options are _Option-Like Arguments_, rather than _Argument-Like Options_.
