### PR TITLE
Fix #628: Bash completion for nested commands broken

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -30,8 +30,8 @@ def get_completion_script(prog_name, complete_var):
 
 def resolve_ctx(cli, prog_name, args):
     ctx = cli.make_context(prog_name, args, resilient_parsing=True)
-    while ctx.args + ctx.protected_args and isinstance(ctx.command, MultiCommand):
-        a = ctx.args + ctx.protected_args
+    while ctx.protected_args + ctx.args and isinstance(ctx.command, MultiCommand):
+        a = ctx.protected_args + ctx.args
         cmd = ctx.command.get_command(ctx, a[0])
         if cmd is None:
             return None

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -3,7 +3,18 @@
 import click
 from click._bashcomplete import get_choices
 
-def test_basic():
+
+def test_single_command():
+    @click.command()
+    @click.option('--local-opt')
+    def cli(local_opt):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--local-opt']
+    assert list(get_choices(cli, 'lol', [], '')) == []
+
+
+def test_small_chain():
     @click.group()
     @click.option('--global-opt')
     def cli(global_opt):
@@ -18,3 +29,34 @@ def test_basic():
     assert list(get_choices(cli, 'lol', [], '-')) == ['--global-opt']
     assert list(get_choices(cli, 'lol', ['sub'], '')) == []
     assert list(get_choices(cli, 'lol', ['sub'], '-')) == ['--local-opt']
+
+
+def test_long_chain():
+    @click.group('cli')
+    @click.option('--cli-opt')
+    def cli(cli_opt):
+        pass
+
+    @cli.group('asub')
+    @click.option('--asub-opt')
+    def asub(asub_opt):
+        pass
+
+    @asub.group('bsub')
+    @click.option('--bsub-opt')
+    def bsub(bsub_opt):
+        pass
+
+    @bsub.command('csub')
+    @click.option('--csub-opt')
+    def csub(csub_opt):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt']
+    assert list(get_choices(cli, 'lol', [], '')) == ['asub']
+    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt']
+    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '')) == ['csub']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '-')) == ['--csub-opt']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '')) == []


### PR DESCRIPTION
When concatenating protected_args and args, protected_args
should be prepended. Otherwise the arguments are out
of order and an incorrect subcommand is choosen.
