### PR TITLE
Fix issue #362.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ Version 5.0
 - Atomic files now only accept the `w` mode.
 - Change the usage part of help output for very long commands to wrap
   their arguments onto the next line, indented by 4 spaces.
+- Fix a bug where return code and error messages were incorrect when
+  using ``CliRunner``.
 
 Version 4.1
 -----------

--- a/click/testing.py
+++ b/click/testing.py
@@ -270,6 +270,7 @@ class CliRunner(object):
         with self.isolation(input=input, env=env, color=color) as out:
             exception = None
             exit_code = 0
+            error_message = ''
 
             try:
                 cli.main(args=args or (),
@@ -278,6 +279,9 @@ class CliRunner(object):
                 if e.code != 0:
                     exception = e
                 exit_code = e.code
+                if not isinstance(exit_code, int):
+                    error_message = '%s\n' % exit_code
+                    exit_code = 1
                 exc_info = sys.exc_info()
             except Exception as e:
                 if not catch_exceptions:
@@ -287,7 +291,9 @@ class CliRunner(object):
                 exc_info = sys.exc_info()
             finally:
                 sys.stdout.flush()
-                output = out.getvalue()
+                if not PY2:
+                    error_message = error_message.encode(self.charset)
+                output = out.getvalue() + error_message
 
         return Result(runner=self,
                       output_bytes=output,

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import click
 
@@ -140,3 +142,44 @@ def test_with_color_but_pause_not_blocking():
     result = runner.invoke(cli, color=True)
     assert not result.exception
     assert result.output == ''
+
+
+def test_exit_code_and_output_from_sys_exit():
+    # See issue #362
+    @click.command()
+    def cli_string():
+        click.echo('hello world')
+        sys.exit('error')
+
+    @click.command()
+    def cli_int():
+        click.echo('hello world')
+        sys.exit(1)
+
+    @click.command()
+    def cli_float():
+        click.echo('hello world')
+        sys.exit(1.0)
+
+    @click.command()
+    def cli_no_error():
+        click.echo('hello world')
+
+    runner = CliRunner()
+
+    result = runner.invoke(cli_string)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\nerror\n'
+
+    result = runner.invoke(cli_int)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n'
+
+    result = runner.invoke(cli_float)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n1.0\n'
+
+    result = runner.invoke(cli_no_error)
+    assert result.exit_code == 0
+    assert result.output == 'hello world\n'
+


### PR DESCRIPTION
Fixes issue #362 (invalid `Result.return_code` and `Result.output` when using `CliRunner` and `sys.exit`).
