### PR TITLE
Added tests which show how show_default=False has no effect

### DIFF
--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -42,3 +42,23 @@ def test_progressbar_length_hint(runner, monkeypatch):
     monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
     result = runner.invoke(cli, [])
     assert result.exception is None
+
+
+def test_show_default(runner, monkeypatch):
+    @click.option('-t', default='hello', prompt=True, show_default=True)
+    @click.command()
+    def cli():
+        pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+    assert '[hello]' in runner.invoke(cli, [], input='none').output
+
+
+def test_do_not_show_default(runner, monkeypatch):
+    @click.option('-t', default='hello', prompt=True, show_default=False)
+    @click.command()
+    def cli():
+        pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+    assert '[hello]' not in runner.invoke(cli, [], input='none').output


### PR DESCRIPTION
When I was writing my changes for the Prompt display of Choices, PR #496, I ended up discovering that passing show_default=False on an option has no effect. I've included two tests for this behaviour where the second one fails with the code currently on mitshuhiko/master.
