### PR TITLE
Modify _bashcomplete for zsh use

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -6,7 +6,7 @@ from .core import MultiCommand, Option
 
 COMPLETION_SCRIPT = '''
 %(complete_func)s() {
-    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \\
+    COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \\
                    COMP_CWORD=$COMP_CWORD \\
                    %(autocomplete_var)s=complete $1 ) )
     return 0


### PR DESCRIPTION
Zsh has support for loading bash completion functions, but dies on the syntax here.
Adding 'env' works on both bash and zsh.

zsh instructions:
1. autoload bashcompinit && bashcompinit
2. Follow bash instructions.
