### PR TITLE
Fix bashism in get_editor()

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -349,7 +349,7 @@ class Editor(object):
         if WIN:
             return 'notepad'
         for editor in 'vim', 'nano':
-            if os.system('which %s &> /dev/null' % editor) == 0:
+            if os.system('which %s >/dev/null 2>&1' % editor) == 0:
                 return editor
         return 'vi'
 


### PR DESCRIPTION
This causes the path to the editor to get printed if the shell spawned by `os.system` is not Bash.
