### PR TITLE
Restore option_name parameter to BadOptionUsage

### DIFF
--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -164,10 +164,13 @@ class BadOptionUsage(UsageError):
     for an option is not correct.
 
     .. versionadded:: 4.0
+
+    :param option_name: the name of the option being used incorrectly.
     """
 
-    def __init__(self, message, ctx=None):
+    def __init__(self, option_name, message, ctx=None):
         UsageError.__init__(self, message, ctx)
+        self.option_name = option_name
 
 
 class BadArgumentUsage(UsageError):

--- a/click/parser.py
+++ b/click/parser.py
@@ -74,8 +74,8 @@ def _unpack_args(args, nargs_spec):
 
 def _error_opt_args(nargs, opt):
     if nargs == 1:
-        raise BadOptionUsage('%s option requires an argument' % opt)
-    raise BadOptionUsage('%s option requires %d arguments' % (opt, nargs))
+        raise BadOptionUsage(opt, '%s option requires an argument' % opt)
+    raise BadOptionUsage(opt, '%s option requires %d arguments' % (opt, nargs))
 
 
 def split_opt(opt):
@@ -342,7 +342,7 @@ class OptionParser(object):
                 del state.rargs[:nargs]
 
         elif explicit_value is not None:
-            raise BadOptionUsage('%s option does not take a value' % opt)
+            raise BadOptionUsage(opt, '%s option does not take a value' % opt)
 
         else:
             value = None


### PR DESCRIPTION
Revert changes made to `BadOptionUsage.__init__` in 5f98f570c08a11e607cccfd9c1b787c69a6a67b7. Additionally, store `option_name` on the exception instance to allow programmatic access to it (this matches the behavior of several other exceptions) and document the param in `BadOptionUsage`'s docstring. Fixes #474.
