### PR TITLE
Added support for dealing with unicode argv on win py2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,13 @@ Version 6.0
 - Click used to return byte strings on Python 2 in some unit-testing
   situations.  This has been fixed to correctly return unicode strings
   now.
+- For Windows users on Python 2, Click will now handle Unicode more
+  correctly handle Unicode coming in from the system.  This also has
+  the disappointing side effect that filenames will now be always
+  unicode by default in the `Path` type which means that this can
+  introduce small bugs for code not aware of this.
+- Added a `type` parameter to `Path` to force a specific string type
+  on the value.
 
 Version 5.1
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,10 @@ Version 6.0
   introduce small bugs for code not aware of this.
 - Added a `type` parameter to `Path` to force a specific string type
   on the value.
+- For users running Python 2 the echo() and prompt() functions now work
+  with unicode in the Python windows console.  For Python 3 the work
+  is delegated to the Python interpreter as general support for Unicode
+  in the console is implemented to some degree.
 
 Version 5.1
 -----------

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -167,8 +167,18 @@ if PY2:
             else:
                 msvcrt.setmode(fileno, os.O_BINARY)
             return f
+
+        class WindowsConsole(_FixupStream):
+            def __repr__(self):
+                return '<%s name=%r>' % (
+                    self.__class__.__name__,
+                    self.name,
+                )
+
+        from ._winconsole import _get_windows_console_stream
     else:
         set_binary_mode = lambda x: x
+        _get_windows_console_stream = lambda x: None
 
     def isidentifier(x):
         return _identifier_re.search(x) is not None
@@ -183,12 +193,21 @@ if PY2:
         return set_binary_mode(sys.stderr)
 
     def get_text_stdin(encoding=None, errors=None):
+        rv = _get_windows_console_stream(sys.stdin, encoding, errors)
+        if rv is not None:
+            return rv
         return _make_text_stream(sys.stdin, encoding, errors)
 
     def get_text_stdout(encoding=None, errors=None):
+        rv = _get_windows_console_stream(sys.stdout, encoding, errors)
+        if rv is not None:
+            return rv
         return _make_text_stream(sys.stdout, encoding, errors)
 
     def get_text_stderr(encoding=None, errors=None):
+        rv = _get_windows_console_stream(sys.stderr, encoding, errors)
+        if rv is not None:
+            return rv
         return _make_text_stream(sys.stderr, encoding, errors)
 
     def filename_to_ui(value):
@@ -496,6 +515,19 @@ if WIN:
     # Windows has a smaller terminal
     DEFAULT_COLUMNS = 79
 
+    def _get_argv_encoding():
+        import locale
+        return locale.getpreferredencoding()
+
+    if PY2:
+        def raw_input(prompt=''):
+            sys.stderr.flush()
+            if prompt:
+                stdout = _default_text_stdout()
+                stdout.write(prompt)
+            stdin = _default_text_stdin()
+            return stdin.readline().rstrip('\r\n')
+
     try:
         import colorama
     except ImportError:
@@ -538,6 +570,9 @@ if WIN:
             win = colorama.win32.GetConsoleScreenBufferInfo(
                 colorama.win32.STDOUT).srWindow
             return win.Right - win.Left, win.Bottom - win.Top
+else:
+    def _get_argv_encoding():
+        return getattr(sys.stdin, 'encoding', None) or get_filesystem_encoding()
 
 
 def term_len(x):
@@ -549,41 +584,6 @@ def isatty(stream):
         return stream.isatty()
     except Exception:
         return False
-
-
-def get_os_args():
-    # On Python 3 or non windows environments, we just return the args
-    # as they are.
-    if not PY2 or os.name != 'nt':
-        return sys.argv[1:]
-
-    from ctypes import WINFUNCTYPE, windll, POINTER, byref, c_int
-    from ctypes.wintypes import LPWSTR, LPCWSTR
-
-    GetCommandLineW = WINFUNCTYPE(LPWSTR)(
-        ('GetCommandLineW', windll.kernel32))
-    CommandLineToArgvW = WINFUNCTYPE(
-        POINTER(LPWSTR), LPCWSTR, POINTER(c_int))(
-            ('CommandLineToArgvW', windll.shell32))
-
-    argc = c_int(0)
-    argv_unicode = CommandLineToArgvW(GetCommandLineW(), byref(argc))
-    argv = [argv_unicode[i] for i in range(0, argc.value)]
-
-    if not hasattr(sys, 'frozen'):
-        argv = argv[1:]
-        while len(argv) > 0:
-            arg = argv[0]
-            if not arg.startswith('-') or arg == '-':
-                break
-            argv = argv[1:]
-            if arg == '-m':
-                break
-            if arg == '-c':
-                argv[0] = '-c'
-                break
-
-    return argv
 
 
 def _get_argv_encoding():
