### PR TITLE
hide '0d' when eta<24h

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -129,7 +129,7 @@ class ProgressBar(object):
 
     def format_eta(self):
         if self.eta_known:
-            t = self.eta + 1
+            t = int(math.floor(self.eta + 1))
             seconds = t % 60
             t /= 60
             minutes = t % 60


### PR DESCRIPTION
t>0 is always true (and we always see '0d ...') if floor is not taken...
