### PR TITLE
Enable plugins via setup tools entry-points.

### DIFF
--- a/click/decorators.py
+++ b/click/decorators.py
@@ -116,43 +116,13 @@ def command(name=None, cls=None, **attrs):
     return decorator
 
 
-def group(name=None, plugins=None, **attrs):
+def group(name=None, **attrs):
     """Creates a new :class:`Group` with a function as callback.  This
     works otherwise the same as :func:`command` just that the `cls`
     parameter is set to :class:`Group`.
-
-    .. versionadded:: 5.0
-       Added `plugins`.
-
-    :param plugins: An iterable like `pkg_resources.iter_entry_points()` that
-                    procuces one instance of  :class:`pkg_resources.EntryPoint()`
-                    per iteration.  Used to load click commands or groups from
-                    setuptools entry-points and attach them to the group being
-                    created by this decorator.
     """
-
     attrs.setdefault('cls', Group)
-    attrs.update(name=name)  # Some people may be using name as a positional arg
-
-    def decorator(f):
-
-        attrs.setdefault('cls', Group)
-        obj = command(**attrs)(f)
-
-        if plugins is not None:
-            for entry_point in plugins:
-                try:
-                    obj.add_command(entry_point.load())
-
-                except Exception:
-                    # Catch this so a busted plugin doesn't take down the CLI.
-                    # Handled by registering a dummy command that does nothing
-                    # other than explain the error.
-                    obj.add_command(BrokenCommand(entry_point.name))
-
-        return obj
-
-    return decorator
+    return command(name, **attrs)
 
 
 def _param_memo(f, param):

--- a/examples/plugins/BrokenPlugin/README.rst
+++ b/examples/plugins/BrokenPlugin/README.rst
@@ -1,0 +1,5 @@
+bold
+====
+
+This plugin should add bold styling to ``printer`` but there is a typo in the
+entry-point section of the ``setup.py`` that prevents the plugin from loading.

--- a/examples/plugins/BrokenPlugin/printer_bold/__init__.py
+++ b/examples/plugins/BrokenPlugin/printer_bold/__init__.py
@@ -1,0 +1,3 @@
+"""
+A broken plugin that raises an exception
+"""

--- a/examples/plugins/BrokenPlugin/printer_bold/core.py
+++ b/examples/plugins/BrokenPlugin/printer_bold/core.py
@@ -1,0 +1,19 @@
+"""
+Add bold styling to `printer`
+"""
+
+
+import click
+
+
+@click.command()
+@click.argument('infile', type=click.File('r'), default='-')
+@click.argument('outfile', type=click.File('w'), default='-')
+def bold(infile, outfile):
+
+    """
+    Make text bold.
+    """
+
+    for line in infile:
+        click.secho(line, bold=True, file=outfile)

--- a/examples/plugins/BrokenPlugin/setup.py
+++ b/examples/plugins/BrokenPlugin/setup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+
+"""
+Setup script for `printer_bold`
+"""
+
+
+from setuptools import setup
+
+
+setup(
+    name='printer_bold',
+    version='0.1dev0',
+    packages=['printer_bold'],
+    entry_points='''
+        [printer.plugins]
+        bold=printer_bold.core:bolddddddddddd
+    '''
+)

--- a/examples/plugins/PrinterStyle/README.rst
+++ b/examples/plugins/PrinterStyle/README.rst
@@ -1,0 +1,12 @@
+PrinterStyle
+============
+
+A plugin for ``printer`` that adds commands for text styling.
+
+
+Installation
+------------
+
+.. code-block:: console
+
+    $ pip install .

--- a/examples/plugins/PrinterStyle/printer_style/__init__.py
+++ b/examples/plugins/PrinterStyle/printer_style/__init__.py
@@ -1,0 +1,3 @@
+"""
+A CLI plugin for `printer` that adds styling options.
+"""

