### PR TITLE
Support nargs=-1 for option

### DIFF
--- a/click/parser.py
+++ b/click/parser.py
@@ -277,7 +277,8 @@ class OptionParser(object):
             if nargs == -1:
                 dash_locs = filter(lambda pair: pair[1].startswith('-'), enumerate(state.rargs))
                 if len(dash_locs) > 0:
-                    nvar = min([x[0] for x in filter(lambda pair: pair[1].startswith('-'), enumerate(state.rargs))])
+                    func = lambda p: (p[1].startswith('-') and len(p[1]) == 2) or p[1].startswith('--')
+                    nvar = min([x[0] for x in filter(func, enumerate(state.rargs))])
                     value = tuple(state.rargs[:nvar])
                     del state.rargs[:nvar]
                 elif len(state.rargs) == 1:

--- a/click/parser.py
+++ b/click/parser.py
@@ -274,7 +274,18 @@ class OptionParser(object):
                 state.rargs.insert(0, explicit_value)
 
             nargs = option.nargs
-            if len(state.rargs) < nargs:
+            if nargs == -1:
+                dash_locs = filter(lambda pair: pair[1].startswith('-'), enumerate(state.rargs))
+                if len(dash_locs) > 0:
+                    nvar = min([x[0] for x in filter(lambda pair: pair[1].startswith('-'), enumerate(state.rargs))])
+                    value = tuple(state.rargs[:nvar])
+                    del state.rargs[:nvar]
+                elif len(state.rargs) == 1:
+                    value = state.rargs.pop(0)
+                else:
+                    value = tuple(state.rargs)
+                    state.rargs = []
+            elif len(state.rargs) < nargs:
                 _error_args(nargs, opt)
             elif nargs == 1:
                 value = state.rargs.pop(0)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -84,6 +84,37 @@ def test_multiple_required(runner):
     assert 'Error: Missing option "-m" / "--message".' in result.output
 
 
+def test_nargs_star(runner):
+    @click.command()
+    @click.option('--option', nargs=-1)
+    @click.option('--foo', nargs=-1)
+    @click.option('--bar', nargs=-1)
+    @click.argument('args', nargs=-1)
+    def vary(args, foo, bar, option):
+        click.echo('|'.join(args))
+        click.echo('|'.join(foo))
+        click.echo('|'.join(bar))
+        click.echo('|'.join(option))
+
+    result = runner.invoke(vary, ['6', '7', '--foo', '1', '2', '3', '--bar', '4', '5', '--option', '9', '10'])
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '6|7',
+        '1|2|3',
+        '4|5',
+        '9|10'
+    ]
+
+    result = runner.invoke(vary, ['--foo', '1', '2', '3', '--bar', '4', '5', '--option', '9', '10', '--', '6', '7'])
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '6|7',
+        '1|2|3',
+        '4|5',
+        '9|10'
+    ]
+
+
 def test_multiple_envvar(runner):
     @click.command()
     @click.option('--arg', multiple=True)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -114,6 +114,15 @@ def test_nargs_star(runner):
         '9|10'
     ]
 
+    result = runner.invoke(vary, ['--foo', '1', '2', '3', '--bar', '4', '5', '--option', '-file', '10', '--', '6', '7'])
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '6|7',
+        '1|2|3',
+        '4|5',
+        '-file|10'
+    ]
+
 
 def test_multiple_envvar(runner):
     @click.command()


### PR DESCRIPTION
Resolves #222

Not sure if this goes against some explicit design decision, but here is a proof-of-concept. I think I've covered the corner cases. `make test` passes.
