### PR TITLE
Incorrect code example.  open with 'write' flag

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -58,7 +58,7 @@ Example::
 
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open('hello.txt') as f:
+            with open('hello.txt', 'w') as f:
                 f.write('Hello World!')
 
             result = runner.invoke(cat, ['hello.txt'])


### PR DESCRIPTION
The example doesn't work as is.  You need the 'w' flag.
