### PR TITLE
Conditionally display missing parameter message

### DIFF
--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -127,7 +127,7 @@ class MissingParameter(BadParameter):
             param_type,
             param_hint and ' %s' % param_hint or '',
             msg and '.  ' or '.',
-            msg,
+            msg and msg or '',
         )
 
 


### PR DESCRIPTION
When building the message for a missing parameter, additional messaging
can be included. The additional messaging is added to the standard
wording regardless of whether or not any such messaging exists. This
results in `None` appearing at the end of the error message.

Conditional logic is being added to prevent this from happening. This
behavior is consistent with other parts of building the message, most
notably when the period is added a space will be included if there is
additional messaging.
