### PR TITLE
Simplelog-feature

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -46,6 +46,9 @@ from .formatting import HelpFormatter, wrap_text
 # Parsing
 from .parser import OptionParser
 
+# Simple-Log-Feature
+from .simplelog import simplelog
+
 
 __all__ = [
     # Core classes

--- a/click/simplelog.py
+++ b/click/simplelog.py
@@ -16,7 +16,7 @@ def simplelog(*args, **kwargs):
     return make_simplelog
 
 
-class SimpleLog:
+class SimpleLog(object):
 
     __name__ = "SimpleLog"
 

--- a/click/simplelog.py
+++ b/click/simplelog.py
@@ -1,0 +1,135 @@
+from core import Option
+import logging
+
+
+def simplelog(*args, **kwargs):
+
+    """ Decorator to add a very simple logging facility to scripts
+
+    For parameters see SimpleLog.__init__
+    """
+
+    def make_simplelog(f):
+
+        return SimpleLog(f, **kwargs)
+
+    return make_simplelog
+
+
+class SimpleLog:
+
+    __name__ = "SimpleLog"
+
+    def __init__(self, callback, verbose_help=None, debug_help=None,
+                 quiet_help=None, remove_args=False, verbose_args=None,
+                 debug_args=None, quiet_args=None, verbose_arg_name=None,
+                 debug_arg_name=None, quiet_arg_name=None,
+                 default_level=None, quiet_level=None, verbose_level=None,
+                 debug_level=None, logger_name=None):
+
+        """ Handler class for SimpleLog
+
+        :param verbose_help: Override the text displayed for the verbose
+                     parameter [Enable verbose logging]
+        :param debug_help: Override the text displayed for the debug parameter
+                           [Enable debugging]
+        :param quiet_help: Override the text displayed for the quiet parameter
+                           [Enable quiet mode]
+        :param remove_args: Remove the logging arguments, so they are not
+                            submitted to the main command [Disabled]
+        :param verbose_args: List of arguments for the "verbose"-setting
+                             [--verbose and -v]
+        :param debug_args: List of arguments for the "debug"-setting
+                           [--debug and -d]
+        :param quiet_args: List of arguments for the "quiet"-setting
+                           [--quiet and -q]
+        :param verbose_arg_name: Name of the "verbose" argument [verbose]
+        :param debug_arg_name: Name of the "debug" argument [debug]
+        :param quiet_arg_name: Name of the "quiet" argument [quiet]
+        :param default_level: Default level [logging.ERROR]
+        :param verbose_level: Level for "verbose"-setting [logging.INFO]
+        :param debug_level: Level for "debug"-setting [logging.DEBUG]
+        :param quiet_level: Level for "quiet"-setting [logging.CRITICAL]
+        :param logger_name: Logger to configure [root-logger]
+        """
+
+        self.callback = callback
+
+        self.verbose_help = verbose_help or "Enable verbose logging"
+        self.debug_help = debug_help or "Enable debugging"
+        self.quiet_help = quiet_help or "Enable quiet mode"
+        self.remove_args = remove_args or False
+        self.verbose_args = verbose_args or ["--verbose", "-v"]
+        self.debug_args = debug_args or ["--debug", "-d"]
+        self.quiet_args = quiet_args or ["--quiet", "-q"]
+        self.verbose_arg_name = verbose_arg_name or "verbose"
+        self.debug_arg_name = debug_arg_name or "debug"
+        self.quiet_arg_name = quiet_arg_name or "quiet"
+        self.default_level = default_level or logging.ERROR
+        self.verbose_level = verbose_level or logging.INFO
+        self.debug_level = debug_level or logging.DEBUG
+        self.quiet_level = quiet_level or logging.CRITICAL
+        self.logger_name = logger_name or None
+
+        self.__click_params__ = [
+            Option(
+                [self.verbose_arg_name] + self.verbose_args,
+                is_flag=True,
+                help=self.verbose_help
+            ),
+            Option(
+                [self.debug_arg_name] + self.debug_args,
+                is_flag=True,
+                help=self.debug_help
+            ),
+            Option(
+                [self.quiet_arg_name] + self.quiet_args,
+                is_flag=True,
+                help=self.quiet_help
+            )
+        ]
+
+        if hasattr(callback, "__click_params__"):
+
+            # Add parameters of the original command as well
+
+            self.__click_params__ = self.__click_params__ + \
+                callback.__click_params__
+
+
+    def __call__(self, *args, **kwargs):
+
+        """ Call the main program, but set up logging first
+        """
+
+        verbose = kwargs[self.verbose_arg_name]
+        debug = kwargs[self.debug_arg_name]
+        quiet = kwargs[self.quiet_arg_name]
+
+        if self.remove_args:
+
+            for key in (self.verbose_arg_name, self.debug_arg_name,
+                        self.quiet_arg_name):
+
+                kwargs.pop(key, None)
+
+        if not self.logger_name:
+
+            # As a precaution, set up the root logger beforehand
+
+            logging.basicConfig()
+
+        logger = logging.getLogger(self.logger_name)
+
+        logger.setLevel(self.default_level)
+
+        if quiet:
+            logger.setLevel(self.quiet_level)
+
+        if verbose:
+            logger.setLevel(self.verbose_level)
+
+        if debug:
+            logger.setLevel(self.debug_level)
+
+        self.callback(*args, **kwargs)

--- a/click/simplelog.py
+++ b/click/simplelog.py
@@ -1,4 +1,4 @@
-from core import Option
+from .core import Option
 import logging
 
 

--- a/click/simplelog.py
+++ b/click/simplelog.py
@@ -25,7 +25,7 @@ class SimpleLog:
                  debug_args=None, quiet_args=None, verbose_arg_name=None,
                  debug_arg_name=None, quiet_arg_name=None,
                  default_level=None, quiet_level=None, verbose_level=None,
-                 debug_level=None, logger_name=None):
+                 debug_level=None, logger_name=None, flavor=None):
 
         """ Handler class for SimpleLog
 
@@ -51,11 +51,16 @@ class SimpleLog:
         :param debug_level: Level for "debug"-setting [logging.DEBUG]
         :param quiet_level: Level for "quiet"-setting [logging.CRITICAL]
         :param logger_name: Logger to configure [root-logger]
+        :param flavor: Parameter-flavor to use:
+                       * qvd: Usage of --quiet, --verbose and --debug parameters
+                       * vvv: Usage mulitple -v parameters (Uses
+                         "Increase verbosity" for verbose_help-parameter and the
+                         verbose_args and verbose_arg_name)
         """
 
         self.callback = callback
 
