### PR TITLE
Fix a couple of typos in the documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -277,7 +277,7 @@ options:
     If you go with this solution, the extra arguments will be collected in
     :attr:`Context.args`.
 2.  You can attach a :func:`argument` with ``nargs`` set to `-1` which
-    will eat up all leftover arguments.  In this case it's recommeded to
+    will eat up all leftover arguments.  In this case it's recommended to
     set the `type` to :data:`UNPROCESSED` to avoid any string processing
     on those arguments as otherwise they are forced into unicode strings
     automatically which is often not what you want.

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -42,7 +42,7 @@ with dashes replaced by underscores.
 
 If your tool is called ``foo-bar``, then the magic variable is called
 ``_FOO_BAR_COMPLETE``.  By exporting it with the ``source`` value it will
-spit out the activation script which can be trivally activated.
+spit out the activation script which can be trivially activated.
 
 For instance, to enable Bash completion for your ``foo-bar`` script, this
 is what you would need to put into your ``.bashrc``::

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -437,7 +437,7 @@ you're not satisfied with the defaults.
 
 The default map can be nested arbitrarily for each subcommand and
 provided when the script is invoked.  Alternatively, it can also be
-overriden at any point by commands.  For instance, a top-level command could
+overridden at any point by commands.  For instance, a top-level command could
 load the defaults from a configuration file.
 
 Example usage:

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -44,7 +44,7 @@ properly by this function.
 Multicommand Chaining API
 `````````````````````````
 
-Click 3 introduced multicommand chaning.  This required a change in how
+Click 3 introduced multicommand chaining.  This required a change in how
 Click internally dispatches.  Unfortunately this change was not correctly
 implemented and it appeared that it was possible to provide an API that
 can inform the super command about all the subcommands that will be

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -226,7 +226,7 @@ Launching Applications
 .. versionadded:: 2.0
 
 Click supports launching applications through :func:`launch`.  This can be
-used to open the default application assocated with a URL or filetype.
+used to open the default application associated with a URL or filetype.
 This can be used to launch web browsers or picture viewers, for instance.
 In addition to this, it can also launch the file manager and automatically
 select the provided file.


### PR DESCRIPTION
Assuming that `master` is the right base for those. If not, I can reapply to another branch or split them up.
