### PR TITLE
Bugfix: Make click.progressbar work with codecs.open files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,11 @@ install:
 
 script: make test
 
+branches:
+  only:
+    - master
+    - auto
+    - /^.*-maintenance$/
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,3 @@ script: make test
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "chat.freenode.net#pocoo"
-    on_success: change
-    on_failure: always
-    use_notice: true
-    skip_join: true

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 7.0
 
 (upcoming release with new features, release date to be decided)
 
+- The exception objects now store unicode properly.
+
 Version 6.3
 -----------
 

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Version 7.0
 
 - The exception objects now store unicode properly.
 - Added the ability to hide commands and options from help.
+- Added Float Range in Types
 
 Version 6.3
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@ Version 7.0
 
 - The exception objects now store unicode properly.
 - Added the ability to hide commands and options from help.
-- Added Float Range in Types
+- Added Float Range in Types.
 
 Version 6.3
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@ Click Changelog
 
 This contains all major version changes between Click releases.
 
+Version 7.0
+-----------
+
+(upcoming release with new features, release date to be decided)
+
 Version 6.1
 -----------
 

--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,7 @@ Version 7.0
 - `secho`'s first argument can now be `None`, like in `echo`.
 - Usage errors now hint at the `--help` option.
 
-Version 6.5
+Version 6.6
 -----------
 
 (bugfix release; released on April 4th 2016)

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 7.0
 - The exception objects now store unicode properly.
 - Added the ability to hide commands and options from help.
 - Added Float Range in Types.
+- `secho`'s first argument can now be `None`, like in `echo`.
 
 Version 6.5
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Version 7.0
 - Added the ability to hide commands and options from help.
 - Added Float Range in Types.
 - `secho`'s first argument can now be `None`, like in `echo`.
+- Usage errors now hint at the `--help` option.
 
 Version 6.5
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 7.0
 (upcoming release with new features, release date to be decided)
 
 - The exception objects now store unicode properly.
+- Added the ability to hide commands and options from help.
 
 Version 6.3
 -----------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,7 +33,7 @@ Submitting patches
   may ignore the line-length-limit if following it would make the code uglier.
 
 - For features: Consider whether your feature would be a better fit for an
-  `external package <click.pocoo.org/contrib/>`_
+  `external package <http://click.pocoo.org/contrib/>`_
 
 Running the testsuite
 ---------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -32,6 +32,9 @@ Submitting patches
 - Try to follow `PEP8 <http://legacy.python.org/dev/peps/pep-0008/>`_, but you
   may ignore the line-length-limit if following it would make the code uglier.
 
+- For features: Consider whether your feature would be a better fit for an
+  `external package <click.pocoo.org/contrib/>`_
+
 Running the testsuite
 ---------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,9 @@
 include Makefile CHANGES LICENSE
-recursive-include artwork *
-recursive-include tests *
-recursive-include examples *
-recursive-include docs *
-recursive-exclude docs *.pyc
-recursive-exclude docs *.pyo
-recursive-exclude tests *.pyc
-recursive-exclude tests *.pyo
-recursive-exclude examples *.pyc
-recursive-exclude examples *.pyo
+
+graft artwork
+graft tests
+graft examples
+graft docs
 prune docs/_build
