### PR TITLE
[setup] Make `setup.py test` work correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 docs/_build
 click.egg-info
 .tox
+.eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal=1
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import re
 import ast
+import re
+import sys
 from setuptools import setup
 
 
@@ -9,6 +10,10 @@ _version_re = re.compile(r'__version__\s+=\s+(.*)')
 with open('click/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
+
+
+needs_ptr = any(cmd for cmd in sys.argv if cmd in {'ptr', 'pytest', 'test'})
+setup_requires = ['pytest-runner'] if needs_ptr else []
 
 
 setup(
@@ -25,4 +30,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
     ],
+    tests_require=[
+        'pytest',
+    ],
+    setup_requires=setup_requires,
 )


### PR DESCRIPTION
Without this change, running `setup.py test` depending on the environment either:
#### 1. does nothing:

```
running test
```
#### or 2. incorrectly uses the unittest test collector, which then crashes on importing a module it shouldn't even try to import:

```
running test
running egg_info
writing dependency_links to click.egg-info/dependency_links.txt
writing click.egg-info/PKG-INFO
writing top-level names to click.egg-info/top_level.txt
reading manifest file 'click.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.pyc' found under directory 'docs'
warning: no previously-included files matching '*.pyo' found under directory 'docs'
warning: no previously-included files matching '*.pyc' found under directory 'tests'
warning: no previously-included files matching '*.pyo' found under directory 'tests'
warning: no previously-included files matching '*.pyc' found under directory 'examples'
warning: no previously-included files matching '*.pyo' found under directory 'examples'
no previously-included directories found matching 'docs/_build'
writing manifest file 'click.egg-info/SOURCES.txt'
running build_ext
_winconsole (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: _winconsole (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: _winconsole
Traceback (most recent call last):
  File "/home/engshare/third-party2/python/3.5.0/gcc-4.8.1-glibc-2.17/4a1fbff/lib/python3.5/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/engshare/third-party2/click/6.6/src/build-gcc-4.8.1-glibc-2.17/build/click/_winconsole.py", line 17, in <module>
    import msvcrt
ImportError: No module named 'msvcrt'

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```

With this pull request, `setup.py test` does the right thing. The pull request also makes pytest and pytest-runner dependencies, both only when invoking `setup.py test`.

This also potentially simplifies the CONTRIBUTING file, you can just tell people to run `setup.py test` and it will take care of installing py.test for them.
