### PR TITLE
Ignore KeyboardInterrupt while writing to pager.

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -306,7 +306,7 @@ def _pipepager(text, cmd, color):
     try:
         c.stdin.write(text.encode(encoding, 'replace'))
         c.stdin.close()
-    except IOError:
+    except (IOError, KeyboardInterrupt):
         pass
 
     # Less doesn't respect ^C, but catches it for its own UI purposes (aborting


### PR DESCRIPTION
This addresses a corner case in #350. 

@untitaker Your solution to ignore the KeyboardInterrupt in `echo_via_pager()` is absolutely right and it works great. But for cases where the amount of text that is being written into the pager is larger than the OS buffer it blocks on writing to the buffer. https://github.com/mitsuhiko/click/blob/4.x-maintenance/click/_termui_impl.py#L309

So it is necessary to ignore the ^C while that is happening as well. 

Test program:

```
import click

@click.command()
@click.option('--foo', prompt=True)
def cli(foo):
    s = open('large_file.txt')
    while True:
        a = click.prompt('>')
        if a == 'exit':
            break
        click.echo_via_pager(s.read())
```

Run the above program with a `large_file.txt` in the working folder. Make sure it has at least 5000 lines in there and press ^C right after the first page. You will trigger the old behavior where the KeyboardInterrupt is bubbled up to the click app and results in 'Aborted!'. With this PR that corner case if fixed. 
