### PR TITLE
Add git-like "Did you mean" functionality

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -556,3 +556,54 @@ know:
 -   When a Click script is invoked as command line application (through
     :meth:`BaseCommand.main`) the return value is ignored unless the
     `standalone_mode` is disabled in which case it's bubbled through.
+
+
+Did you mean functionality
+--------------------------
+
+.. versionadded:: 6.4
+
+All :class:`MultiCommand` based classes like the built-in :class:`Group`
+and :class:`CommandCollection` support a *Did you mean* functionality.
+If this functionality is enabled and a command can not be found the help
+text gets extended with suggestions of commands which the user could have meant.
+
+This example shows how to enable the *did you mean* functionality:
+
+.. click:example::
+
+    import click
+
+    @click.group(enable_didyoumean=True)
+    def cli(ctx):
+        pass
+
+    @cli.command()
+    def foo():
+        pass
+
+    @cli.command()
+    def bar():
+        pass
+
+    @cli.command()
+    def barrr():
+        pass
+
+    if __name__ == '__main__':
+        cli()
+
+
+The following help text will be echoed if a not existing command is triggered:
+
+.. click:run::
+
+    $ cli barr
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+    Error: No such command "barr".
+
+    Did you mean one of these?
+        barrr
+        bar
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -253,3 +253,38 @@ def test_unprocessed_options(runner):
         'Verbosity: 4',
         'Args: -foo|-x|--muhaha|x|y|-x',
     ]
+
+
+def test_didyoumean_on_no_such_command(runner):
+    @click.group(enable_didyoumean=True)
+    def cli(ctx):
+        pass
+
+    @cli.command()
+    def foo():
+        pass
+
+    @cli.command()
+    def bar():
+        pass
+
+    @cli.command()
+    def barrr():
+        pass
+
+    result = runner.invoke(cli, ['fo'])
+    assert result.output == (
+        'Usage: cli [OPTIONS] COMMAND [ARGS]...\n\n'
+        'Error: No such command "fo".\n\n'
+        'Did you mean one of these?\n'
+        '    foo\n'
+    )
+
+    result = runner.invoke(cli, ['barr'])
+    assert result.output == (
+        'Usage: cli [OPTIONS] COMMAND [ARGS]...\n\n'
+        'Error: No such command "barr".\n\n'
+        'Did you mean one of these?\n'
+        '    barrr\n'
+        '    bar\n'
+    )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,7 +32,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading', 'colorama'
+    'threading', 'colorama', 'difflib'
 ])
 
 if WIN:


### PR DESCRIPTION
This patch adds a git-like _Did you mean_ functionality for `MultiCommand` based classes like `Group` and `CommandCollection`.

``` python
import click

@click.group(enable_didyoumean=True)
def cli(ctx):
    pass

@cli.command()
def foo():
    pass

@cli.command()
def bar():
    pass

@cli.command()
def barrr():
    pass

if __name__ == '__main__':
    cli()
```

The following help text will be echoed if a not existing command is triggered:

```
$ cli barr
Usage: cli [OPTIONS] COMMAND [ARGS]...

Error: No such command "barr".

Did you mean one of these?
    barrr
    bar
```
