### PR TITLE
added init files to setuptools.rst example

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -108,9 +108,11 @@ contained in a Python package the changes necessary are minimal.  Let's
 assume your directory structure changed to this::
 
     yourpackage/
+        __init__.py
         main.py
         utils.py
         scripts/
+            __init__.py
             yourscript.py
 
 In this case instead of using ``py_modules`` in your ``setup.py`` file you


### PR DESCRIPTION
Without the **init**.py files, new programmers will waste time with a broken example.
