### PR TITLE
Non standalone exit

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -7,7 +7,7 @@ from functools import update_wrapper
 from .types import convert_type, IntRange, BOOL
 from .utils import make_str, make_default_short_help, echo, get_os_args
 from .exceptions import ClickException, UsageError, BadParameter, Abort, \
-     MissingParameter
+     MissingParameter, Exit
 from .termui import prompt, confirm
 from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
@@ -480,7 +480,7 @@ class Context(object):
 
     def exit(self, code=0):
         """Exits the application with a given exit code."""
-        sys.exit(code)
+        raise Exit(code, self)
 
     def get_usage(self):
         """Helper method to get formatted usage string for the current
@@ -700,6 +700,12 @@ class BaseCommand(object):
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()
+            except Exit as e:
+                if not standalone_mode:
+                    if e.exit_code:
+                        raise
+                    return None
+                sys.exit(e.exit_code)
             except ClickException as e:
                 if not standalone_mode:
                     raise

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -7,6 +7,7 @@ class ClickException(Exception):
 
     #: The exit code for this exception
     exit_code = 1
+    show_prefix ='Error: '
 
     def __init__(self, message):
         ctor_msg = message
@@ -28,19 +29,17 @@ class ClickException(Exception):
     def show(self, file=None):
         if file is None:
             file = get_text_stderr()
-        echo('Error: %s' % self.format_message(), file=file)
+        echo('%s%s' % (self.show_prefix, self.format_message()), file=file)
 
 
-class UsageError(ClickException):
-    """An internal exception that signals a usage error.  This typically
-    aborts any further handling.
+class ContextAwareException(ClickException):
+    """An exception that knows how to use a :class:`~click.Context` object
+    to properly display itself.
 
     :param message: the error message to display.
     :param ctx: optionally the context that caused this error.  Click will
                 fill in the context automatically in some situations.
     """
-    exit_code = 2
-
     def __init__(self, message, ctx=None):
         ClickException.__init__(self, message)
         self.ctx = ctx
@@ -52,7 +51,37 @@ class UsageError(ClickException):
         if self.ctx is not None:
             color = self.ctx.color
             echo(self.ctx.get_usage() + '\n', file=file, color=color)
-        echo('Error: %s' % self.format_message(), file=file, color=color)
+        echo(
+            '%s%s' % (self.show_prefix, self.format_message()),
+            file=file,
+            color=color,
+        )
+
+
+class Exit(ContextAwareException):
+    """An exception that indicates that the application should exit with some
+    status code.
+
+    :param code: the status code to exit with.
+    :param ctx: optionally the context that caused this error.  Click will
+                fill in the context automatically in some situations.
+    """
+    show_prefix = 'Exit: '
+
+    def __init__(self, code, ctx=None):
+        ContextAwareException.__init__(self, str(code), ctx=None)
+        self.exit_code = code
+
+
+class UsageError(ContextAwareException):
+    """An internal exception that signals a usage error.  This typically
+    aborts any further handling.
+
+    :param message: the error message to display.
+    :param ctx: optionally the context that caused this error.  Click will
+                fill in the context automatically in some situations.
+    """
+    exit_code = 2
 
 
 class BadParameter(UsageError):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 import click
 
 
@@ -203,3 +205,27 @@ def test_close_before_pop(runner):
     assert not result.exception
     assert result.output == 'aha!\n'
     assert called == [True]
+
+
+def test_exit_not_standalone_failure():
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        ctx.exit(1)
+
+    with pytest.raises(click.exceptions.Exit) as e:
+        cli.main([], 'test_exit_not_standalone', standalone_mode=False)
+    assert e.value.exit_code == 1
+
+
+def test_exit_not_standalone_success():
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        ctx.exit(0)
+
+    assert cli.main(
+        [],
+        'test_exit_not_standalone',
+        standalone_mode=False,
+    ) is None

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -153,14 +153,32 @@ def test_exit_code_and_output_from_sys_exit():
         sys.exit('error')
 
     @click.command()
+    @click.pass_context
+    def cli_string_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit('error')
+
+    @click.command()
     def cli_int():
         click.echo('hello world')
         sys.exit(1)
 
     @click.command()
+    @click.pass_context
+    def cli_int_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit(1)
+
+    @click.command()
     def cli_float():
         click.echo('hello world')
         sys.exit(1.0)
+
+    @click.command()
+    @click.pass_context
+    def cli_float_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit(1.0)
 
     @click.command()
     def cli_no_error():
@@ -172,11 +190,23 @@ def test_exit_code_and_output_from_sys_exit():
     assert result.exit_code == 1
     assert result.output == 'hello world\nerror\n'
 
+    result = runner.invoke(cli_string_ctx_exit)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\nerror\n'
+
     result = runner.invoke(cli_int)
     assert result.exit_code == 1
     assert result.output == 'hello world\n'
 
+    result = runner.invoke(cli_int_ctx_exit)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n'
+
     result = runner.invoke(cli_float)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n1.0\n'
+
+    result = runner.invoke(cli_float_ctx_exit)
     assert result.exit_code == 1
     assert result.output == 'hello world\n1.0\n'
 


### PR DESCRIPTION
I am using `Command.main` with `standalone=False` and found that `--help` would still call `ctx.exit()` which turned into a call to `sys.exit()`. This change makes `Context.exit` raise a custom click exception that is handled in `Command.main`. This allows us to check if we are in standalone mode and delegate to the proper behavior. In standalone mode we just pass the exit_code from the exception to `sys.exit` like before; however, when not in standalone mode we re-raise the exception when `exit_code != 0`, otherwise we just return None. This makes it possible for commands to early exit with `ctx.exit` without breaking non standalone usage.