+
+global-exclude *.py[co] .DS_Store

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -95,4 +95,4 @@ __all__ = [
 disable_unicode_literals_warning = False
 
 
-__version__ = '6.1-dev'
+__version__ = '7.0-dev'

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -28,7 +28,7 @@ from .decorators import pass_context, pass_obj, make_pass_decorator, \
 
 # Types
 from .types import ParamType, File, Path, Choice, IntRange, Tuple, \
-     STRING, INT, FLOAT, BOOL, UUID, UNPROCESSED
+     STRING, INT, FLOAT, BOOL, UUID, UNPROCESSED, FloatRange
 
 # Utilities
 from .utils import echo, get_binary_stream, get_text_stream, open_file, \
@@ -66,7 +66,7 @@ __all__ = [
 
     # Types
     'ParamType', 'File', 'Path', 'Choice', 'IntRange', 'Tuple', 'STRING',
-    'INT', 'FLOAT', 'BOOL', 'UUID', 'UNPROCESSED',
+    'INT', 'FLOAT', 'BOOL', 'UUID', 'UNPROCESSED', 'FloatRange'
 
     # Utilities
     'echo', 'get_binary_stream', 'get_text_stream', 'open_file',

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -139,6 +139,7 @@ if PY2:
     bytes = str
     raw_input = raw_input
     string_types = (str, unicode)
+    int_types = (int, long)
     iteritems = lambda x: x.iteritems()
     range_type = xrange
 
@@ -212,6 +213,7 @@ else:
     text_type = str
     raw_input = input
     string_types = (str,)
+    int_types = (int,)
     range_type = range
     isidentifier = lambda x: x.isidentifier()
     iteritems = lambda x: iter(x.items())

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -31,7 +31,7 @@ def _length_hint(obj):
     """Returns the length hint of an object."""
     try:
         return len(obj)
-    except TypeError:
+    except (AttributeError, TypeError):
         try:
             get_hint = type(obj).__length_hint__
         except AttributeError:

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -14,7 +14,7 @@ import sys
 import time
 import math
 from ._compat import _default_text_stdout, range_type, PY2, isatty, \
-     open_stream, strip_ansi, term_len, get_best_encoding, WIN
+     open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types
 from .utils import echo
 from .exceptions import ClickException
 
@@ -41,7 +41,7 @@ def _length_hint(obj):
         except TypeError:
             return None
         if hint is NotImplemented or \
-           not isinstance(hint, (int, long)) or \
+           not isinstance(hint, int_types) or \
            hint < 0:
             return None
         return hint

--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -94,7 +94,7 @@ def _verify_python3_env():
         else:
             extra += (
                 'This system lists a couple of UTF-8 supporting locales that\n'
-                'you can pick from.  The following suitable locales where\n'
+                'you can pick from.  The following suitable locales were\n'
                 'discovered: %s'
             ) % ', '.join(sorted(good_locales))
 

--- a/click/core.py
+++ b/click/core.py
@@ -737,11 +737,13 @@ class Command(BaseCommand):
                        shown on the command listing of the parent command.
     :param add_help_option: by default each command registers a ``--help``
                             option.  This can be disabled by this parameter.
+    :param hidden: hide this command from help outputs.
     """
 
     def __init__(self, name, context_settings=None, callback=None,
                  params=None, help=None, epilog=None, short_help=None,
-                 options_metavar='[OPTIONS]', add_help_option=True):
+                 options_metavar='[OPTIONS]', add_help_option=True,
+                 hidden=False):
         BaseCommand.__init__(self, name, context_settings)
         #: the callback to execute when the command fires.  This might be
         #: `None` in which case nothing happens.
@@ -757,6 +759,7 @@ class Command(BaseCommand):
             short_help = make_default_short_help(help)
         self.short_help = short_help
         self.add_help_option = add_help_option
+        self.hidden = hidden
 
     def get_usage(self, ctx):
         formatter = ctx.make_formatter()
@@ -995,6 +998,8 @@ class MultiCommand(Command):
             cmd = self.get_command(ctx, subcommand)
             # What is this, the tool lied about a command.  Ignore it
             if cmd is None:
+                continue
+            if cmd.hidden:
                 continue
 
             help = cmd.short_help or ''
@@ -1442,6 +1447,7 @@ class Option(Parameter):
                                variable in case a prefix is defined on the
                                context.
     :param help: the help string.
+    :param hidden: hide this option from help outputs.
     """
     param_type_name = 'option'
 
@@ -1449,7 +1455,7 @@ class Option(Parameter):
                  prompt=False, confirmation_prompt=False,
                  hide_input=False, is_flag=None, flag_value=None,
                  multiple=False, count=False, allow_from_autoenv=True,
-                 type=None, help=None, **attrs):
+                 type=None, help=None, hidden=False, **attrs):
         default_is_missing = attrs.get('default', _missing) is _missing
         Parameter.__init__(self, param_decls, type=type, **attrs)
 
@@ -1462,6 +1468,7 @@ class Option(Parameter):
         self.prompt = prompt_text
         self.confirmation_prompt = confirmation_prompt
         self.hide_input = hide_input
+        self.hidden = hidden
 
         # Flags
         if is_flag is None:
@@ -1589,6 +1596,8 @@ class Option(Parameter):
             parser.add_option(self.opts, **kwargs)
 
     def get_help_record(self, ctx):
