### PR TITLE
Attempt to use an available locale

### DIFF
--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -70,11 +70,15 @@ def _verify_python3_env():
             rv = rv.decode('ascii', 'replace')
 
         for line in rv.splitlines():
-            locale = line.strip()
-            if locale.lower().endswith(('.utf-8', '.utf8')):
-                good_locales.add(locale)
-                if locale.lower() in ('c.utf8', 'c.utf-8'):
+            l = line.strip()
+            if l.lower().endswith(('.utf-8', '.utf8')):
+                good_locales.add(l)
+                if l.lower() in ('c.utf8', 'c.utf-8'):
                     has_c_utf8 = True
+
+        for l in good_locales:
+            locale.setlocale(locale.LC_ALL, l)
+            return
 
         extra += '\n\n'
         if not good_locales:

--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -76,9 +76,12 @@ def _verify_python3_env():
                 if l.lower() in ('c.utf8', 'c.utf-8'):
                     has_c_utf8 = True
 
-        for l in good_locales:
-            locale.setlocale(locale.LC_ALL, l)
-            return
+        try:
+            for l in good_locales:
+                locale.setlocale(locale.LC_ALL, l)
+                return
+        except:
+            pass
 
         extra += '\n\n'
         if not good_locales:


### PR DESCRIPTION
Click can detect if usable locales are available, but only exhibits this to users via a message.
I originally came across this via untitaker/vdirsyncer#335, where there was a possible sane environment, but click was still failing.

This patch attempts to use one of those good locales. It seems to fix click failing when both `LANG` and `LC_CTYPES` are unset, with no obvious drawbacks.

I haven't added any tests (yet) because I'd like to know if this patch is acceptable, or if, in my ignorance, I've overlooked something that makes this useless. It it's acceptable, I'll add some tests (and polish it a bit).
