### PR TITLE
Fix bug which happens while using @click.pass_obj

### DIFF
--- a/click/decorators.py
+++ b/click/decorators.py
@@ -22,7 +22,6 @@ def pass_obj(f):
     context onwards (:attr:`Context.obj`).  This is useful if that object
     represents the state of a nested system.
     """
-    @pass_context
     def new_func(*args, **kwargs):
         return f(get_current_context().obj, *args, **kwargs)
     return update_wrapper(new_func, f)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -168,3 +168,19 @@ def test_context_pushing():
         assert ctx._depth == 1
 
     assert rv == [42]
+
+
+def test_pass_obj(runner):
+    @click.group()
+    @click.pass_context
+    def cli(ctx):
+        ctx.obj = 'test'
+
+    @cli.command()
+    @click.pass_obj
+    def test(obj):
+        click.echo(obj)
+
+    result = runner.invoke(cli, ['test'])
+    assert not result.exception
+    assert result.output == 'test\n'


### PR DESCRIPTION
When a function is decorated with `@click.pass_obj`, it should receive the ctx.obj content as first argument. Instead, it actually receives the ctx.obj content _and_ ctx itself. This is an undocumented behavior, and it was introduced in click 5.0 with commit 695ca34.

That's breaking all the applications which uses `@click.pass_obj`, including [pipsi](https://github.com/mitsuhiko/pipsi), because decorated functions are receiving an extra parameter. This pull request fixes the decorator in order to restore the documented, pre-5.0 behavior, so the decorated function will receive only ctx.obj.
