### PR TITLE
longer eta(>1day) support

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -129,7 +129,18 @@ class ProgressBar(object):
 
     def format_eta(self):
         if self.eta_known:
-            return time.strftime('%H:%M:%S', time.gmtime(self.eta + 1))
+            t = self.eta + 1
+            seconds = t % 60
+            t /= 60
+            minutes = t % 60
+            t /= 60
+            hours = t % 24
+            t /= 24
+            if t > 0:
+                days = t
+                return '%dd %02d:%02d:%02d' % (days, hours, minutes, seconds)
+            else:
+                return '%02d:%02d:%02d' % (hours, minutes, seconds)
         return ''
 
     def format_pos(self):


### PR DESCRIPTION
Sometimes our tasks take long time (longer than 24hrs), but in current version of click, progressbar doesn't seem to intend to be used for such time-consuming tasks.

Could you please consider to display how many days it will take if the estimated time > 1day ?
