### PR TITLE
Minor typo.  Variable PATH and not PATHS

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -479,7 +479,7 @@ Example usage:
 .. click:example::
 
     @click.command()
-    @click.option('paths', '--path', envvar='PATHS', multiple=True,
+    @click.option('paths', '--path', envvar='PATH', multiple=True,
                   type=click.Path())
     def perform(paths):
         for path in paths:


### PR DESCRIPTION
The ENV variable that's being referenced is and should be `PATH` singular not `PATHS` plural.

Also, just for fun, I think it would be way more funny if line 376, referencing dangerous operations was a bit more sinister: `click.echo('Dropped all tables, lol!')`
