### PR TITLE
Add note about subcommands testing. Closes #377

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -38,6 +38,29 @@ Example::
         assert result.exit_code == 0
         assert result.output == 'Hello Peter!\n'
 
+For subcommand testing, a subcommand name must be specified in the `args` parameter of :meth:`CliRunner.invoke` method.
+
+Example::
+
+    import click
+    from click.testing import CliRunner
+    
+    def test_sync():
+        @click.group()
+        @click.option('--debug/--no-debug', default=False)
+        def cli(debug):
+            click.echo('Debug mode is %s' % ('on' if debug else 'off')) 
+    
+        @cli.command()
+        def sync():
+            click.echo('Syncing')
+    
+        runner = CliRunner()
+        result = runner.invoke(cli, ['--debug', 'sync'])
+        assert result.exit_code == 0
+        assert 'Debug mode is on' in result.output
+        assert 'Syncing' in result.output
+
 File System Isolation
 ---------------------
 


### PR DESCRIPTION
Testing `Click` Applications documentation isn't clear enough for cases involving subcommands. I have added a note about subcommand testing, as well as a code example.
