### PR TITLE
Suppress trailing None in usage/error output as described in mitsuhiko/click/#312

### DIFF
--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -127,7 +127,7 @@ class MissingParameter(BadParameter):
             param_type,
             param_hint and ' %s' % param_hint or '',
             msg and '.  ' or '.',
-            msg,
+            msg or '',
         )
 
 


### PR DESCRIPTION
I don't have a complete grasp on the click internals but I believe this fixes #312.
