### PR TITLE
Fix formatting of long argument lists

### DIFF
--- a/click/formatting.py
+++ b/click/formatting.py
@@ -133,13 +133,12 @@ class HelpFormatter(object):
         :param args: whitespace separated list of arguments.
         :param prefix: the prefix for the first line.
         """
-        prefix = '%*s%s' % (self.current_indent, prefix, prog)
-        self.write(prefix)
+        prefix = '%*s%s ' % (self.current_indent, prefix, prog)
 
-        text_width = max(self.width - self.current_indent - term_len(prefix), 10)
-        indent = ' ' * (term_len(prefix) + 1)
+        text_width = max(self.width - self.current_indent, 10)
+        indent = ' ' * term_len(prefix)
         self.write(wrap_text(args, text_width,
-                             initial_indent=' ',
+                             initial_indent=prefix,
                              subsequent_indent=indent))
 
         self.write('\n')


### PR DESCRIPTION
With long argument lists, the help formatting can erroneously produce badly wrapped text.  For example:

```
import click

@click.group()
def example():
    pass

@example.group()
def long_subgroup_name():
    pass

@long_subgroup_name.command()
@click.argument("argument1")
@click.argument("argument2")
def long_command_name(argument1, argument2):
    pass


if __name__ == '__main__':
    example()
```

When run as `python format.py long_subgroup_name long_command_name --help`
Produces:

```
Usage: format.py long_subgroup_name long_command_name [OPTIONS] ARGUMENT1
                                                      A
                                                      R
                                                      G
                                                      U
                                                      M
                                                      E
                                                      N
                                                      T
                                                      2
```

The wrapping lines are using a `text_width` that is too small.

This is because the prefix is first printed, and then the wrapper is configured with whatever is remaining on that line, which is not very much.  By the time it adds in the prefix spaces for subsequent lines, it has run out of room for more than one character.

With this fix, the output becomes:

```
Usage: format.py long_subgroup_name long_command_name [OPTIONS] ARGUMENT1
                                                      ARGUMENT2
```
