### PR TITLE
progressbar label should not be shown when the output is not a tty

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -181,8 +181,6 @@ class ProgressBar(object):
         from .termui import get_terminal_size
 
         if self.is_hidden:
-            echo(self.label, file=self.file, color=self.color)
-            self.file.flush()
             return
 
         # Update width in case the terminal has been resized

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -12,3 +12,17 @@ def test_progressbar_strip_regression(runner, monkeypatch):
 
     monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
     assert label in runner.invoke(cli, []).output
+
+
+def test_progressbar_should_not_show_in_non_tty(runner, monkeypatch):
+    label = 'progress label'
+
+    @click.command()
+    def cli():
+        with click.progressbar(range(3), label=label) as progress:
+            for thing in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: False)
+    output = runner.invoke(cli, []).output
+    assert '' == output


### PR DESCRIPTION
If you pass a label to a progressbar, the label is incorrectly included when you redirect the command output to a file. 

The docstring states: "By default, this progress bar will not be rendered if the file is not a terminal."
However, the label is always displayed even when the output is not a tty.

The `render_finish` function does this correctly:
https://github.com/mitsuhiko/click/blob/36f83d91e27b5b88ee806cb40f284658e2f9cdb5/click/_termui_impl.py#L106

In contrast `render_progress` always prints a label even if `self.is_hidden`, and should just return instead without any echo:
https://github.com/mitsuhiko/click/blob/36f83d91e27b5b88ee806cb40f284658e2f9cdb5/click/_termui_impl.py#L183

This simple command shows the issue:

```
import click

@click.command()
def mycli():
    with click.progressbar(range(2), label='xyz') as pb:
        for _ in pb:
           pass

if __name__ == '__main__':
    mycli()
```

This is correct:

```
$ python click_checker.py
xyz  [------------------------------------]    0%
```

This is not:

```
$ python click_checker.py > tst
$ cat tst
xyz
```

I would expect the redirected stdout to be empty in this case.

This commit fixes this.