+        if self.hidden:
+            return
         any_prefix_is_slash = []
 
         def _write_opts(opts):

--- a/click/core.py
+++ b/click/core.py
@@ -654,7 +654,7 @@ class BaseCommand(object):
                           name from ``sys.argv[0]``.
         :param complete_var: the environment variable that controls the
                              bash completion support.  The default is
-                             ``"_<prog_name>_COMPLETE"`` with prog name in
+                             ``"_<prog_name>_COMPLETE"`` with prog_name in
                              uppercase.
         :param standalone_mode: the default behavior is to invoke the script
                                 in standalone mode.  Click will then
@@ -669,7 +669,7 @@ class BaseCommand(object):
                       constructor.  See :class:`Context` for more information.
         """
         # If we are in Python 3, we will verify that the environment is
-        # sane at this point of reject further execution to avoid a
+        # sane at this point or reject further execution to avoid a
         # broken script.
         if not PY2:
             _verify_python3_env()
@@ -1424,9 +1424,9 @@ class Option(Parameter):
 
     :param show_default: controls if the default value should be shown on the
                          help page.  Normally, defaults are not shown.
-    :param prompt: if set to `True` or a non empty string then the user will
-                   be prompted for input if not set.  If set to `True` the
-                   prompt will be the option name capitalized.
+    :param prompt: if set to `True` or a non empty string then the user will be
+                   prompted for input.  If set to `True` the prompt will be the
+                   option name capitalized.
     :param confirmation_prompt: if set then the value will need to be confirmed
                                 if it was prompted for.
     :param hide_input: if this is `True` then the input on the prompt will be

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -164,10 +164,13 @@ class BadOptionUsage(UsageError):
     for an option is not correct.
 
     .. versionadded:: 4.0
+
+    :param option_name: the name of the option being used incorrectly.
     """
 
-    def __init__(self, message, ctx=None):
+    def __init__(self, option_name, message, ctx=None):
         UsageError.__init__(self, message, ctx)
+        self.option_name = option_name
 
 
 class BadArgumentUsage(UsageError):

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -44,16 +44,20 @@ class UsageError(ClickException):
     def __init__(self, message, ctx=None):
         ClickException.__init__(self, message)
         self.ctx = ctx
+        self.cmd = self.ctx and self.ctx.command or None
 
     def show(self, file=None):
         if file is None:
             file = get_text_stderr()
         color = None
+        hint = ''
+        if (self.cmd is not None and
+                self.cmd.get_help_option(self.ctx) is not None):
+            hint = ('Try "%s %s" for help.\n'
+                    % (self.ctx.command_path, self.ctx.help_option_names[0]))
         if self.ctx is not None:
             color = self.ctx.color
-            echo(self.ctx.get_usage() + '\nTry "%s %s" for help.\n'
-                 % (self.ctx.command_path, self.ctx.help_option_names[0]),
-                 file=file, color=color)
+            echo(self.ctx.get_usage() + '\n%s' % hint, file=file, color=color)
         echo('Error: %s' % self.format_message(), file=file, color=color)
 
 

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -9,14 +9,21 @@ class ClickException(Exception):
     exit_code = 1
 
     def __init__(self, message):
+        ctor_msg = message
         if PY2:
-            if message is not None:
-                message = message.encode('utf-8')
-        Exception.__init__(self, message)
+            if ctor_msg is not None:
+                ctor_msg = ctor_msg.encode('utf-8')
+        Exception.__init__(self, ctor_msg)
         self.message = message
 
     def format_message(self):
         return self.message
+
+    def __unicode__(self):
+        return self.message
+
+    def __str__(self):
+        return self.message.encode('utf-8')
 
     def show(self, file=None):
         if file is None:

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -51,7 +51,9 @@ class UsageError(ClickException):
         color = None
         if self.ctx is not None:
             color = self.ctx.color
-            echo(self.ctx.get_usage() + '\n', file=file, color=color)
+            echo(self.ctx.get_usage() + '\nTry "%s %s" for help.\n'
+                 % (self.ctx.command_path, self.ctx.help_option_names[0]),
+                 file=file, color=color)
         echo('Error: %s' % self.format_message(), file=file, color=color)
 
 

