### PR TITLE
Improve help text formatting.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ Version 5.0
 
 - Removed various deprecated functionality.
 - Atomic files now only accept the `w` mode.
+- Change the usage part of help output for very long commands to wrap
+  their arguments onto the next line, indented by 4 spaces.
 
 Version 4.1
 -----------

--- a/click/formatting.py
+++ b/click/formatting.py
@@ -123,20 +123,20 @@ class HelpFormatter(object):
         :param args: whitespace separated list of arguments.
         :param prefix: the prefix for the first line.
         """
-        prefix = '%*s%s ' % (self.current_indent, prefix, prog)
+        usage_prefix = '%*s%s ' % (self.current_indent, prefix, prog)
         text_width = self.width - self.current_indent
 
-        if text_width >= (term_len(prefix) + 20):
+        if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
-            indent = ' ' * term_len(prefix)
+            indent = ' ' * term_len(usage_prefix)
             self.write(wrap_text(args, text_width,
-                                 initial_indent=prefix,
+                                 initial_indent=usage_prefix,
                                  subsequent_indent=indent))
         else:
             # The prefix is too long, put the arguments on the next line.
-            self.write(prefix)
+            self.write(usage_prefix)
             self.write('\n')
-            indent = ' ' * (self.current_indent + 12)
+            indent = ' ' * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(wrap_text(args, text_width,
                                  initial_indent=indent,
                                  subsequent_indent=indent))

--- a/click/formatting.py
+++ b/click/formatting.py
@@ -18,12 +18,6 @@ def iter_rows(rows, col_count):
         yield row + ('',) * (col_count - len(row))
 
 
-def add_subsequent_indent(text, subsequent_indent):
-    lines = text.splitlines()
-    lines = lines[:1] + [subsequent_indent + line for line in lines[1:]]
-    return '\n'.join(lines)
-
-
 def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
               preserve_paragraphs=False):
     """A helper function that intelligently wraps text.  By default, it
@@ -46,13 +40,11 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
     """
     from ._textwrap import TextWrapper
     text = text.expandtabs()
-    post_wrap_indent = subsequent_indent[:-1]
-    subsequent_indent = subsequent_indent[-1:]
     wrapper = TextWrapper(width, initial_indent=initial_indent,
                           subsequent_indent=subsequent_indent,
                           replace_whitespace=False)
     if not preserve_paragraphs:
-        return add_subsequent_indent(wrapper.fill(text), post_wrap_indent)
+        return wrapper.fill(text)
 
     p = []
     buf = []
@@ -83,11 +75,9 @@ def wrap_text(text, width=78, initial_indent='', subsequent_indent='',
     for indent, raw, text in p:
         with wrapper.extra_indent(' ' * indent):
             if raw:
-                rv.append(add_subsequent_indent(wrapper.indent_only(text),
-                                                post_wrap_indent))
+                rv.append(wrapper.indent_only(text))
             else:
-                rv.append(add_subsequent_indent(wrapper.fill(text),
-                                                post_wrap_indent))
+                rv.append(wrapper.fill(text))
 
     return '\n\n'.join(rv)
 
@@ -133,14 +123,23 @@ class HelpFormatter(object):
         :param args: whitespace separated list of arguments.
         :param prefix: the prefix for the first line.
         """
-        prefix = '%*s%s' % (self.current_indent, prefix, prog)
-        self.write(prefix)
+        prefix = '%*s%s ' % (self.current_indent, prefix, prog)
+        text_width = self.width - self.current_indent
 
-        text_width = max(self.width - self.current_indent - term_len(prefix), 10)
-        indent = ' ' * (term_len(prefix) + 1)
-        self.write(wrap_text(args, text_width,
-                             initial_indent=' ',
-                             subsequent_indent=indent))
+        if text_width >= (term_len(prefix) + 20):
+            # The arguments will fit to the right of the prefix.
+            indent = ' ' * term_len(prefix)
+            self.write(wrap_text(args, text_width,
+                                 initial_indent=prefix,
+                                 subsequent_indent=indent))
+        else:
+            # The prefix is too long, put the arguments on the next line.
+            self.write(prefix)
+            self.write('\n')
+            indent = ' ' * (self.current_indent + 12)
+            self.write(wrap_text(args, text_width,
+                                 initial_indent=indent,
+                                 subsequent_indent=indent))
 
         self.write('\n')
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -116,14 +116,15 @@ def test_wrapping_long_command_name(runner):
     assert not result.exception
     assert result.output.splitlines() == [
         'Usage: cli a_very_very_very_long command ',
-        '            [OPTIONS] FIRST SECOND THIRD FOURTH FIFTH',
-        '            SIXTH',
+        '           [OPTIONS] FIRST SECOND THIRD FOURTH FIFTH',
+        '           SIXTH',
         '',
         '  A command.',
         '',
         'Options:',
         '  --help  Show this message and exit.',
     ]
+
 
 def test_formatting_empty_help_lines(runner):
     @click.command()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -72,7 +72,7 @@ def test_wrapping_long_options_strings(runner):
         """A command.
         """
 
-    # 54 is chosen as a lenthg where the second line is one character
+    # 54 is chosen as a length where the second line is one character
     # longer than the maximum length.
     result = runner.invoke(cli, ['a_very_long', 'command', '--help'],
                            terminal_width=54)
@@ -88,6 +88,42 @@ def test_wrapping_long_options_strings(runner):
         '  --help  Show this message and exit.',
     ]
 
+
+def test_wrapping_long_command_name(runner):
+    @click.group()
+    def cli():
+        """Top level command
+        """
+
+    @cli.group()
+    def a_very_very_very_long():
+        """Second level
+        """
+
+    @a_very_very_very_long.command()
+    @click.argument('first')
+    @click.argument('second')
+    @click.argument('third')
+    @click.argument('fourth')
+    @click.argument('fifth')
+    @click.argument('sixth')
+    def command():
+        """A command.
+        """
+
+    result = runner.invoke(cli, ['a_very_very_very_long', 'command', '--help'],
+                           terminal_width=54)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: cli a_very_very_very_long command ',
+        '            [OPTIONS] FIRST SECOND THIRD FOURTH FIFTH',
+        '            SIXTH',
+        '',
+        '  A command.',
+        '',
+        'Options:',
+        '  --help  Show this message and exit.',
+    ]
 
 def test_formatting_empty_help_lines(runner):
     @click.command()


### PR DESCRIPTION
I promised an updated pull request, so here it is.

In fact it turns out that the bug I was seeing had actually been fixed on master, I was just using an out-of-date version of click.

However, I do have a couple of improvements that you might be interested in:
- Clean up the code.  There's actually no need for a separate function to add subsequent indents, we can do what we want with the normal wrap function as long as we put the command in the initial_indent, rather than printing it out first and starting the textwrapper when the output cursor is not in column zero.
- When the command is too long for the arguments to fit on the right of the command help text, wrap them to the next line at a reduced indent.

For comparison, given a long command and a narrow terminal:

With current master:

```
Usage: format.py long_subgroup_name long_command_name [OPTIO
NS]
                                                      ARGUME
NT1
                                                      ARGUME
NT2

  This is a long command.
```

With this change:

```
Usage: format.py long_subgroup_name long_command_name
            [OPTIONS] ARGUMENT1 ARGUMENT2

  This is a long command.
```

Of course, if it gets so narrow that the command name itself doesn't fit, things still start to look wrong.
