### PR TITLE
Fixed exception in Option.get_help_record()

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1509,7 +1509,10 @@ class Option(Parameter):
         help = self.help or ''
         extra = []
         if self.default is not None and self.show_default:
-            extra.append('default: %s' % self.default)
+            extra.append('default: %s' % (
+                         ', '.join('%s' % d for d in self.default)
+                         if isinstance(self.default, (list, tuple))
+                         else self.default, ))
         if self.required:
             extra.append('required')
         if extra:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -115,6 +115,21 @@ def test_multiple_envvar(runner):
     assert result.output == 'foo|bar\n'
 
 
+def test_multiple_default_help(runner):
+    @click.command()
+    @click.option("--arg1", multiple=True, default=('foo', 'bar'),
+                  show_default=True)
+    @click.option("--arg2", multiple=True, default=(1, 2), type=int,
+                  show_default=True)
+    def cmd(arg, arg2):
+        pass
+
+    result = runner.invoke(cmd, ['--help'])
+    assert not result.exception
+    assert "foo, bar" in result.output
+    assert "1, 2" in result.output
+
+
 def test_nargs_envvar(runner):
     @click.command()
     @click.option('--arg', nargs=2)


### PR DESCRIPTION
This PR fixes a TypeError ("not all arguments converted during string formatting") in `Option.get_help_record()` that occurred while showing the help for options that are defined with `multiple=True`, `show_default=True` and have a list or tuple as default value.
