### PR TITLE
allow_dash fails to allow dash due to readable check

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -433,7 +433,7 @@ class Path(ParamType):
                 self.path_type,
                 filename_to_ui(value)
             ), param, ctx)
-        if self.readable and not os.access(value, os.R_OK):
+        if self.readable and not is_dash and not os.access(value, os.R_OK):
             self.fail('%s "%s" is not readable.' % (
                 self.path_type,
                 filename_to_ui(value)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -290,6 +290,27 @@ def test_path_option(runner):
         result = runner.invoke(exists, ['-f', '.'])
         assert 'exists=True' in result.output
 
+    @click.command()
+    @click.argument('some_file', type=click.Path(exists=True, allow_dash=True))
+    def dash_allowed(some_file):
+        if some_file == '-':
+            click.echo("It's standard in :-D")
+        else:
+            click.echo("It's not standard in :-(")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(dash_allowed, ['-'])
+        assert "It's standard in :-D" in result.output
+
+        result = runner.invoke(dash_allowed, ['xxx'])
+        assert 'Error: Invalid value for "some_file": Path "xxx" does not exist' \
+            in result.output
+
+        with open('foo.txt', 'wb') as f:
+            f.write(b"bar\n")
+        result = runner.invoke(dash_allowed, ['foo.txt'])
+        assert "It's not standard in :-(" in result.output
+
 
 def test_choice_option(runner):
     @click.command()


### PR DESCRIPTION
When passing in '-' as a parameter to a click.Path type (allowed in click 6.0), the convert method will fail on a check for whether the file is readable as it simply asks whether `os.access('-', os.R_OK)` is True. This PR corrects this and adds some tests for allow_dash.