@@ -612,6 +612,8 @@ def _make_cached_stream_func(src_func, wrapper_func):
     return func
 
 
+_default_text_stdin = _make_cached_stream_func(
+    lambda: sys.stdin, get_text_stdin)
 _default_text_stdout = _make_cached_stream_func(
     lambda: sys.stdout, get_text_stdout)
 _default_text_stderr = _make_cached_stream_func(

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -580,7 +580,7 @@ def get_os_args():
             if arg == '-m':
                 break
             if arg == '-c':
-                argv[0] = '-c'
+                argv[0] = u'-c'
                 break
 
     return argv

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -178,7 +178,7 @@ if PY2:
         from ._winconsole import _get_windows_console_stream
     else:
         set_binary_mode = lambda x: x
-        _get_windows_console_stream = lambda x: None
+        _get_windows_console_stream = lambda *x: None
 
     def isidentifier(x):
         return _identifier_re.search(x) is not None

--- a/click/_winconsole.py
+++ b/click/_winconsole.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+# This module is based on the excellent work by Adam Bartoš who
+# provided a lot of what went into the implementation here in
+# the discussion to issue1602 in the Python bug tracker.
+#
+# There are some general differences in regards to how this works
+# compared to the original patches as we do not need to patch
+# the entire interpreter but just work in our little world of
+# echo and prmopt.
+
+import io
+import sys
+import ctypes
+from click._compat import _NonClosingTextIOWrapper, text_type
+from ctypes import byref, POINTER, pythonapi, c_int, c_char, c_char_p, \
+     c_void_p, py_object, c_ssize_t, c_ulong, windll, WINFUNCTYPE
+from ctypes.wintypes import LPWSTR, LPCWSTR
+
+
+PY2 = sys.version_info[0] == 2
+
+c_ssize_p = POINTER(c_ssize_t)
+
+PyObject_GetBuffer = pythonapi.PyObject_GetBuffer
+PyBuffer_Release = pythonapi.PyBuffer_Release
+
+kernel32 = windll.kernel32
+GetStdHandle = kernel32.GetStdHandle
+ReadConsoleW = kernel32.ReadConsoleW
+WriteConsoleW = kernel32.WriteConsoleW
+GetLastError = kernel32.GetLastError
+GetCommandLineW = WINFUNCTYPE(LPWSTR)(
+    ('GetCommandLineW', windll.kernel32))
+CommandLineToArgvW = WINFUNCTYPE(
+    POINTER(LPWSTR), LPCWSTR, POINTER(c_int))(
+        ('CommandLineToArgvW', windll.shell32))
+
+
+STDIN_HANDLE = GetStdHandle(-10)
+STDOUT_HANDLE = GetStdHandle(-11)
+STDERR_HANDLE = GetStdHandle(-12)
+
+
+PyBUF_SIMPLE = 0
+PyBUF_WRITABLE = 1
+
+ERROR_SUCCESS = 0
+ERROR_NOT_ENOUGH_MEMORY = 8
+ERROR_OPERATION_ABORTED = 995
+
+STDIN_FILENO = 0
+STDOUT_FILENO = 1
+STDERR_FILENO = 2
+
+EOF = b'\x1a'
+MAX_BYTES_WRITTEN = 32767
+
+
+class Py_buffer(ctypes.Structure):
+    _fields_ = [
+        ('buf', c_void_p),
+        ('obj', py_object),
+        ('len', c_ssize_t),
+        ('itemsize', c_ssize_t),
+        ('readonly', c_int),
+        ('ndim', c_int),
+        ('format', c_char_p),
+        ('shape', c_ssize_p),
+        ('strides', c_ssize_p),
+        ('suboffsets', c_ssize_p),
+        ('internal', c_void_p)
+    ]
+
+    if PY2:
+        _fields_.insert(-1, ('smalltable', c_ssize_t * 2))
+
+
+def get_buffer(obj, writable=False):
+    buf = Py_buffer()
+    flags = PyBUF_WRITABLE if writable else PyBUF_SIMPLE
+    PyObject_GetBuffer(py_object(obj), byref(buf), flags)
+    try:
+        buffer_type = c_char * buf.len
+        return buffer_type.from_address(buf.buf)
+    finally:
+        PyBuffer_Release(byref(buf))
+
+
+class _WindowsConsoleRawIOBase(io.RawIOBase):
+
+    def __init__(self, handle):
+        self.handle = handle
+
+    def isatty(self):
+        super(WindowsConsoleRawIOBase, self).isatty()
+        return True
+
+
+class _WindowsConsoleReader(_WindowsConsoleRawIOBase):
+
+    def readable(self):
+        return True
+
+    def readinto(self, b):
+        bytes_to_be_read = len(b)
+        if not bytes_to_be_read:
+            return 0
+        elif bytes_to_be_read % 2:
+            raise ValueError('cannot read odd number of bytes from '
+                             'UTF-16-LE encoded console')
+
+        buffer = get_buffer(b, writable=True)
+        code_units_to_be_read = bytes_to_be_read // 2
+        code_units_read = c_ulong()
+
+        rv = ReadConsoleW(self.handle, buffer, code_units_to_be_read,
+                          byref(code_units_read), None)
+        if GetLastError() == ERROR_OPERATION_ABORTED:
+            # wait for KeyboardInterrupt
+            time.sleep(0.1)
+        if not rv:
+            raise OSError('Windows error: %s' % GetLastError())
+
+        if buffer[0] == EOF:
+            return 0
+        return 2 * code_units_read.value
+
+
+class _WindowsConsoleWriter(_WindowsConsoleRawIOBase):
+
+    def writable(self):
+        return True
+
+    @staticmethod
+    def _get_error_message(errno):
+        if errno == ERROR_SUCCESS:
+            return 'ERROR_SUCCESS'
+        elif errno == ERROR_NOT_ENOUGH_MEMORY:
+            return 'ERROR_NOT_ENOUGH_MEMORY'
+        return 'Windows error %s' % errno
+
+    def write(self, b):
+        bytes_to_be_written = len(b)
+        buf = get_buffer(b)
+        code_units_to_be_written = min(bytes_to_be_written,
+                                       MAX_BYTES_WRITTEN) // 2
+        code_units_written = c_ulong()
+
+        WriteConsoleW(self.handle, buf, code_units_to_be_written,
+                      byref(code_units_written), None)
+        bytes_written = 2 * code_units_written.value
+
+        if bytes_written == 0 and bytes_to_be_written > 0:
+            raise OSError(self._get_error_message(GetLastError()))
+        return bytes_written
+
+
+class ConsoleStream(object):
+
+    def __init__(self, text_stream, byte_stream):
+        self._text_stream = text_stream
+        self.buffer = byte_stream
+
+    @property
+    def name(self):
+        return self.buffer.name
+
+    def write(self, x):
+        if isinstance(x, text_type):
+            return self._text_stream.write(x)
+        try:
+            self.flush()
+        except Exception:
+            pass
+        return self.buffer.write(x)
+
+    def writelines(self, lines):
+        for line in lines:
+            self.write(line)
+
+    def __getattr__(self, name):
+        return getattr(self._text_stream, name)
+
+    def isatty(self):
+        return self.buffer.isatty()
+
+    def __repr__(self):
+        return '<ConsoleStream name=%r encoding=%r>' % (
+            self.name,
+            self.encoding,
+        )
+
+
+def _get_text_stdin():
+    text_stream = _NonClosingTextIOWrapper(
+        io.BufferedReader(_WindowsConsoleReader(STDIN_HANDLE)),
+        'utf-16-le', 'strict', line_buffering=True)
+    return ConsoleStream(text_stream, sys.stdin)
+
+
+def _get_text_stdout():
+    text_stream = _NonClosingTextIOWrapper(
+        _WindowsConsoleWriter(STDOUT_HANDLE),
+        'utf-16-le', 'strict', line_buffering=True)
+    return ConsoleStream(text_stream, sys.stdout)
+
+
+def _get_text_stderr():
+    text_stream = _NonClosingTextIOWrapper(
+        _WindowsConsoleWriter(STDERR_HANDLE),
+        'utf-16-le', 'strict', line_buffering=True)
+    return ConsoleStream(text_stream, sys.stderr)
+
+
+def _get_windows_argv():
+    argc = c_int(0)
+    argv_unicode = CommandLineToArgvW(GetCommandLineW(), byref(argc))
+    argv = [argv_unicode[i] for i in range(0, argc.value)]
+
+    if not hasattr(sys, 'frozen'):
+        argv = argv[1:]
+        while len(argv) > 0:
+            arg = argv[0]
+            if not arg.startswith('-') or arg == '-':
+                break
+            argv = argv[1:]
+            if arg == '-m':
+                break
+            if arg == '-c':
+                argv[0] = '-c'
+                break
+
+    return argv
+
+
+_stream_factories = {
+    0: _get_text_stdin,
+    1: _get_text_stdout,
+    2: _get_text_stderr,
+}
+
+
+def _get_windows_console_stream(f, encoding, errors):
+    if encoding in ('utf-16-le', None) \
+       and errors in ('strict', None):
+        func = _stream_factories.get(f.fileno())
+        if func is not None:
+            return func()

--- a/click/core.py
+++ b/click/core.py
@@ -13,7 +13,7 @@ from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
 from .globals import push_context, pop_context
 
-from ._compat import PY2, isidentifier, iteritems, get_os_args
+from ._compat import PY2, isidentifier, iteritems
 from ._unicodefun import _check_for_unicode_literals, _verify_python3_env
 
 
@@ -1712,3 +1712,4 @@ class Argument(Parameter):
 
 # Circular dependency between decorators and core
 from .decorators import command, group
+from .utils import get_os_args

--- a/click/core.py
+++ b/click/core.py
@@ -13,7 +13,7 @@ from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
 from .globals import push_context, pop_context
 
-from ._compat import PY2, isidentifier, iteritems
+from ._compat import PY2, isidentifier, iteritems, get_os_args
 from ._unicodefun import _check_for_unicode_literals, _verify_python3_env
 
 
@@ -670,9 +670,10 @@ class BaseCommand(object):
             _check_for_unicode_literals()
 
         if args is None:
-            args = sys.argv[1:]
+            args = get_os_args()
         else:
             args = list(args)
+
         if prog_name is None:
             prog_name = make_str(os.path.basename(
                 sys.argv and sys.argv[0] or __file__))

--- a/click/types.py
+++ b/click/types.py
@@ -354,17 +354,24 @@ class Path(ParamType):
     :param resolve_path: if this is true, then the path is fully resolved
                          before the value is passed onwards.  This means
                          that it's absolute and symlinks are resolved.
+    :param type: optionally a string type that should be used to
+                 represent the path.  The default is `None` which
+                 means the return value will be either bytes or
+                 unicode depending on what makes most sense given the
+                 input data Click deals with.
     """
     envvar_list_splitter = os.path.pathsep
 
     def __init__(self, exists=False, file_okay=True, dir_okay=True,
-                 writable=False, readable=True, resolve_path=False):
+                 writable=False, readable=True, resolve_path=False,
+                 path_type=None):
         self.exists = exists
         self.file_okay = file_okay
         self.dir_okay = dir_okay
         self.writable = writable
         self.readable = readable
         self.resolve_path = resolve_path
+        self.type = path_type
 
         if self.file_okay and not self.dir_okay:
             self.name = 'file'
@@ -411,6 +418,12 @@ class Path(ParamType):
                 self.path_type,
                 filename_to_ui(value)
             ), param, ctx)
+
+        if self.type is not None and not isinstance(rv, self.type):
+            if self.type is text_type:
+                rv = rv.decode(get_filesystem_encoding())
+            else:
+                rv = rv.encode(get_filesystem_encoding())
 
         return rv
 

--- a/click/utils.py
+++ b/click/utils.py
@@ -11,6 +11,8 @@ from ._compat import text_type, open_stream, get_filesystem_encoding, \
 
 if not PY2:
     from ._compat import _find_binary_writer
+    if WIN:
+        from ._winconsole import _get_windows_argv
 
 
 echo_native_types = string_types + (bytes, bytearray)
@@ -379,6 +381,23 @@ def open_file(filename, mode='r', encoding=None, errors='strict',
     if not should_close:
         f = KeepOpenFile(f)
     return f
+
+
+def get_os_args():
+    """This returns the argument part of sys.argv in the most appropriate
+    form for processing.  What this means is that this return value is in
+    a format that works for Click to process but does not necessarily
+    correspond well to what's actually standard for the interpreter.
+
+    On most environments the return value is ``sys.argv[:1]`` unchanged.
+    However if you are on Windows and running Python 2 the return value
+    will actually be a list of unicode strings instead because the
+    default behavior on that platform otherwise will not be able to
+    carry all possible values that sys.argv can have.
+    """
+    if not PY2 or os.name != 'nt':
+        return sys.argv[1:]
+    return _get_windows_argv()
 
 
 def format_filename(filename, shorten=False):


### PR DESCRIPTION
This should help with getting data back correctly on Windows when
users are running Python2.  Unfortunately this also required
some changes to compensate for in the Path type.