--- a/click/parser.py
+++ b/click/parser.py
@@ -74,8 +74,8 @@ def _unpack_args(args, nargs_spec):
 
 def _error_opt_args(nargs, opt):
     if nargs == 1:
-        raise BadOptionUsage('%s option requires an argument' % opt)
-    raise BadOptionUsage('%s option requires %d arguments' % (opt, nargs))
+        raise BadOptionUsage(opt, '%s option requires an argument' % opt)
+    raise BadOptionUsage(opt, '%s option requires %d arguments' % (opt, nargs))
 
 
 def split_opt(opt):
@@ -342,7 +342,7 @@ class OptionParser(object):
                 del state.rargs[:nargs]
 
         elif explicit_value is not None:
-            raise BadOptionUsage('%s option does not take a value' % opt)
+            raise BadOptionUsage(opt, '%s option does not take a value' % opt)
 
         else:
             value = None

--- a/click/termui.py
+++ b/click/termui.py
@@ -405,7 +405,7 @@ def unstyle(text):
     return strip_ansi(text)
 
 
-def secho(text, file=None, nl=True, err=False, color=None, **styles):
+def secho(message=None, file=None, nl=True, err=False, color=None, **styles):
     """This function combines :func:`echo` and :func:`style` into one
     call.  As such the following two calls are the same::
 
@@ -417,7 +417,9 @@ def secho(text, file=None, nl=True, err=False, color=None, **styles):
 
     .. versionadded:: 2.0
     """
