### PR TITLE
Add tee capability to CliRunner.invoke().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build
 docs/_build
 click.egg-info
 .tox
+.swp
+.*.swp
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	@cd tests; PYTHONPATH=.. py.test --tb=short
+	@cd tests; PYTHONPATH=.. py.test -s --tb=short
 
 upload-docs:
 	$(MAKE) -C docs dirhtml

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,3 +1,4 @@
+# vi: ts=4 et
 import sys
 
 import pytest
@@ -15,6 +16,8 @@ else:
 
 
 def test_runner():
+
+    # Copy command. Used for testing.
     @click.command()
     def test():
         i = click.get_binary_stream('stdin')
@@ -26,19 +29,19 @@ def test_runner():
             o.write(chunk)
             o.flush()
 
-	# Invoke copy command
+    # Invoke copy command
     runner = CliRunner()
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\n'
 
-	# Invoke copy command with input echoing
+    # Invoke copy command with input echoing
     runner = CliRunner(echo_stdin=True)
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\nHello World!\n'
 
-	# Invoke copy command without blocking output to stderr and stdout (change nothing to result output string)
+    # Invoke copy command without blocking output to stderr and stdout (change nothing to result output string)
     runner = CliRunner()
     result = runner.invoke(test, input='Hello World!\n', tee=True)
     assert not result.exception

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -26,15 +26,23 @@ def test_runner():
             o.write(chunk)
             o.flush()
 
+	# Invoke copy command
     runner = CliRunner()
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\n'
 
+	# Invoke copy command with input echoing
     runner = CliRunner(echo_stdin=True)
     result = runner.invoke(test, input='Hello World!\n')
     assert not result.exception
     assert result.output == 'Hello World!\nHello World!\n'
+
+	# Invoke copy command without blocking output to stderr and stdout (change nothing to result output string)
+    runner = CliRunner()
+    result = runner.invoke(test, input='Hello World!\n', tee=True)
+    assert not result.exception
+    assert result.output == 'Hello World!\n'
 
 
 def test_runner_with_stream():


### PR DESCRIPTION
Hi,

I'm a French software developer, working at CEA (http://www.cea.fr/english-portal). For a project using Galaxy (https://galaxyproject.org/), I've been looking at the related project Planemo (http://planemo.readthedocs.org/en/latest/index.html), which uses your library "click". One issue I have is that Planemo tests run a script using your CliRunner class, but this script takes a long time and, since stdout is hidden, no feedback is given to the user until the script terminates and Planemo tests finally print the output.
So I've decided to modify your library in order to be able to print continuously stdout and stderr while running. I've added a parameter called tee inside the invoke method, and I set it to false by default. When set to true, a class called MultOutput will be instantiated instead of StringIO, that will take for parameters the StringIO instance and also stdout (or stderr). Each output will then be printed into StringIO as well as into stdout (or stderr).

Don't hesitate to contact me if you have any question.

Regards,
Pierrick
