### PR TITLE
Quick fix to get_winterm_size() returning (0, 0)

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -167,7 +167,11 @@ def get_terminal_size():
             return sz.columns, sz.lines
 
     if get_winterm_size is not None:
-        return get_winterm_size()
+        size = get_winterm_size()
+        if size == (0, 0):
+            return (79, 24)
+        else:
+            return size
 
     def ioctl_gwinsz(fd):
         try:


### PR DESCRIPTION
The `get_winterm_size()` function will return `(0, 0)` when invoked
from inside a subprocess. This is not very useful and results in a very
cramped and ugly output, so instead provide a sensible default.