-        self.verbose_help = verbose_help or "Enable verbose logging"
+        self.verbose_help = verbose_help or None
         self.debug_help = debug_help or "Enable debugging"
         self.quiet_help = quiet_help or "Enable quiet mode"
         self.remove_args = remove_args or False
@@ -70,24 +75,46 @@ class SimpleLog:
         self.debug_level = debug_level or logging.DEBUG
         self.quiet_level = quiet_level or logging.CRITICAL
         self.logger_name = logger_name or None
+        self.flavor = flavor or "qvd"
 
-        self.__click_params__ = [
-            Option(
-                [self.verbose_arg_name] + self.verbose_args,
-                is_flag=True,
-                help=self.verbose_help
-            ),
-            Option(
-                [self.debug_arg_name] + self.debug_args,
-                is_flag=True,
-                help=self.debug_help
-            ),
-            Option(
-                [self.quiet_arg_name] + self.quiet_args,
-                is_flag=True,
-                help=self.quiet_help
-            )
-        ]
+        if self.flavor == "qvd":
+
+            self.verbose_help = "Enable verbose logging"
+
+            self.__click_params__ = [
+                Option(
+                    [self.verbose_arg_name] + self.verbose_args,
+                    is_flag=True,
+                    help=self.verbose_help
+                ),
+                Option(
+                    [self.debug_arg_name] + self.debug_args,
+                    is_flag=True,
+                    help=self.debug_help
+                ),
+                Option(
+                    [self.quiet_arg_name] + self.quiet_args,
+                    is_flag=True,
+                    help=self.quiet_help
+                )
+            ]
+
+        elif self.flavor == "vvv":
+
+            self.verbose_help = "Increase verbosity"
+
+            self.__click_params__ = [
+                Option(
+                    [self.verbose_arg_name] + self.verbose_args,
+                    count=True,
+                    help=self.verbose_help
+                )
+
+            ]
+
+        else:
+
+            raise Exception("Unknown Flavor value %s" % self.flavor)
 
         if hasattr(callback, "__click_params__"):
 
