### PR TITLE
Fix clear() on win, colorama

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -297,7 +297,7 @@ def clear():
     # If we're on Windows and we don't have colorama available, then we
     # clear the screen by shelling out.  Otherwise we can use an escape
     # sequence.
-    if WIN and colorama is None:
+    if WIN:
         os.system('cls')
     else:
         sys.stdout.write('\033[2J\033[1;1H')


### PR DESCRIPTION
win10, python2.7, installed click, colorama

```
python
>>>import click;click.clear()
[2J[1;1H>>>
```
