### PR TITLE
Handle SIGPIPE in click.echo().

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -694,13 +694,7 @@ class BaseCommand(object):
         try:
             try:
                 with self.make_context(prog_name, args, **extra) as ctx:
-                    try:
-                        rv = self.invoke(ctx)
-                    except IOError as e:
-                        if e.errno == errno.EPIPE:
-                            sys.exit(errno.EPIPE)
-                        else:
-                            raise
+                    rv = self.invoke(ctx)
                     if not standalone_mode:
                         return rv
                     ctx.exit()
@@ -712,6 +706,11 @@ class BaseCommand(object):
                     raise
                 e.show()
                 sys.exit(e.exit_code)
+            except IOError as e:
+                if e.errno == errno.EPIPE:
+                    sys.exit(1)
+                else:
+                    raise
         except Abort:
             if not standalone_mode:
                 raise

--- a/click/core.py
+++ b/click/core.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import sys
 from contextlib import contextmanager
@@ -693,7 +694,13 @@ class BaseCommand(object):
         try:
             try:
                 with self.make_context(prog_name, args, **extra) as ctx:
-                    rv = self.invoke(ctx)
+                    try:
+                        rv = self.invoke(ctx)
+                    except IOError as e:
+                        if e.errno == errno.EPIPE:
+                            sys.exit(errno.EPIPE)
+                        else:
+                            raise
                     if not standalone_mode:
                         return rv
                     ctx.exit()

--- a/click/utils.py
+++ b/click/utils.py
@@ -241,7 +241,7 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
                 file.flush()
                 binary_file.write(message)
                 binary_file.flush()
-            except IOError, e:
+            except IOError as e:
                 if e.errno != errno.EPIPE:
                     raise
             return
@@ -264,7 +264,7 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
     if message:
         try:
             file.write(message)
-        except IOError, e:
+        except IOError as e:
             if e.errno != errno.EPIPE:
                 raise
     file.flush()

--- a/click/utils.py
+++ b/click/utils.py
@@ -1,4 +1,3 @@
-import errno
 import os
 import sys
 
@@ -237,13 +236,9 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
     if message and not PY2 and is_bytes(message):
         binary_file = _find_binary_writer(file)
         if binary_file is not None:
-            try:
-                file.flush()
-                binary_file.write(message)
-                binary_file.flush()
-            except IOError as e:
-                if e.errno != errno.EPIPE:
-                    raise
+            file.flush()
+            binary_file.write(message)
+            binary_file.flush()
             return
 
     # ANSI-style support.  If there is no message or we are dealing with
@@ -262,11 +257,7 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
                 message = strip_ansi(message)
 
     if message:
-        try:
-            file.write(message)
-        except IOError as e:
-            if e.errno != errno.EPIPE:
-                raise
+        file.write(message)
     file.flush()
 
 

--- a/click/utils.py
+++ b/click/utils.py
@@ -1,6 +1,6 @@
+import errno
 import os
 import sys
-import errno
 
 from .globals import resolve_color_default
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,7 +32,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading', 'colorama'
+    'threading', 'colorama', 'errno'
 ])
 
 if WIN:


### PR DESCRIPTION
When the output of a click program is sent to another program via a
pipe, and the pipe is closed prematurely, click.echo() was printing an
exception backtrace instead of silently exiting like most command line
utilities.

Fixes: https://github.com/pallets/click/issues/625
