### PR TITLE
Add ability to truncate help text in docstrings.

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -752,6 +752,8 @@ class Command(BaseCommand):
         #: should show up in the help page and execute.  Eager parameters
         #: will automatically be handled before non eager ones.
         self.params = params or []
+        if help and '\f' in help:
+            help = help.split('\f', 1)[0]
         self.help = help
         self.epilog = epilog
         self.options_metavar = options_metavar

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -77,6 +77,40 @@ And what it looks like:
     invoke(cli, args=['--help'])
 
 
+Truncating Help Texts
+---------------------
+
+Click gets command help text from function docstrings.  However if you
+already use docstrings to document function arguments you may not want
+to see :param: and :return: lines in your help text.
+
+You can use the ``\f`` escape marker to have Click truncate the help text
+after the marker.
+
+Example:
+
+.. click:example::
+
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        """First paragraph.
+
+        This is a very long second
+        paragraph and not correctly
+        wrapped but it will be rewrapped.
+        \f
+
+        :param click.core.Context ctx: Click context.
+        """
+
+And what it looks like:
+
+.. click:run::
+
+    invoke(cli, args=['--help'])
+
+
 Meta Variables
 --------------
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -212,3 +212,32 @@ def test_formatting_usage_custom_help(runner):
         '',
         'Error: Missing argument "arg".'
     ]
+
+
+def test_truncating_docstring(runner):
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        """First paragraph.
+
+        This is a very long second
+        paragraph and not correctly
+        wrapped but it will be rewrapped.
+        \f
+
+        :param click.core.Context ctx: Click context.
+        """
+
+    result = runner.invoke(cli, ['--help'], terminal_width=60)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: cli [OPTIONS]',
+        '',
+        '  First paragraph.',
+        '',
+        '  This is a very long second paragraph and not correctly',
+        '  wrapped but it will be rewrapped.',
+        '',
+        'Options:',
+        '  --help  Show this message and exit.',
+    ]


### PR DESCRIPTION
I use docstrings in all of my functions to document function arguments
so it makes me sad that I couldn't exclude :param: and other tags from
my command help texts.

Here I am introducing the ability for Click to truncate help text in
docstrings using the \f form feed escaped character. I chose it
randomly.

I've been accomplishing this in my project using this decorator:

``` python
def click_truncate(click_func, **kwargs):
    """Truncate function docstrings from Click's perspective on the form-feed character.

    :param function click_func: Either click.command or click.group.
    :param dict kwargs: Extra keyword arguments to pass to click.option().

    :return: The wrapped function.
    :rtype: function
    """
    def wrapper(func):
        original = func.__doc__
        if original:
            func.__doc__ = original.split('\f', 1)[0].rstrip()
        wrapped = click_func(**kwargs)(func)
        if original:
            wrapped.__doc__ = func.__doc__ = original
        return wrapped
    return wrapper
```
