### PR TITLE
Ensure bash completion functions have valid posix names

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -1,4 +1,5 @@
 import os
+from string import letters, digits
 from .utils import echo
 from .parser import split_arg_string
 from .core import MultiCommand, Option
@@ -17,8 +18,15 @@ complete -F %(complete_func)s -o default %(script_names)s
 
 
 def get_completion_script(prog_name, complete_var):
+    def valid_posix(c):
+        if c in letters:
+            return c
+        if c in digits:
+            return c
+        return '_'
+    cf_name = ''.join([valid_posix(c) for c in prog_name])
     return (COMPLETION_SCRIPT % {
-        'complete_func': '_%s_completion' % prog_name,
+        'complete_func': '_%s_completion' % cf_name,
         'script_names': prog_name,
         'autocomplete_var': complete_var,
     }).strip() + ';'


### PR DESCRIPTION
A click application 'foo-bar' would generation a completion function
with a hyphen in the name. This is accepted by Bash interactive shells,
but fails during graphical login on a Ubuntu machine:

/usr/sbin/lightdm-session: 11: /home/rayl/.my_aliases: Syntax error: Bad function name

This leads to a login/logout loop until you login on a terminal and
fix the function name.

Signed-off-by: Ray Lehtiniemi rayl@mail.com
