### PR TITLE
Added list of choices to termui prompt for user data if the data requested is a Choice

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@ Version 7.0
 
 (upcoming release with new features, release date to be decided)
 
+- The user is now presented with the available choices if prompt=True and
+  type=click.Choice in a click.option. The choices are listed within
+  parentthesis like 'Choose fruit (apple, orange): '.
 - The exception objects now store unicode properly.
 - Added the ability to hide commands and options from help.
 - Added Float Range in Types.

--- a/click/core.py
+++ b/click/core.py
@@ -1461,7 +1461,7 @@ class Option(Parameter):
                  prompt=False, confirmation_prompt=False,
                  hide_input=False, is_flag=None, flag_value=None,
                  multiple=False, count=False, allow_from_autoenv=True,
-                 type=None, help=None, hidden=False, **attrs):
+                 type=None, help=None, hidden=False, show_choices=True, **attrs):
         default_is_missing = attrs.get('default', _missing) is _missing
         Parameter.__init__(self, param_decls, type=type, **attrs)
 
@@ -1507,6 +1507,7 @@ class Option(Parameter):
         self.allow_from_autoenv = allow_from_autoenv
         self.help = help
         self.show_default = show_default
+        self.show_choices = show_choices
 
         # Sanity check for stuff we don't support
         if __debug__:
@@ -1658,8 +1659,8 @@ class Option(Parameter):
         if self.is_bool_flag:
             return confirm(self.prompt, default)
 
-        return prompt(self.prompt, default=default,
-                      hide_input=self.hide_input,
+        return prompt(self.prompt, default=default, type=self.type,
+                      hide_input=self.hide_input, show_choices=self.show_choices,
                       confirmation_prompt=self.confirmation_prompt,
                       value_proc=lambda x: self.process_value(ctx, x))
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -44,6 +44,23 @@ def test_progressbar_length_hint(runner, monkeypatch):
     assert result.exception is None
 
 
+def test_choices_list_in_prompt(runner, monkeypatch):
+    @click.option('-g', type=click.Choice(['none', 'day', 'week', 'month']), prompt=True)
+    @click.command()
+    def cli_with_choices():
+        pass
+
+    @click.option('-g', type=click.Choice(['none', 'day', 'week', 'month']), prompt=True, show_choices=False)
+    @click.command()
+    def cli_without_choices():
+        pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+
+    assert '(none, day, week, month)' in runner.invoke(cli_with_choices, [], input='none').output
+    assert '(none, day, week, month)' not in runner.invoke(cli_without_choices, [], input='none').output
+
+
 def test_secho(runner):
     with runner.isolation() as out:
         click.secho(None, nl=False)


### PR DESCRIPTION
I found it odd that the user had to give incorrect input in order to be presented with the list of available options, for example:

```
Group by: something
Error: invalid choice: something. (choose from none, day, week, month)
```

In the above example the user is asked to give the program some interval to group by but offers no help as to what the valid inputs are until the user has incorrectly entered 'something'. With the modifications included in this commit the prompt would look as follows:

```
Group by (none, day, week, month):
```

It is now clear to the user that it has a limited set of options to chose from. This of course works in combination with default options.

```
Group by (none, day, week, month) [week]:
```

It is possible to disable the display of the choices by passing show_choices=False just like passing show_default=False works.

Also added a test for the new behaviour.

The last test of the test_chain.py test suite xFails, whatever that means, but it does that on master too so I don't think it's related to my changes.