-    return echo(style(text, **styles), file=file, nl=nl, err=err, color=color)
+    if message is not None:
+        message = style(message, **styles)
+    return echo(message, file=file, nl=nl, err=err, color=color)
 
 
 def edit(text=None, editor=None, env=None, require_save=True,

--- a/click/types.py
+++ b/click/types.py
@@ -358,7 +358,9 @@ class Path(ParamType):
     :param readable: if true, a readable check is performed.
     :param resolve_path: if this is true, then the path is fully resolved
                          before the value is passed onwards.  This means
-                         that it's absolute and symlinks are resolved.
+                         that it's absolute and symlinks are resolved.  It
+                         will not expand a tilde-prefix, as this is
+                         supposed to be done by the shell only.
     :param allow_dash: If this is set to `True`, a single dash to indicate
                        standard streams is permitted.
     :param type: optionally a string type that should be used to

--- a/click/types.py
+++ b/click/types.py
@@ -214,6 +214,59 @@ class IntRange(IntParamType):
         return 'IntRange(%r, %r)' % (self.min, self.max)
 
 
+class FloatParamType(ParamType):
+    name = 'float'
+
+    def convert(self, value, param, ctx):
+        try:
+            return float(value)
+        except (UnicodeError, ValueError):
+            self.fail('%s is not a valid floating point value' %
+                      value, param, ctx)
+
+    def __repr__(self):
+        return 'FLOAT'
+
+
+class FloatRange(FloatParamType):
+    """A parameter that works similar to :data:`click.FLOAT` but restricts
+    the value to fit into a range.  The default behavior is to fail if the
+    value falls outside the range, but it can also be silently clamped
+    between the two edges.
+
+    See :ref:`ranges` for an example.
+    """
+    name = 'float range'
+
+    def __init__(self, min=None, max=None, clamp=False):
+        self.min = min
+        self.max = max
+        self.clamp = clamp
+
+    def convert(self, value, param, ctx):
+        rv = FloatParamType.convert(self, value, param, ctx)
+        if self.clamp:
+            if self.min is not None and rv < self.min:
+                return self.min
+            if self.max is not None and rv > self.max:
+                return self.max
+        if self.min is not None and rv < self.min or \
+           self.max is not None and rv > self.max:
+            if self.min is None:
+                self.fail('%s is bigger than the maximum valid value '
+                          '%s.' % (rv, self.max), param, ctx)
+            elif self.max is None:
+                self.fail('%s is smaller than the minimum valid value '
+                          '%s.' % (rv, self.min), param, ctx)
+            else:
+                self.fail('%s is not in the valid range of %s to %s.'
+                          % (rv, self.min, self.max), param, ctx)
+        return rv
+
+    def __repr__(self):
+        return 'FloatRange(%r, %r)' % (self.min, self.max)
+
+
 class BoolParamType(ParamType):
     name = 'boolean'
 
@@ -229,20 +282,6 @@ class BoolParamType(ParamType):
 
     def __repr__(self):
         return 'BOOL'
-
-
-class FloatParamType(ParamType):
-    name = 'float'
-
-    def convert(self, value, param, ctx):
-        try:
-            return float(value)
-        except (UnicodeError, ValueError):
-            self.fail('%s is not a valid floating point value' %
-                      value, param, ctx)
-
-    def __repr__(self):
-        return 'FLOAT'
 
 
 class UUIDParameterType(ParamType):

--- a/click/utils.py
+++ b/click/utils.py
@@ -43,6 +43,7 @@ def make_str(value):
 
 
 def make_default_short_help(help, max_length=45):
+    """Return a condensed version of help string."""
     words = help.split()
     total_length = 0
     result = []
@@ -171,7 +172,7 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
 
     Primarily it means that you can print binary data as well as Unicode
     data on both 2.x and 3.x to the given file in the most appropriate way
-    possible.  This is a very carefree function as in that it will try its
+    possible.  This is a very carefree function in that it will try its
     best to not fail.  As of Click 6.0 this includes support for unicode
     output on the Windows console.
 

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -8,6 +8,6 @@
 <ul>
   <li><a href="http://click.pocoo.org/">The Click Website</a></li>
   <li><a href="http://pypi.python.org/pypi/click">click @ PyPI</a></li>
-  <li><a href="http://github.com/mitsuhiko/click">click @ github</a></li>
-  <li><a href="http://github.com/mitsuhiko/click/issues">Issue Tracker</a></li>
+  <li><a href="http://github.com/pallets/click">click @ github</a></li>
+  <li><a href="http://github.com/pallets/click/issues">Issue Tracker</a></li>
 </ul>

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -346,7 +346,7 @@ Global Context Access
 .. versionadded:: 5.0
 
 Starting with Click 5.0 it is possible to access the current context from
-anywhere within the same through through the use of the
+anywhere within the same thread through the use of the
 :func:`get_current_context` function which returns it.  This is primarily
 useful for accessing the context bound object as well as some flags that
 are stored on it to customize the runtime behavior.  For instance the

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -417,7 +417,7 @@ to not use the file type and manually open the file through
 
 For a more complex example that also improves upon handling of the
 pipelines have a look at the `imagepipe multi command chaining demo
-<https://github.com/mitsuhiko/click/tree/master/examples/imagepipe>`__ in
+<https://github.com/pallets/click/tree/master/examples/imagepipe>`__ in
 the Click repository.  It implements a pipeline based image editing tool
 that has a nice internal structure for the pipelines.
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -67,6 +67,9 @@ different behavior and some are supported out of the box:
 .. autoclass:: IntRange
    :noindex:
 
+.. autoclass:: FloatRange
+  :noindex:
+
 Custom parameter types can be implemented by subclassing
 :class:`click.ParamType`.  For simple cases, passing a Python function that
 fails with a `ValueError` is also supported, though discouraged.

--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -8,7 +8,7 @@ it suffers from the Unicode text model in Python 3.  All examples in the
 documentation were written so that they could run on both Python 2.x and
 Python 3.3 or higher.
 
-At the moment, it is strongly recommended is to use Python 2 for Click
+At the moment, it is strongly recommended to use Python 2 for Click
 utilities unless Python 3 is a hard requirement.
 
 .. _python3-limitations:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -79,7 +79,7 @@ And if you want to go back to the real world, use the following command::
 
     $ deactivate
 
-After doing this, the prompt of your shell should be as familar as before.
+After doing this, the prompt of your shell should be as familiar as before.
 
 Now, let's move on. Enter the following command to get Click activated in your
 virtualenv::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -102,23 +102,23 @@ Examples of Click applications can be found in the documentation as well
 as in the GitHub repository together with readme files:
 
 *   ``inout``: `File input and output
-    <https://github.com/mitsuhiko/click/tree/master/examples/inout>`_
+    <https://github.com/pallets/click/tree/master/examples/inout>`_
 *   ``naval``: `Port of docopt naval example
-    <https://github.com/mitsuhiko/click/tree/master/examples/naval>`_
+    <https://github.com/pallets/click/tree/master/examples/naval>`_
 *   ``aliases``: `Command alias example
-    <https://github.com/mitsuhiko/click/tree/master/examples/aliases>`_
+    <https://github.com/pallets/click/tree/master/examples/aliases>`_
 *   ``repo``: `Git-/Mercurial-like command line interface
-    <https://github.com/mitsuhiko/click/tree/master/examples/repo>`_
+    <https://github.com/pallets/click/tree/master/examples/repo>`_
 *   ``complex``: `Complex example with plugin loading
-    <https://github.com/mitsuhiko/click/tree/master/examples/complex>`_
+    <https://github.com/pallets/click/tree/master/examples/complex>`_
 *   ``validation``: `Custom parameter validation example
-    <https://github.com/mitsuhiko/click/tree/master/examples/validation>`_
+    <https://github.com/pallets/click/tree/master/examples/validation>`_
 *   ``colors``: `Colorama ANSI color support
-    <https://github.com/mitsuhiko/click/tree/master/examples/colors>`_
+    <https://github.com/pallets/click/tree/master/examples/colors>`_
 *   ``termui``: `Terminal UI functions demo
-    <https://github.com/mitsuhiko/click/tree/master/examples/termui>`_
+    <https://github.com/pallets/click/tree/master/examples/termui>`_
 *   ``imagepipe``: `Multi command chaining demo
-    <https://github.com/mitsuhiko/click/tree/master/examples/imagepipe>`_
+    <https://github.com/pallets/click/tree/master/examples/imagepipe>`_
 
 Basic Concepts
 --------------

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -266,7 +266,7 @@ streams respond to Unicode and binary data.
 
 Because of this, click provides the :func:`get_binary_stream` and
 :func:`get_text_stream` functions, which produce consistent results with
-different Python versions and for a wide variety pf terminal configurations.
+different Python versions and for a wide variety of terminal configurations.
 
 The end result is that these functions will always return a functional
 stream object (except in very odd cases in Python 3; see

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='Armin Ronacher',
     author_email='armin.ronacher@active-4.com',
     version=version,
-    url='http://github.com/mitsuhiko/click',
+    url='http://github.com/pallets/click',
     packages=['click'],
     description='A simple wrapper around optparse for '
                 'powerful command line utilities.',

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import click
+from click._bashcomplete import get_choices
+
+def test_basic():
+    @click.group()
+    @click.option('--global-opt')
+    def cli(global_opt):
+        pass
+
+    @cli.command()
+    @click.option('--local-opt')
+    def sub(local_opt):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '')) == ['sub']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--global-opt']
+    assert list(get_choices(cli, 'lol', ['sub'], '')) == []
+    assert list(get_choices(cli, 'lol', ['sub'], '-')) == ['--local-opt']

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -343,6 +343,39 @@ def test_int_range_option(runner):
     assert result.output == '0\n'
 
 
