### PR TITLE
Simplify MANIFEST.in commands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,9 @@
 include Makefile CHANGES LICENSE
-recursive-include artwork *
-recursive-include tests *
-recursive-include examples *
-recursive-include docs *
-recursive-exclude docs *.pyc
-recursive-exclude docs *.pyo
-recursive-exclude tests *.pyc
-recursive-exclude tests *.pyo
-recursive-exclude examples *.pyc
-recursive-exclude examples *.pyo
+
+graft artwork
+graft tests
+graft examples
+graft docs
 prune docs/_build
+
+global-exclude *.py[co] .DS_Store


### PR DESCRIPTION
The full MANIFEST.in syntax is here: https://docs.python.org/3/distutils/commandref.html

For what it's worth, many of the directories being packaged up here never get installed. They're just bundled up in the source distribution and ignored by pip on install. Only `click/` actually makes it onto the user's system.

Fixes #480.
