### PR TITLE
Fix formatting issue when last line of docstring is blank

### DIFF
--- a/click/formatting.py
+++ b/click/formatting.py
@@ -20,7 +20,7 @@ def iter_rows(rows, col_count):
 
 def add_subsequent_indent(text, subsequent_indent):
     lines = text.splitlines()
-    lines = [lines[0]] + [subsequent_indent + line for line in lines[1:]]
+    lines = lines[:1] + [subsequent_indent + line for line in lines[1:]]
     return '\n'.join(lines)
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -87,3 +87,24 @@ def test_wrapping_long_options_strings(runner):
         'Options:',
         '  --help  Show this message and exit.',
     ]
+
+
+def test_formatting_empty_help_lines(runner):
+    @click.command()
+    def cli():
+        """Top level command
+
+        """
+
+    result = runner.invoke(cli, ['--help'])
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: cli [OPTIONS]',
+        '',
+        '  Top level command',
+        '',
+        '',
+        '',
+        'Options:',
+        '  --help  Show this message and exit.',
+    ]


### PR DESCRIPTION
@mitsuhiko 

Fixes the following issue that was not uncovered by earlier testing:
When the docstring ends with a blank line, the traceback below is seen.

```
@click.command()
def cli():
    """Top level command

    """
```

```
$ hatcher --debug eggs update-index --help
Traceback (most recent call last):
  File "/home/sjagoe/.virtualenvs/hatcher34/bin/hatcher", line 9, in <module>
    load_entry_point('hatcher==0.8.0.dev604-36b030c', 'console_scripts', 'hatcher')()
  File "/home/sjagoe/workspace/enthought/source/hatcher/hatcher/cli/main.py", line 60, in main
    return hatcher(auto_envvar_prefix='HATCHER')
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/sjagoe/workspace/enthought/source/hatcher/hatcher/cli/utils.py", line 52, in invoke
    return super(_ErrorHandlingMixin, self).invoke(ctx)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 989, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 560, in make_context
    self.parse_args(ctx, args)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 822, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 1326, in handle_parse_result
    self.callback, ctx, self, value)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 54, in invoke_param_callback
    return callback(ctx, param, value)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 751, in show_help
    echo(ctx.get_help(), color=ctx.color)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 416, in get_help
    return self.command.get_help(self)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 772, in get_help
    self.format_help(ctx, formatter)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 786, in format_help
    self.format_help_text(ctx, formatter)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/core.py", line 795, in format_help_text
    formatter.write_text(self.help)
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/formatting.py", line 165, in write_text
    preserve_paragraphs=True))
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/formatting.py", line 90, in wrap_text
    post_wrap_indent))
  File "/home/sjagoe/.virtualenvs/hatcher34/lib/python3.4/site-packages/click/formatting.py", line 23, in add_subsequent_indent
    lines = [lines[0]] + [subsequent_indent + line for line in lines[1:]]
IndexError: list index out of range
```
