### PR TITLE
Handle multiple args after star arg

### DIFF
--- a/click/utils.py
+++ b/click/utils.py
@@ -43,6 +43,7 @@ def unpack_args(args, nargs_spec):
     nargs_spec = deque(nargs_spec)
     rv = []
     spos = None
+    spos_rv = None
 
     def _fetch(c):
         try:
@@ -53,24 +54,34 @@ def unpack_args(args, nargs_spec):
     while nargs_spec:
         nargs = _fetch(nargs_spec)
         if nargs == 1:
-            rv.append(_fetch(args))
+            arg = _fetch(args)
+            if spos is not None:
+                spos_rv.append(arg)
+            else:
+                rv.append(arg)
         elif nargs > 1:
             x = [_fetch(args) for _ in range(nargs)]
             # If we're reversed, we're pulling in the arguments in reverse,
             # so we need to turn them around.
             if spos is not None:
                 x.reverse()
-            rv.append(tuple(x))
+                spos_rv.append(x)
+            else:
+                rv.append(tuple(x))
         elif nargs < 0:
             if spos is not None:
                 raise TypeError('Cannot have two nargs < 0')
             spos = len(rv)
             rv.append(None)
+            # handle reversing arg order after spos set
+            spos_rv = []
 
     # spos is the position of the wildcard (star).  If it's not `None`,
     # we fill it with the remainder.
     if spos is not None:
         rv[spos] = tuple(args)
+        spos_rv.reverse()
+        rv.extend(spos_rv)
         args = []
 
     return tuple(rv), list(args)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -210,3 +210,38 @@ def test_eat_options(runner):
         'bar',
         '-x',
     ]
+
+
+def test_nargs_star_ordering(runner):
+    @click.command()
+    @click.argument('a', nargs=-1)
+    @click.argument('b')
+    @click.argument('c')
+    def cmd(a, b, c):
+        for arg in (a, b, c):
+            click.echo(arg)
+
+    result = runner.invoke(cmd, ['a', 'b', 'c'])
+    assert result.output.splitlines() == [
+        "('a',)",
+        'b',
+        'c',
+    ]
+
+
+def test_nargs_specified_plus_star_ordering(runner):
+    @click.command()
+    @click.argument('a', nargs=-1)
+    @click.argument('b')
+    @click.argument('c', nargs=2)
+    def cmd(a, b, c):
+        for arg in (a, b, c):
+            click.echo(arg)
+
+    result = runner.invoke(cmd, ['a', 'b', 'c', 'd', 'e', 'f'])
+    print result.output
+    assert result.output.splitlines() == [
+        "('a', 'b', 'c')",
+        'd',
+        "('e', 'f')",
+    ]

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -239,7 +239,6 @@ def test_nargs_specified_plus_star_ordering(runner):
             click.echo(arg)
 
     result = runner.invoke(cmd, ['a', 'b', 'c', 'd', 'e', 'f'])
-    print result.output
     assert result.output.splitlines() == [
         "('a', 'b', 'c')",
         'd',


### PR DESCRIPTION
Addresses issue #316.  Previous behavior only worked if there was
a single arg specified after an arg with nargs=-1.
