### PR TITLE
Included click.DateTime type (with tests)

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -28,7 +28,7 @@ from .decorators import pass_context, pass_obj, make_pass_decorator, \
 
 # Types
 from .types import ParamType, File, Path, Choice, IntRange, Tuple, \
-     STRING, INT, FLOAT, BOOL, UUID, UNPROCESSED
+     DateTime, STRING, INT, FLOAT, BOOL, UUID, UNPROCESSED
 
 # Utilities
 from .utils import echo, get_binary_stream, get_text_stream, open_file, \

--- a/click/types.py
+++ b/click/types.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import stat
+from datetime import datetime
 
 from ._compat import open_stream, text_type, filename_to_ui, \
     get_filesystem_encoding, get_streerror
@@ -160,6 +161,39 @@ class Choice(ParamType):
 
     def __repr__(self):
         return 'Choice(%r)' % list(self.choices)
+
+
+class DateTime(ParamType):
+    name = 'datetime'
+
+    def __init__(self, formats=None):
+        self.formats = formats or [
+            '%Y-%m-%d',
+            '%Y-%m-%dT%H:%M:%S'
+        ]
+
+    def get_metavar(self, param):
+        return '[{}]'.format('|'.join(self.formats))
+
+    def _try_to_convert_date(self, value, format):
+        try:
+            return datetime.strptime(value, format)
+        except ValueError:
+            return None
+
+    def convert(self, value, param, ctx):
+        # Exact match
+        for format in self.formats:
+            dtime = self._try_to_convert_date(value, format)
+            if dtime:
+                return dtime
+
+        self.fail(
+            'invalid datetime format: {}. (choose from {})'.format(
+                value, ', '.join(self.formats)))
+
+    def __repr__(self):
+        return 'DateTime'
 
 
 class IntParamType(ParamType):

--- a/click/types.py
+++ b/click/types.py
@@ -173,7 +173,7 @@ class DateTime(ParamType):
         ]
 
     def get_metavar(self, param):
-        return '[{}]'.format('|'.join(self.formats))
+        return '[%s]' % '|'.join(self.formats)
 
     def _try_to_convert_date(self, value, format):
         try:
@@ -189,7 +189,7 @@ class DateTime(ParamType):
                 return dtime
 
         self.fail(
-            'invalid datetime format: {}. (choose from {})'.format(
+            'invalid datetime format: %s. (choose from %s)' % (
                 value, ', '.join(self.formats)))
 
     def __repr__(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -310,6 +310,42 @@ def test_choice_option(runner):
     assert '--method [foo|bar|baz]' in result.output
 
 
+def test_datetime_option_default(runner):
+
+    @click.command()
+    @click.option('--start_date', type=click.DateTime())
+    def cli(start_date):
+        click.echo(start_date.strftime('%Y-%m-%dT%H:%M:%S'))
+
+    result = runner.invoke(cli, ['--start_date=2015-09-29'])
+    assert not result.exception
+    assert result.output == '2015-09-29T00:00:00\n'
+
+    result = runner.invoke(cli, ['--start_date=2015-09-29T09:11:22'])
+    assert not result.exception
+    assert result.output == '2015-09-29T09:11:22\n'
+
+    result = runner.invoke(cli, ['--start_date=2015-09'])
+    assert result.exit_code == 2
+    assert 'Invalid value for "--start_date": invalid datetime format: 2015-09. ' \
+        '(choose from %Y-%m-%d, %Y-%m-%dT%H:%M:%S)' in result.output
+
+    result = runner.invoke(cli, ['--help'])
+    assert '--start_date [%Y-%m-%d|%Y-%m-%dT%H:%M:%S]' in result.output
+
+
+def test_datetime_option_custom(runner):
+    @click.command()
+    @click.option('--start_date',
+                  type=click.DateTime(formats=['%A %B %d, %Y']))
+    def cli(start_date):
+        click.echo(start_date.strftime('%Y-%m-%dT%H:%M:%S'))
+
+    result = runner.invoke(cli, ['--start_date=Wednesday June 05, 2010'])
+    assert not result.exception
+    assert result.output == '2010-06-05T00:00:00\n'
+
+
 def test_int_range_option(runner):
     @click.command()
     @click.option('--x', type=click.IntRange(0, 5))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -30,7 +30,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading'
+    'threading', 'datetime'
 ])
 
 


### PR DESCRIPTION
Anyone interested in something like this?

``` python
@click.command()
@click.option('--start_date', type=click.DateTime())
def cli(start_date):
    pass
```

You can always specify the formats you expect.

``` python
@click.command()
@click.option('--start_date', type=click.DateTime(formats=['%A %B %d, %Y']))
def cli(start_date):
    pass
```