--- a/examples/plugins/PrinterStyle/printer_style/core.py
+++ b/examples/plugins/PrinterStyle/printer_style/core.py
@@ -1,0 +1,46 @@
+"""
+Core components for printer_style
+"""
+
+
+import click
+
+
+COLORS = (
+    'black',
+    'red',
+    'green',
+    'yellow',
+    'blue',
+    'magenta',
+    'cyan',
+    'white',
+)
+
+
+@click.command()
+@click.argument('infile', type=click.File('r'), default='-')
+@click.argument('outfile', type=click.File('w'), default='-')
+@click.option('-c', '--color', type=click.Choice(COLORS), required=True)
+def background(infile, outfile, color):
+
+    """
+    Add a background color.
+    """
+
+    for line in infile:
+        click.echo(line, file=outfile, color=color)
+
+
+@click.command()
+@click.argument('infile', type=click.File('r'), default='-')
+@click.argument('outfile', type=click.File('w'), default='-')
+@click.option('-c', '--color', type=click.Choice(COLORS), required=True)
+def color(infile, outfile, color):
+
+    """
+    Add color to text.
+    """
+
+    for line in infile:
+        click.echo(line, color=color, file=outfile)

--- a/examples/plugins/PrinterStyle/setup.py
+++ b/examples/plugins/PrinterStyle/setup.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+
+"""
+Setup script for `printer_style`
+"""
+
+
+from setuptools import setup
+
+
+setup(
+    name='printer_style',
+    version='0.1dev0',
+    packages=['printer_style'],
+    entry_points='''
+        [printer.plugins]
+        background=printer_style.core:background
+        color=printer_style.core:color
+    '''
+)

--- a/examples/plugins/README.rst
+++ b/examples/plugins/README.rst
@@ -1,0 +1,146 @@
+plugins
+=======
+
+A sample package that loads CLI plugins from another package.
+
+
+Contents
+--------
+
+* ``printer`` - The core package.
+* ``PrinterStyle`` - An external plugin for ``printer``'s CLI that adds colors.
+* ``BrokenPlugin`` - An broken external plugin that is supposed to add bold styling.
+
+
+Workflow
+--------
+
+First get into the example directory:
+
+.. code-block:: console
+
+    $ cd examples/plugins
+
+Install the main package:
+
+.. code-block:: console
+
+    $ pip install .
+
+And run the commandline utility to see the usage:
+
+.. code-block:: console
+
+    $ printer
+    Usage: printer [OPTIONS] COMMAND [ARGS]...
+
+      Format and print file contents.
+
+      For example:
+
+          $ cat README.rst | printer lower
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      lower  Convert to lower case.
+      upper  Convert to uppser case.
+
+
+Try running ``cat README.rst | printer upper`` to convert this file to upper-case.
+
+The ``PrinterStyle`` directory is an external CLI plugin that is compatible with
+``printer``.  In this case ``PrinterStyle`` adds styling options to the ``printer``
+utility.
+
+Install it:
+
+.. code-block:: console
+
+    $ pip install PrinterStyle/
+
+And get the ``printer`` usage again, now with two additional commands:
+
+.. code-block:: console
+
+    $ printer
+    Usage: printer [OPTIONS] COMMAND [ARGS]...
+
+      Format and print file contents.
+
+      For example:
+
+          $ cat README.rst | printer lower
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      background  Add a background color.
+      bold        Make text bold.
+      color       Add color to text.
+      lower       Convert to lower case.
+      upper       Convert to upper case.
+
+
+Broken Plugins
+--------------
+
+Plugins that trigger an exception on load are flagged in the usage and the full
+traceback can be viewed by executing the command.
+
+Install the included broken plugin, which should give us a bold styling option:
+
+.. code-block:: console
+
+    $ pip install BrokenPlugin/
+
+And look at the ``printer`` usage again - notice the icon next to ``bold``:
+
+.. code-block:: console
+
+    $ printer
+    Usage: printer [OPTIONS] COMMAND [ARGS]...
+
+      Format and print file contents.
+
+      For example:
+
+          $ cat README.rst | printer lower
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      background  Add a background color.
+      bold        † Warning: could not load plugin. See `printer bold --help`.
+      color       Add color to text.
+      lower       Convert to lower case.
+      upper       Convert to upper case.
+
+Executing ``printer bold`` reveals the full traceback:
+
+.. code-block:: console
+
+    $ printer bold
+
+    Warning: entry point could not be loaded. Contact its author for help.
+
+    Traceback (most recent call last):
+      File "/Users/wursterk/github/click/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2353, in resolve
+        return functools.reduce(getattr, self.attrs, module)
+    AttributeError: 'module' object has no attribute 'bolddddddddddd'
+
+    During handling of the above exception, another exception occurred:
+
+    Traceback (most recent call last):
+      File "/Users/wursterk/github/click/click/decorators.py", line 145, in decorator
+        obj.add_command(entry_point.load())
+      File "/Users/wursterk/github/click/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2345, in load
+        return self.resolve()
+      File "/Users/wursterk/github/click/venv/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2355, in resolve
+        raise ImportError(str(exc))
+    ImportError: 'module' object has no attribute 'bolddddddddddd'
+
+In this case the error is in the broken plugin's ``setup.py``.

