### PR TITLE
use source command to activate virtualenv

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -91,7 +91,7 @@ To test the script, you can make a new virtualenv and then install your
 package::
 
     $ virtualenv venv
-    $ . venv/bin/activate
+    $ source venv/bin/activate
     $ pip install --editable .
 
 Afterwards, your command should be available:


### PR DESCRIPTION
using source command instead of `.` makes things more clear and easier to understand