@@ -96,22 +123,59 @@ class SimpleLog:
             self.__click_params__ = self.__click_params__ + \
                 callback.__click_params__
 
-
     def __call__(self, *args, **kwargs):
 
         """ Call the main program, but set up logging first
         """
 
-        verbose = kwargs[self.verbose_arg_name]
-        debug = kwargs[self.debug_arg_name]
-        quiet = kwargs[self.quiet_arg_name]
+        verbose = False
+        debug = False
+        quiet = False
+
+        if self.flavor == "qvd":
+
+            verbose = kwargs[self.verbose_arg_name]
+            debug = kwargs[self.debug_arg_name]
+            quiet = kwargs[self.quiet_arg_name]
+
+        elif self.flavor == "vvv":
+
+            verbosity = kwargs[self.verbose_arg_name]
+
+            if verbosity == 0:
+
+                quiet = True
+
+            elif verbosity == 1:
+
+                # Meaning the default, which is already set above
+
+                pass
+
+            elif verbosity == 2:
+
+                verbose = True
+
+            elif verbosity > 2:
+
+                debug = True
+
+            else:
+
+                raise Exception("Verbosity had an unknown value %s" % verbosity)
+
+        else:
+
+            raise Exception("Unknown Flavor value %s" % self.flavor)
 
         if self.remove_args:
 
             for key in (self.verbose_arg_name, self.debug_arg_name,
                         self.quiet_arg_name):
 
-                kwargs.pop(key, None)
+                if key in kwargs:
+
+                    kwargs.pop(key, None)
 
         if not self.logger_name:
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -29,7 +29,8 @@ click.echo(json.dumps(rv))
 
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
-    'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io'
+    'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
+    'logging'
 ])
 
 

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -16,7 +16,7 @@ def test_simplelog_defaults_option(runner):
     @click.option("--test")
     def cli(verbose, quiet, debug, test):
 
-        print test
+        print(test)
 
         logging.critical("CRITICAL")
         logging.error("ERROR")
@@ -38,7 +38,7 @@ def test_simplelog_defaults_option_remove_args(runner):
     @click.option("--test")
     def cli(test):
 
-        print test
+        print(test)
 
         logging.critical("CRITICAL")
         logging.error("ERROR")

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -29,7 +29,7 @@ def tool_resetlog():
         import io
         log_stream = io.StringIO()
 
-    handler = logging.StreamHandler(stream=log_stream)
+    handler = logging.StreamHandler(log_stream)
 
     root.addHandler(handler)
 

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -1,0 +1,150 @@
+import StringIO
+import re
+import click
+import logging
+
+
+log_stream = StringIO.StringIO()
+logging.basicConfig(stream=log_stream)
+
+
+def test_simplelog_defaults(runner):
+
+    @click.command()
+    @click.simplelog()
+    def cli(verbose, quiet, debug):
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli)
+
+    assert log_stream.getvalue() == "CRITICAL:root:CRITICAL\nERROR:root:ERROR\n"
+
+
+def test_simplelog_defaults_option(runner):
+
+    @click.command()
+    @click.simplelog()
+    @click.option("--test")
+    def cli(verbose, quiet, debug, test):
+
+        print test
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli, ["--test=test"])
+
+    assert result.output == "test\n"
+    assert log_stream.getvalue() == "CRITICAL:root:CRITICAL\nERROR:root:ERROR\n"
+
+
+def test_simplelog_defaults_option_remove_args(runner):
+
+    @click.command()
+    @click.simplelog(remove_args=True)
+    @click.option("--test")
+    def cli(test):
+
+        print test
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli, ["--test=test"])
+
+    assert result.output == "test\n"
+    assert log_stream.getvalue() == "CRITICAL:root:CRITICAL\nERROR:root:ERROR\n"
+
+
+def test_simplelog_defaults_help(runner):
+
+    @click.command()
+    @click.simplelog()
+    @click.option("--test")
+    def cli(verbose, quiet, debug):
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    result = runner.invoke(cli, ["--help"])
+
+    for output in (
+        "-q, --quiet *Enable quiet mode",
+        "-v, --verbose *Enable verbose logging",
+        "-d, --debug *Enable debugging"
+    ):
+
+        assert re.search(output, result.output) is not None
+
+
+def test_simplelog_quiet(runner):
+
+    @click.command()
+    @click.simplelog()
+    def cli(verbose, quiet, debug):
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli, ["--quiet"])
+
+    assert log_stream.getvalue() == "CRITICAL:root:CRITICAL\n"
+
+
+def test_simplelog_verbose(runner):
+
+    @click.command()
+    @click.simplelog()
+    def cli(verbose, quiet, debug):
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli, ["-v"])
+
+    assert log_stream.getvalue() == \
+        "CRITICAL:root:CRITICAL\nERROR:root:ERROR\nINFO:root:INFO\n"
+
+
+def test_simplelog_debug(runner):
+
+    @click.command()
+    @click.simplelog()
+    def cli(verbose, quiet, debug):
+
+        logging.critical("CRITICAL")
+        logging.error("ERROR")
+        logging.info("INFO")
+        logging.debug("DEBUG")
+
+    log_stream.truncate(0)
+
+    result = runner.invoke(cli, ["-d"])
+
+    assert log_stream.getvalue() == \
+        "CRITICAL:root:CRITICAL\nERROR:root:ERROR\n" \
+        "INFO:root:INFO\nDEBUG:root:DEBUG\n"

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -4,6 +4,24 @@ import click
 import logging
 
 