+def test_float_range_option(runner):
+    @click.command()
+    @click.option('--x', type=click.FloatRange(0, 5))
+    def cli(x):
+        click.echo(x)
+
+    result = runner.invoke(cli, ['--x=5.0'])
+    assert not result.exception
+    assert result.output == '5.0\n'
+
+    result = runner.invoke(cli, ['--x=6.0'])
+    assert result.exit_code == 2
+    assert 'Invalid value for "--x": 6.0 is not in the valid range of 0 to 5.\n' \
+        in result.output
+
+    @click.command()
+    @click.option('--x', type=click.FloatRange(0, 5, clamp=True))
+    def clamp(x):
+        click.echo(x)
+
+    result = runner.invoke(clamp, ['--x=5.0'])
+    assert not result.exception
+    assert result.output == '5.0\n'
+
+    result = runner.invoke(clamp, ['--x=6.0'])
+    assert not result.exception
+    assert result.output == '5\n'
+
+    result = runner.invoke(clamp, ['--x=-1.0'])
+    assert not result.exception
+    assert result.output == '0\n'
+
+
 def test_required_option(runner):
     @click.command()
     @click.option('--foo', required=True)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -397,3 +397,47 @@ def test_evaluation_order(runner):
         'normal1',
         'missing',
     ]
