### PR TITLE
Let click.utils.KeepOpenFile()/LazyFile() be an iterator.  For #338.

### DIFF
--- a/click/utils.py
+++ b/click/utils.py
@@ -191,6 +191,10 @@ class LazyFile(object):
     def __exit__(self, exc_type, exc_value, tb):
         self.close_intelligently()
 
+    def __iter__(self):
+        self.open()
+        return iter(self._f)
+
 
 class KeepOpenFile(object):
 
@@ -208,6 +212,9 @@ class KeepOpenFile(object):
 
     def __repr__(self):
         return repr(self._file)
+
+    def __iter__(self):
+        return iter(self._file)
 
 
 def echo(message=None, file=None, nl=True, err=False, color=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import os
 import sys
-import click
 
+import click
+import click.utils
 import click._termui_impl
 
 
@@ -227,3 +228,23 @@ def test_open_file(runner):
         result = runner.invoke(cli, ['-'], input='foobar')
         assert result.exception is None
         assert result.output == 'foobar\nmeep\n'
+
+
+def test_iter_keepopenfile(tmpdir):
+
+    expected = list(map(str, range(10)))
+    p = tmpdir.mkdir('testdir').join('testfile')
+    p.write(os.linesep.join(expected))
+    f = p.open()
+    for e_line, a_line in zip(expected, click.utils.KeepOpenFile(f)):
+        assert e_line == a_line.strip()
+
+
+def test_iter_lazyfile(tmpdir):
+
+    expected = list(map(str, range(10)))
+    p = tmpdir.mkdir('testdir').join('testfile')
+    p.write(os.linesep.join(expected))
+    f = p.open()
+    for e_line, a_line in zip(expected, click.utils.LazyFile(f.name)):
+        assert e_line == a_line.strip()


### PR DESCRIPTION
Added a `__iter__()` method to `KeepOpenFile()` and `LazyFile()` that just returns the underlying `self._file.__iter__()` so an exception will still be raised if the underlying file isn't an iterator.  `LazyFile()` calls its `open()` method first.

Included a unittest in `tests/test_utils.py` as well.