--- a/examples/plugins/printer/__init__.py
+++ b/examples/plugins/printer/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tools for printing things
+"""

--- a/examples/plugins/printer/cli.py
+++ b/examples/plugins/printer/cli.py
@@ -1,0 +1,47 @@
+"""
+Commandline interface for printer
+"""
+
+
+from pkg_resources import iter_entry_points
+
+import click
+
+
+@click.group(plugins=iter_entry_points('printer.plugins'))
+def cli():
+
+    """
+    Format and print file contents.
+
+    \b
+    For example:
+    \b
+        $ cat README.rst | printer lower
+    """
+
+
+@cli.command()
+@click.argument('infile', type=click.File('r'), default='-')
+@click.argument('outfile', type=click.File('w'), default='-')
+def upper(infile, outfile):
+
+    """
+    Convert to upper case.
+    """
+
+    for line in infile:
+        outfile.write(line.upper())
+
+
+@cli.command()
+@click.argument('infile', type=click.File('r'), default='-')
+@click.argument('outfile', type=click.File('w'), default='-')
+def lower(infile, outfile):
+
+    """
+    Convert to lower case.
+    """
+
+    for line in infile:
+        outfile.write(line.lower())

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+
+"""
+Setup script for `printer`
+"""
+
+
+from setuptools import setup
+
+
+setup(
+    name='printer',
+    version='0.1dev0',
+    packages=['printer'],
+    entry_points='''
+        [console_scripts]
+        printer=printer.cli:cli
+    '''
+)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Required for test_plugins.py

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -29,7 +29,8 @@ click.echo(json.dumps(rv))
 
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
-    'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io'
+    'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
+    'traceback'
 ])
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,127 @@
+from pkg_resources import EntryPoint
+from pkg_resources import iter_entry_points
+from pkg_resources import working_set
+
+import click
+
+
+# Create a few CLI commands for testing
+@click.command()
+@click.argument('arg')
+def cmd1(arg):
+    """Test command 1"""
+    click.echo('passed')
+
+@click.command()
+@click.argument('arg')
+def cmd2(arg):
+    """Test command 2"""
+    click.echo('passed')
+
+
+# Manually register plugins in an entry point and put broken plugins in a
+# different entry point.
+
+# The `DistStub()` class gets around an exception that is raised when
+# `entry_point.load()` is called.  By default `load()` has `requires=True`
+# which calls `dist.requires()` and the `click.group()` decorator
+# doesn't allow us to change this.  Because we are manually registering these
+# plugins the `dist` attribute is `None` so we can just create a stub that
+# always returns an empty list since we don't have any requirements.  A full
+# `pkg_resources.Distribution()` instance is not needed because there isn't
+# a package installed anywhere.
+class DistStub(object):
+    def requires(self, *args):
+        return []
+
+working_set.by_key['click']._ep_map = {
+    'click.test_plugins': {
+        'cmd1': EntryPoint.parse(
+            'cmd1=tests.test_plugins:cmd1', dist=DistStub()),
+        'cmd2': EntryPoint.parse(
+            'cmd2=tests.test_plugins:cmd2', dist=DistStub())
+    },
+    'click.broken_plugins': {
+        'before': EntryPoint.parse(
+            'before=tests.broken_plugins:before', dist=DistStub()),
+        'after': EntryPoint.parse(
+            'after=tests.broken_plugins:after', dist=DistStub()),
+        'do_not_exist': EntryPoint.parse(
+            'do_not_exist=tests.broken_plugins:do_not_exist', dist=DistStub())
+    }
+}
+
+
+# Main CLI groups - one with good plugins attached and the other broken
+@click.group(plugins=iter_entry_points('click.test_plugins'))
+def good_cli():
+    """Good CLI group."""
+    pass
+
+
+@click.group(plugins=iter_entry_points('click.broken_plugins'))
+def broken_cli():
+    """Broken CLI group."""
+    pass
+
+
+def test_registered():
+    # Make sure the plugins are properly registered.  If this test fails it
+    # means that some of the for loops in other tests may not be executing.
+    assert len([ep for ep in iter_entry_points('click.test_plugins')]) > 1
+    assert len([ep for ep in iter_entry_points('click.broken_plugins')]) > 1
+
+
+def test_register_and_run(runner):
+
+    result = runner.invoke(good_cli)
+    assert result.exit_code is 0
+
+    for ep in iter_entry_points('click.test_plugins'):
+        cmd_result = runner.invoke(good_cli, [ep.name, 'something'])
+        assert cmd_result.exit_code is 0
+        assert cmd_result.output.strip() == 'passed'
+
+
+def test_broken_register_and_run(runner):
+
+    result = runner.invoke(broken_cli)
+    assert result.exit_code is 0
+    assert u'\U0001F4A9' in result.output or u'\u2020' in result.output
+
+    for ep in iter_entry_points('click.broken_plugins'):
+        cmd_result = runner.invoke(broken_cli, [ep.name])
+        assert cmd_result.exit_code is not 0
+        assert 'Traceback' in cmd_result.output
+
+
+def test_group_chain(runner):
+
+    # Attach a sub-group to a CLI and get execute it without arguments to make
+    # sure both the sub-group and all the parent group's commands are present
+    @good_cli.group()
+    def sub_cli():
+        """Sub CLI."""
+        pass
+
+    result = runner.invoke(good_cli)
+    assert result.exit_code is 0
+    assert sub_cli.name in result.output
+    for ep in iter_entry_points('click.test_plugins'):
+        assert ep.name in result.output
+
+    # Same as above but the sub-group has plugins
+    @good_cli.group(plugins=iter_entry_points('click.test_plugins'))
+    def sub_cli_plugins():
+        """Sub CLI with plugins."""
+        pass
+
+    result = runner.invoke(good_cli, ['sub_cli_plugins'])
+    assert result.exit_code is 0
+    for ep in iter_entry_points('click.test_plugins'):
+        assert ep.name in result.output
+
+    # Execute one of the sub-group's commands
+    result = runner.invoke(good_cli, ['sub_cli_plugins', 'cmd1', 'something'])
+    assert result.exit_code is 0
+    assert result.output.strip() == 'passed'


### PR DESCRIPTION
This PR allows developers to open their CLI to external plugins via setuptools entry-points.  Plugins must be a `click.Group()` or `click.Command()` and be registered to an entry-point that is loaded by the `click.group()` decorator.  See `examples/plugins/README.rst` for a a walkthrough.

The primary modification is in `click.group()`, which has a new `plugins` keyword argument accepting `pkg_resources.iter_entry_points()`, or any iterator producing a `pkg_resources.EntryPoint()` per iteration.  Each entry-point is loaded and attached to the group being created by the group decorator.

``` python
from pkg_resources import iter_entry_points

import click

@click.group(plugins=iter_entry_points('entry.point'))
def cli():
   """Main CLI group."""
```

Plugins that raise an exception on load are intercepted and converted to a `click.core.BrokenCommand()` and overrides the command's short description with a note stating the plugin is broken and if invoked, the full traceback is printed.

Some things to consider:
1. The core package gets to decide where plugins are registered, not the plugins themselves.  This can create a UI with a lot of commands as it is difficult for some plugins to register to one group while other plugins register under a different group.  The workaround is for the core package to have additional entry-points for each group if the core package developer wants a deeper group-based CLI instead of one that is flat.
2. I haven't done anything with command chaining other than some R&D so I'm not quite sure of the positive or negative affects for this feature.  It seems like plugins that cannot be chained can can be registered alongside commands that can be chained, which may be confusing for end users.
3. Where else should this feature be documented?

My initial though is that the above two points, especially the second, are really documentation issues and are minor when compared to the added functionality.

/ cc @sgillies
