### PR TITLE
ability to pass custom implementations of ``Option`` and ``Argument``

### DIFF
--- a/click/decorators.py
+++ b/click/decorators.py
@@ -140,8 +140,8 @@ def argument(*param_decls, **attrs):
     This is equivalent to creating an :class:`Argument` instance manually
     and attaching it to the :attr:`Command.params` list.
 
-    :param cls: a custom :class:`Argument` subclass that can be instatiated
-                instead of a default one.
+    :param cls: the argument class to instantiate.  This defaults to
+                :class:`Argument`.
     """
     def decorator(f):
         ArgumentClass = attrs.pop('cls', Argument)
@@ -157,8 +157,8 @@ def option(*param_decls, **attrs):
     This is equivalent to creating an :class:`Option` instance manually
     and attaching it to the :attr:`Command.params` list.
 
-    :param cls: a custom :class:`Option` subclass that can be instatiated
-                instead of a default one.
+    :param cls: the option class to instantiate.  This defaults to
+                :class:`Option`.
     """
     def decorator(f):
         if 'help' in attrs:

--- a/click/decorators.py
+++ b/click/decorators.py
@@ -136,12 +136,16 @@ def _param_memo(f, param):
 def argument(*param_decls, **attrs):
     """Attaches an argument to the command.  All positional arguments are
     passed as parameter declarations to :class:`Argument`; all keyword
-    arguments are forwarded unchanged.  This is equivalent to creating an
-    :class:`Argument` instance manually and attaching it to the
-    :attr:`Command.params` list.
+    arguments are forwarded unchanged (except ``cls``).
+    This is equivalent to creating an :class:`Argument` instance manually
+    and attaching it to the :attr:`Command.params` list.
+
+    :param cls: a custom :class:`Argument` subclass that can be instatiated
+                instead of a default one.
     """
     def decorator(f):
-        _param_memo(f, Argument(param_decls, **attrs))
+        ArgumentClass = attrs.pop('cls', Argument)
+        _param_memo(f, ArgumentClass(param_decls, **attrs))
         return f
     return decorator
 
@@ -149,14 +153,18 @@ def argument(*param_decls, **attrs):
 def option(*param_decls, **attrs):
     """Attaches an option to the command.  All positional arguments are
     passed as parameter declarations to :class:`Option`; all keyword
-    arguments are forwarded unchanged.  This is equivalent to creating an
-    :class:`Option` instance manually and attaching it to the
-    :attr:`Command.params` list.
+    arguments are forwarded unchanged (except ``cls``).
+    This is equivalent to creating an :class:`Option` instance manually
+    and attaching it to the :attr:`Command.params` list.
+
+    :param cls: a custom :class:`Option` subclass that can be instatiated
+                instead of a default one.
     """
     def decorator(f):
         if 'help' in attrs:
             attrs['help'] = inspect.cleandoc(attrs['help'])
-        _param_memo(f, Option(param_decls, **attrs))
+        OptionClass = attrs.pop('cls', Option)
+        _param_memo(f, OptionClass(param_decls, **attrs))
         return f
     return decorator
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -222,7 +222,7 @@ def test_multiline_help(runner):
 def test_argument_custom_class(runner):
     class CustomArgument(click.Argument):
         def get_default(self, ctx):
-            '''a dumb ovverride of a default value for testing'''
+            '''a dumb override of a default value for testing'''
             return 'I am a default'
 
     @click.command()
@@ -238,7 +238,7 @@ def test_argument_custom_class(runner):
 def test_option_custom_class(runner):
     class CustomOption(click.Option):
         def get_help_record(self, ctx):
-            '''a dumb ovverride of a help text for testing'''
+            '''a dumb override of a help text for testing'''
             return ('--help', 'I am a help text')
 
     @click.command()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -217,3 +217,35 @@ def test_multiline_help(runner):
     assert '  --foo TEXT  hello' in out
     assert '              i am' in out
     assert '              multiline' in out
+
+
+def test_argument_custom_class(runner):
+    class CustomArgument(click.Argument):
+        def get_default(self, ctx):
+            '''a dumb ovverride of a default value for testing'''
+            return 'I am a default'
+
+    @click.command()
+    @click.argument('testarg', cls=CustomArgument, default='you wont see me')
+    def cmd(testarg):
+        click.echo(testarg)
+
+    result = runner.invoke(cmd)
+    assert 'I am a default' in result.output
+    assert 'you wont see me' not in result.output
+
+
+def test_option_custom_class(runner):
+    class CustomOption(click.Option):
+        def get_help_record(self, ctx):
+            '''a dumb ovverride of a help text for testing'''
+            return ('--help', 'I am a help text')
+
+    @click.command()
+    @click.option('--testoption', cls=CustomOption, help='you wont see me')
+    def cmd(testoption):
+        click.echo(testoption)
+
+    result = runner.invoke(cmd, ['--help'])
+    assert 'I am a help text' in result.output
+    assert 'you wont see me' not in result.output


### PR DESCRIPTION
allow passing a different class to `option` and `argument` decorators via `cls` keyword argument.
