### PR TITLE
Fix erroneous region code on python3 doc page

### DIFF
--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -133,7 +133,7 @@ by exporting the locale to ``de_DE.utf-8``::
     export LC_ALL=de_DE.utf-8
     export LANG=de_DE.utf-8
 
-If you are on a US machine, ``en_EN.utf-8`` is the encoding of choice.  On
+If you are on a US machine, ``en_US.utf-8`` is the encoding of choice.  On
 some newer Linux systems, you could also try ``C.UTF-8`` as the locale::
 
     export LC_ALL=C.UTF-8


### PR DESCRIPTION
There is no territory with a region code of "EN"; the correct one is "US." At least, it didn't work when I tried it, but "en_US" did!
