### PR TITLE
Fix usage wrapping on narrow terminals

### DIFF
--- a/click/formatting.py
+++ b/click/formatting.py
@@ -46,11 +46,13 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
     """
     from ._textwrap import TextWrapper
     text = text.expandtabs()
+    post_wrap_indent = subsequent_indent[:-1]
+    subsequent_indent = subsequent_indent[-1:]
     wrapper = TextWrapper(width, initial_indent=initial_indent,
-                          subsequent_indent='',
+                          subsequent_indent=subsequent_indent,
                           replace_whitespace=False)
     if not preserve_paragraphs:
-        return add_subsequent_indent(wrapper.fill(text), subsequent_indent)
+        return add_subsequent_indent(wrapper.fill(text), post_wrap_indent)
 
     p = []
     buf = []
@@ -82,10 +84,10 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
         with wrapper.extra_indent(' ' * indent):
             if raw:
                 rv.append(add_subsequent_indent(wrapper.indent_only(text),
-                                                subsequent_indent))
+                                                post_wrap_indent))
             else:
                 rv.append(add_subsequent_indent(wrapper.fill(text),
-                                                subsequent_indent))
+                                                post_wrap_indent))
 
     return '\n\n'.join(rv)
 

--- a/click/formatting.py
+++ b/click/formatting.py
@@ -18,6 +18,12 @@ def iter_rows(rows, col_count):
         yield row + ('',) * (col_count - len(row))
 
 
+def add_subsequent_indent(text, subsequent_indent):
+    lines = text.splitlines()
+    lines = [lines[0]] + [subsequent_indent + line for line in lines[1:]]
+    return '\n'.join(lines)
+
+
 def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
               preserve_paragraphs=False):
     """A helper function that intelligently wraps text.  By default, it
@@ -41,10 +47,10 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
     from ._textwrap import TextWrapper
     text = text.expandtabs()
     wrapper = TextWrapper(width, initial_indent=initial_indent,
-                          subsequent_indent=subsequent_indent,
+                          subsequent_indent='',
                           replace_whitespace=False)
     if not preserve_paragraphs:
-        return wrapper.fill(text)
+        return add_subsequent_indent(wrapper.fill(text), subsequent_indent)
 
     p = []
     buf = []
@@ -75,9 +81,11 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
     for indent, raw, text in p:
         with wrapper.extra_indent(' ' * indent):
             if raw:
-                rv.append(wrapper.indent_only(text))
+                rv.append(add_subsequent_indent(wrapper.indent_only(text),
+                                                subsequent_indent))
             else:
-                rv.append(wrapper.fill(text))
+                rv.append(add_subsequent_indent(wrapper.fill(text),
+                                                subsequent_indent))
 
     return '\n\n'.join(rv)
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -48,3 +48,37 @@ def test_basic_functionality(runner):
         'Options:',
         '  --help  Show this message and exit.',
     ]
+
+
+def test_wrapping_long_options_strings(runner):
+    @click.group()
+    def cli():
+        """Top level command
+        """
+
+    @cli.group()
+    def a_very_long():
+        """Second level
+        """
+
+    @a_very_long.command()
+    @click.argument('first')
+    @click.argument('second')
+    @click.argument('third')
+    @click.argument('fourth')
+    def command():
+        """A command.
+        """
+
+    result = runner.invoke(cli, ['a_very_long', 'command', '--help'],
+                           terminal_width=54)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: cli a_very_long command [OPTIONS] FIRST SECOND',
+        '                               THIRD FOURTH',
+        '',
+        '  A command.',
+        '',
+        'Options:',
+        '  --help  Show this message and exit.',
+    ]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -66,16 +66,21 @@ def test_wrapping_long_options_strings(runner):
     @click.argument('second')
     @click.argument('third')
     @click.argument('fourth')
+    @click.argument('fifth')
+    @click.argument('sixth')
     def command():
         """A command.
         """
 
+    # 54 is chosen as a lenthg where the second line is one character
+    # longer than the maximum length.
     result = runner.invoke(cli, ['a_very_long', 'command', '--help'],
                            terminal_width=54)
     assert not result.exception
     assert result.output.splitlines() == [
         'Usage: cli a_very_long command [OPTIONS] FIRST SECOND',
-        '                               THIRD FOURTH',
+        '                               THIRD FOURTH FIFTH',
+        '                               SIXTH',
         '',
         '  A command.',
         '',


### PR DESCRIPTION
@mitsuhiko Fixes #231.

I'm not entirely comfortable with this fix, but short of rewriting TextWrapper to not include the `subsequent_indent` in the wrapped-text width, I don't know what else can be done.