+# Set up logger for tests
+
+
+class ClickStream(object):
+
+    """ Logger Stream handler, which uses click.echo - Thanks to @unittaker
+    """
+
+    def write(self, string):
+        click.echo(string, file=sys.stdout, nl=False)
+
+stdout_handler = logging.StreamHandler(ClickStream())
+formatter = logging.Formatter()
+stdout_handler.setFormatter(formatter)
+root_logger = logging.getLogger()
+root_logger.handlers = [stdout_handler]
+
+
 def test_simplelog_defaults_option(runner):
 
     @click.command()
@@ -17,8 +35,6 @@ def test_simplelog_defaults_option(runner):
         logging.error("ERROR")
         logging.info("INFO")
         logging.debug("DEBUG")
-
-    logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
     result = runner.invoke(cli, ["--test=test"])
 
@@ -39,8 +55,6 @@ def test_simplelog_defaults_option_remove_args(runner):
         logging.info("INFO")
         logging.debug("DEBUG")
 
-    logging.basicConfig(format="%(message)s", stream=sys.stdout)
-
     result = runner.invoke(cli, ["--test=test"])
 
     assert result.output == "test\nCRITICAL\nERROR\n"
@@ -56,8 +70,6 @@ def tool_run_cli(runner, simplelog_opts={}, cli_args=None):
         logging.error("ERROR")
         logging.info("INFO")
         logging.debug("DEBUG")
-
-    logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
     return runner.invoke(cli, cli_args)
 

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -1,8 +1,16 @@
-import StringIO
+import sys
+
+if sys.version < '3':
+
+    import StringIO
+
+else:
+
+    from io import StringIO
+
 import re
 import click
 import logging
-from click import simplelog
 
 
 log_stream = StringIO.StringIO()

--- a/tests/test_simplelog.py
+++ b/tests/test_simplelog.py
@@ -1,37 +1,7 @@
-import sys
-
 import re
+import sys
 import click
 import logging
-
-log_stream = None
-
-
-def tool_resetlog():
-
-    global log_stream
-
-    logging.basicConfig()
-
-    root = logging.getLogger()
-
-    for handler in root.handlers:
-
-        root.removeHandler(handler)
-
-    if sys.version < '3':
-
-        import StringIO
-        log_stream = StringIO.StringIO()
-
-    else:
-
-        import io
-        log_stream = io.StringIO()
-
-    handler = logging.StreamHandler(log_stream)
-
-    root.addHandler(handler)
 
 
 def test_simplelog_defaults_option(runner):
@@ -48,12 +18,11 @@ def test_simplelog_defaults_option(runner):
         logging.info("INFO")
         logging.debug("DEBUG")
 
-    tool_resetlog()
+    logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
     result = runner.invoke(cli, ["--test=test"])
 
