### PR TITLE
Option value separators

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -175,7 +175,8 @@ class Context(object):
                  resilient_parsing=False, allow_extra_args=None,
                  allow_interspersed_args=None,
                  ignore_unknown_options=None, help_option_names=None,
-                 token_normalize_func=None, color=None):
+                 token_normalize_func=None, color=None,
+                 option_value_separators=None):
         #: the parent context or `None` if none exists.
         self.parent = parent
         #: the :class:`Command` for this context.
@@ -250,6 +251,8 @@ class Context(object):
         #:
         #: .. versionadded:: 4.0
         self.ignore_unknown_options = ignore_unknown_options
+
+        self.option_value_separators = option_value_separators
 
         if help_option_names is None:
             if parent is not None:
@@ -553,6 +556,7 @@ class BaseCommand(object):
     allow_interspersed_args = True
     #: the default for the :attr:`Context.ignore_unknown_options` flag.
     ignore_unknown_options = False
+    option_value_separators = set('=')
 
     def __init__(self, name, context_settings=None):
         #: the name the command thinks it has.  Upon registering a command

--- a/click/core.py
+++ b/click/core.py
@@ -167,6 +167,10 @@ class Context(object):
                   codes are used in texts that Click prints which is by
                   default not the case.  This for instance would affect
                   help output.
+    :param option_value_separators: list of characters that may be used
+                                    separate to separate options and values
+                                    like in ``--option=value``. The default is
+                                    ``('=')``.
     """
 
     def __init__(self, command, parent=None, info_name=None, obj=None,
@@ -252,6 +256,10 @@ class Context(object):
         #: .. versionadded:: 4.0
         self.ignore_unknown_options = ignore_unknown_options
 
+        if option_value_separators is None:
+            option_value_separators = command.option_value_separators
+        #: List of option value separators. This is used to allow
+        #: parsing options like ``--option=value``.
         self.option_value_separators = option_value_separators
 
         if help_option_names is None:
@@ -556,6 +564,7 @@ class BaseCommand(object):
     allow_interspersed_args = True
     #: the default for the :attr:`Context.ignore_unknown_options` flag.
     ignore_unknown_options = False
+    #: the default for the :attr:`Context.option_value_separators` flag.
     option_value_separators = set('=')
 
     def __init__(self, name, context_settings=None):

--- a/click/parser.py
+++ b/click/parser.py
@@ -157,6 +157,8 @@ class OptionParser(object):
         #: second mode where it will ignore it and continue processing
         #: after shifting all the unknown options into the resulting args.
         self.ignore_unknown_options = False
+        #: This allows to separate long option names an values by something
+        #: different than the default '=' character, as in ``--option=value``.
         self.option_value_separators = set('=')
         if ctx is not None:
             self.allow_interspersed_args = ctx.allow_interspersed_args

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -146,6 +146,28 @@ And how it works on the command line:
 
     invoke(cli, prog_name='cli', args=['--NAME=Pete'])
 
+Option value separator
+----------------------
+
+Options must separate its name from the value using a space or a ``=``
+character like in ``--option=value``.  In order to use a different value
+separator, you can override the separator list. This might be used to define
+Windows compatible option value separators like ``--option:value``.
+
+    CONTEXT_SETTINGS = dict(option_value_separators=set(['=', ':']))
+
+    @click.command(context_settings=CONTEXT_SETTINGS)
+    @click.option('--name')
+    def cli(name):
+        click.echo('Name: %s' % name)
+
+That could be called using either ``=`` or ``:`` as separator:
+
+.. click:run::
+
+    invoke(cli, prog_name='cli', args=['--name:Pete'])
+
+
 Invoking Other Commands
 -----------------------
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -304,3 +304,15 @@ def test_option_custom_class(runner):
     result = runner.invoke(cmd, ['--help'])
     assert 'I am a help text' in result.output
     assert 'you wont see me' not in result.output
+
+
+def test_option_custom_separator(runner):
+    @click.command(context_settings=dict(option_value_separators=set(':')))
+    @click.option('--foo')
+    def cmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(cmd, ['--foo:value'])
+    print(result.output)
+    assert result.exit_code == 0
+    assert result.output.strip() == 'value'


### PR DESCRIPTION
Adds _option_value_separators_ context setting to override default option value parsing

Currently `OptionParser` splits long option values using the '=' character.  eg: 

`command   --option=value`

This option extends the parser to admit value splitting via user defined text separator. eg: 

`command --option:value`

This is done by adding a new configuration variable named _option_value_separators_ at `Command` and `Context` level. This var holds a list of text separator that might be used to split long options into its name and associated parameter value.

``` python
CONTEXT_SETTINGS = dict(option_value_separators=set(['=', ':']))

@click.command(context_settings=CONTEXT_SETTINGS)
@click.option('--name')
def cli(name):
click.echo('Name: %s' % name)
```

The main purpouse of this change is to allow Windows Click users to compliment Microsoft [Command Line Standard](https://technet.microsoft.com/en-us/library/ee156811.aspx), which allows options to separate its value using a colon `:` instead of *nix convention which uses `=`.

> Consistent Syntax
> 
> Required:
> 
> ```
> Commands must use the “-“ character for parameter delimitation; a
> colon (:) or whitespace to separate the parameter name and its
> arguments and a comma (,) to separate multiple values within an
> argument.
> ```

To add a bit more of context to reason why someone would ever need this, I'm currently wrapping and extending an existing awfully big Windows C++ legacy application using Click. To my dismay, the operations group demanded the colon `--option:value` option syntax to be accepted, both because Windows CLI applications should accept it, and because the old application did it so. All options, overriden, redirected or new should admit this format.

If this does not get managed at Click parsing level, the only thing I could do would be to pre-parse `sys.argv` and replace the offending separators before passing it to Click.

Thanks for all the good work. :)
