### PR TITLE
Click testing crashes in case of non existing name attribute.

### DIFF
--- a/click/testing.py
+++ b/click/testing.py
@@ -125,7 +125,10 @@ class CliRunner(object):
         for it.  The default is the `name` attribute or ``"root"`` if not
         set.
         """
-        return cli.name or 'root'
+        try:
+            return cli.name
+        except AttributeError:
+            return 'root'
 
     def make_env(self, overrides=None):
         """Returns the environment overrides for invoking a script."""


### PR DESCRIPTION
Should fix error when calling and no name attribute.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/click/testing.py", line 276, in invoke
    prog_name=self.get_default_prog_name(cli), **extra)
  File "/usr/lib/python2.7/site-packages/click/testing.py", line 128, in get_default_prog_name
    return cli.name or 'root'
AttributeError: 'module' object has no attribute 'name'
```
