### PR TITLE
Accept empty strings via the prompt.

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -77,15 +77,17 @@ def prompt(text, default=None, hide_input=False,
     prompt = _build_prompt(text, prompt_suffix, show_default, default)
 
     while 1:
-        while 1:
-            value = prompt_func(prompt)
-            if value:
-                break
-            # If a default is set and used, then the confirmation
-            # prompt is always skipped because that's the only thing
-            # that really makes sense.
-            elif default is not None:
-                return default
+        value = prompt_func(prompt)
+        if value:
+            break
+        # If a default is set and used, then the confirmation
+        # prompt is always skipped because that's the only thing
+        # that really makes sense.
+        elif default is not None:
+            return default
+        else:
+            return ''
+
         try:
             result = value_proc(value)
         except UsageError as e:


### PR DESCRIPTION
Currently there is no way to accept an empty string as an input from the prompt. For example the following example will keep requesting a password when the user enters an empty string at the prompt (i.e., simply presses the enter key without typing any characters). 

```
@click.command()
@click.option('-h', '--host', default='localhost')
@click.option('--password', prompt=True, hide_input=True,
              confirmation_prompt=False, type=str)
def cli(host, password):
    print(host: %s password: %s' % (host, password))
```

The PR I've sent allows accepting empty strings. But the problem is it defaults to a string. 

The use case for an empty password is a database CLI. I'm writing a CLI client for SQLite and Postgres where it's perfectly fine to have an empty password. 
