### PR TITLE
Added support for gvim blocking

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -394,15 +394,15 @@ class Editor(object):
     def edit_file(self, filename):
         import subprocess
         editor = self.get_editor()
+        if os.path.basename(editor) == 'gvim':
+            editor += " -f"
+
         if self.env:
             environ = os.environ.copy()
             environ.update(self.env)
         else:
             environ = None
         try:
-            if os.path.basename(editor) == 'gvim':
-                editor += " -f"
-
             c = subprocess.Popen('%s "%s"' % (editor, filename),
                                  env=environ, shell=True)
             exit_code = c.wait()

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -400,8 +400,12 @@ class Editor(object):
         else:
             environ = None
         try:
-            c = subprocess.Popen('%s "%s"' % (editor, filename),
-                                 env=environ, shell=True)
+            editor_args = [editor]
+            if os.path.basename(editor) == 'gvim':
+                editor_args.append('-f')
+
+            editor_args.append(filename)
+            c = subprocess.Popen(editor_args, env=environ, shell=True)
             exit_code = c.wait()
             if exit_code != 0:
                 raise ClickException('%s: Editing failed!' % editor)

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -400,12 +400,11 @@ class Editor(object):
         else:
             environ = None
         try:
-            editor_args = [editor]
             if os.path.basename(editor) == 'gvim':
-                editor_args.append('-f')
+                editor += " -f"
 
-            editor_args.append(filename)
-            c = subprocess.Popen(editor_args, env=environ, shell=True)
+            c = subprocess.Popen('%s "%s"' % (editor, filename),
+                                 env=environ, shell=True)
             exit_code = c.wait()
             if exit_code != 0:
                 raise ClickException('%s: Editing failed!' % editor)


### PR DESCRIPTION
Currently, if your EDITOR or VISUAL environmental values are set to 'gvim', subprocess.Popen will not block, and c.wait() immediately returns. This is different from the behavior with other editors, where this blocks until the file is closed. This pull request adds the '-f' flag to gvim invocations, which runs the editor in the foreground.

This is a fix for https://github.com/pallets/click/issues/580
