### PR TITLE
PR: a global ctx object

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -46,6 +46,9 @@ from .formatting import HelpFormatter, wrap_text
 # Parsing
 from .parser import OptionParser
 
+# Global context variable
+from .context import ctx
+
 
 __all__ = [
     # Core classes

--- a/click/context.py
+++ b/click/context.py
@@ -1,0 +1,35 @@
+class _Stack(object):
+    def __init__(self):
+        self._stack = []
+
+    @property
+    def top(self):
+        return self._stack[-1]
+
+    def push(self, value):
+        self._stack.append(value)
+
+    def pop(self):
+        return self._stack.pop()
+
+
+class _StackProxy(object):
+    def __init__(self, stack):
+        object.__setattr__(self, '_click_ctx_stack', stack)
+
+    def __bool__(self):
+        try:
+            self. _click_ctx_stack.top
+        except IndexError:
+            return False
+        else:
+            return True
+
+    __nonzero__ = __bool__
+
+    __getattr__ = lambda s, n: getattr(s._click_ctx_stack.top, n)
+    __setattr__ = lambda s, n, v: setattr(s._click_ctx_stack.top, n, v)
+
+
+_ctx_stack = _Stack()
+ctx = _StackProxy(_ctx_stack)

--- a/click/context.py
+++ b/click/context.py
@@ -4,13 +4,24 @@ class _Stack(object):
 
     @property
     def top(self):
-        return self._stack[-1]
+        try:
+            return self._stack[-1]
+        except IndexError:
+            raise RuntimeError(
+                'Working outside of click context. This means that currently '
+                'no click app is running whose context you could access. Note '
+                'that multiprocessing or similar libraries are not supported '
+                'by click.'
+            )
 
     def push(self, value):
         self._stack.append(value)
 
     def pop(self):
-        return self._stack.pop()
+        try:
+            return self._stack.pop()
+        except RuntimeError:
+            raise RuntimeError('No click context to pop.')
 
 
 class _StackProxy(object):
@@ -20,7 +31,7 @@ class _StackProxy(object):
     def __bool__(self):
         try:
             self. _click_ctx_stack.top
-        except IndexError:
+        except RuntimeError:
             return False
         else:
             return True

--- a/click/core.py
+++ b/click/core.py
@@ -12,6 +12,7 @@ from .exceptions import ClickException, UsageError, BadParameter, Abort, \
 from .termui import prompt, confirm
 from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
+from .context import _ctx_stack
 
 from ._compat import PY2, isidentifier, iteritems
 
@@ -291,10 +292,17 @@ class Context(object):
 
     def __enter__(self):
         self._depth += 1
+        _ctx_stack.push(self)
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
         self._depth -= 1
+        if _ctx_stack.pop() is not self:
+            raise RuntimeError(
+                'The wrong context got popped off the stack. Note that click '
+                'doesn\'t support multiple applications being invoked in the '
+                'same process.'
+            )
         if self._depth == 0:
             self.close()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -110,3 +110,16 @@ def test_multi_enter(runner):
     result = runner.invoke(cli, [])
     assert result.exception is None
     assert called == [True]
+
+
+def test_global_context_object(runner):
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        assert click.ctx
+        ctx.obj = 'FOOBAR'
+        assert click.ctx.obj == 'FOOBAR'
+
+    assert not click.ctx
+    result = runner.invoke(cli, [], catch_exceptions=False)
+    assert not click.ctx


### PR DESCRIPTION
Fix #292

---
- [x] Use better exceptions, provide own ones
- [ ] Does bool behavior of `click.ctx` make sense? I personally liked it in [vdirsyncer's doubleclick wrapper](https://github.com/untitaker/vdirsyncer/blob/master/vdirsyncer/doubleclick.py), it was useful for checking whether ctx is available.
- [ ] Deprecate/remove `pass_context`?