-    assert result.output == "test\n"
-    assert log_stream.getvalue() == "CRITICAL\nERROR\n"
+    assert result.output == "test\nCRITICAL\nERROR\n"
 
 
 def test_simplelog_defaults_option_remove_args(runner):
@@ -70,12 +39,11 @@ def test_simplelog_defaults_option_remove_args(runner):
         logging.info("INFO")
         logging.debug("DEBUG")
 
-    tool_resetlog()
+    logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
     result = runner.invoke(cli, ["--test=test"])
 
-    assert result.output == "test\n"
-    assert log_stream.getvalue() == "CRITICAL\nERROR\n"
+    assert result.output == "test\nCRITICAL\nERROR\n"
 
 
 def tool_run_cli(runner, simplelog_opts={}, cli_args=None):
@@ -89,16 +57,16 @@ def tool_run_cli(runner, simplelog_opts={}, cli_args=None):
         logging.info("INFO")
         logging.debug("DEBUG")
 
-    tool_resetlog()
+    logging.basicConfig(format="%(message)s", stream=sys.stdout)
 
     return runner.invoke(cli, cli_args)
 
 
 def test_simplelog_defaults(runner):
 
-    tool_run_cli(runner)
+    result = tool_run_cli(runner)
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\n"
+    assert result.output == "CRITICAL\nERROR\n"
 
 
 def test_simplelog_defaults_help(runner):
@@ -116,63 +84,63 @@ def test_simplelog_defaults_help(runner):
 
 def test_simplelog_quiet(runner):
 
-    tool_run_cli(runner, cli_args=["--quiet"])
+    result = tool_run_cli(runner, cli_args=["--quiet"])
 
-    assert log_stream.getvalue() == "CRITICAL\n"
+    assert result.output == "CRITICAL\n"
 
 
 def test_simplelog_verbose(runner):
 
-    tool_run_cli(runner, cli_args=["--verbose"])
+    result = tool_run_cli(runner, cli_args=["--verbose"])
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\nINFO\n"
+    assert result.output == "CRITICAL\nERROR\nINFO\n"
 
 
 def test_simplelog_debug(runner):
 
-    tool_run_cli(runner, cli_args=["--debug"])
+    result = tool_run_cli(runner, cli_args=["--debug"])
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\nINFO\nDEBUG\n"
+    assert result.output == "CRITICAL\nERROR\nINFO\nDEBUG\n"
 
 
 def test_simplelog_vvvflavor_quiet(runner):
 
-    tool_run_cli(runner, simplelog_opts={"flavor": "vvv"})
+    result = tool_run_cli(runner, simplelog_opts={"flavor": "vvv"})
 
-    assert log_stream.getvalue() == "CRITICAL\n"
+    assert result.output == "CRITICAL\n"
 
 
 def test_simplelog_vvvflavor_defaults(runner):
 
-    tool_run_cli(
+    result = tool_run_cli(
         runner,
         simplelog_opts={"flavor": "vvv"},
         cli_args=["-v"]
     )
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\n"
+    assert result.output == "CRITICAL\nERROR\n"
 
 
 def test_simplelog_vvvflavor_verbose(runner):
 
-    tool_run_cli(
+    result = tool_run_cli(
         runner,
         simplelog_opts={"flavor": "vvv"},
         cli_args=["-vv"]
     )
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\nINFO\n"
+    assert result.output == "CRITICAL\nERROR\nINFO\n"
 
 
 def test_simplelog_vvvflavor_debug(runner):
 
-    tool_run_cli(
+    result = tool_run_cli(
         runner,
         simplelog_opts={"flavor": "vvv"},
         cli_args=["-vvv"]
     )
 
-    assert log_stream.getvalue() == "CRITICAL\nERROR\nINFO\nDEBUG\n"
+    assert result.output == "CRITICAL\nERROR\nINFO\nDEBUG\n"
 
 
 def test_simplelog_invalidflavor(runner):
@@ -189,4 +157,3 @@ def test_simplelog_invalidflavor(runner):
         return
 
     assert result.exception
-


### PR DESCRIPTION
This is what I meant in #277 :)

Now you can add @click.simplelog() to a command to add logging behaviour to it. Afterwards you can simply call logging.debug for debugging messages and they will only show up, if the user specified the --debug/-d-switch.

If you like it, I can additionally add the relevant documentation.