+
+
+def test_hidden_option(runner):
+    @click.command()
+    @click.option('--nope', hidden=True)
+    def cli(nope):
+        click.echo(nope)
+
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert '--nope' not in result.output
+
+
+def test_hidden_command(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command(hidden=True)
+    def nope():
+        pass
+
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert 'nope' not in result.output
+
+
+def test_hidden_group(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @cli.group(hidden=True)
+    def subgroup():
+        pass
+
+    @subgroup.command()
+    def nope():
+        pass
+
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert 'subgroup' not in result.output
+    assert 'nope' not in result.output

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -145,3 +145,38 @@ def test_formatting_empty_help_lines(runner):
         'Options:',
         '  --help  Show this message and exit.',
     ]
+
+
+def test_formatting_usage_error(runner):
+    @click.command()
+    @click.argument('arg')
+    def cmd(arg):
+        click.echo('arg:' + arg)
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        'Usage: cmd [OPTIONS] ARG',
+        'Try "cmd --help" for help.',
+        '',
+        'Error: Missing argument "arg".'
+    ]
+
+
+def test_formatting_usage_error_nested(runner):
+    @click.group()
+    def cmd():
+        pass
+
+    @cmd.command()
+    @click.argument('bar')
+    def foo(bar):
+        click.echo('foo:' + bar)
+
+    result = runner.invoke(cmd, ['foo'])
+    assert result.output.splitlines() == [
+        'Usage: cmd foo [OPTIONS] BAR',
+        'Try "cmd foo --help" for help.',
+        '',
+        'Error: Missing argument "bar".'
+    ]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -174,9 +174,41 @@ def test_formatting_usage_error_nested(runner):
         click.echo('foo:' + bar)
 
     result = runner.invoke(cmd, ['foo'])
+    assert result.exit_code == 2
     assert result.output.splitlines() == [
         'Usage: cmd foo [OPTIONS] BAR',
         'Try "cmd foo --help" for help.',
         '',
         'Error: Missing argument "bar".'
+    ]
+
+
+def test_formatting_usage_error_no_help(runner):
+    @click.command(add_help_option=False)
+    @click.argument('arg')
+    def cmd(arg):
+        click.echo('arg:' + arg)
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        'Usage: cmd [OPTIONS] ARG',
+        '',
+        'Error: Missing argument "arg".'
+    ]
+
+
+def test_formatting_usage_custom_help(runner):
+    @click.command(context_settings=dict(help_option_names=['--man']))
+    @click.argument('arg')
+    def cmd(arg):
+        click.echo('arg:' + arg)
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        'Usage: cmd [OPTIONS] ARG',
+        'Try "cmd --man" for help.',
+        '',
+        'Error: Missing argument "arg".'
     ]

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -12,3 +12,31 @@ def test_progressbar_strip_regression(runner, monkeypatch):
 
     monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
     assert label in runner.invoke(cli, []).output
+
+
+def test_progressbar_length_hint(runner, monkeypatch):
+    class Hinted(object):
+        def __init__(self, n):
+            self.items = list(range(n))
+
+        def __length_hint__(self):
+            return len(self.items)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.items:
+                return self.items.pop()
+            else:
+                raise StopIteration
+
+    @click.command()
+    def cli():
+        with click.progressbar(Hinted(10), label='test') as progress:
+            for thing in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+    result = runner.invoke(cli, [])
+    assert result.exception is None

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -31,6 +31,8 @@ def test_progressbar_length_hint(runner, monkeypatch):
             else:
                 raise StopIteration
 
+        next = __next__
+
     @click.command()
     def cli():
         with click.progressbar(Hinted(10), label='test') as progress:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -42,3 +42,10 @@ def test_progressbar_length_hint(runner, monkeypatch):
     monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
     result = runner.invoke(cli, [])
     assert result.exception is None
+
+
+def test_secho(runner):
+    with runner.isolation() as out:
+        click.secho(None, nl=False)
+        bytes = out.getvalue()
+        assert bytes == b''


### PR DESCRIPTION
- codecs.open returns a StreamReaderWriter when used with encoding, this object doesn't have a `__len__` attribute, so calling the `len` function on it result in an `AttributeError` instead of a `TypeError`
- this will catch the AttributeError as well as the TypeError instead of only catching the later
- Fixes: https://github.com/pallets/click/issues/636
