### PR TITLE
add support for custom bash completers and choices

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1260,7 +1260,8 @@ class Parameter(object):
 
     def __init__(self, param_decls=None, type=None, required=False,
                  default=None, callback=None, nargs=None, metavar=None,
-                 expose_value=True, is_eager=False, envvar=None):
+                 expose_value=True, is_eager=False, envvar=None,
+                 completer=None, choices=None):
         self.name, self.opts, self.secondary_opts = \
             self._parse_decls(param_decls or (), expose_value)
 
@@ -1283,6 +1284,8 @@ class Parameter(object):
         self.is_eager = is_eager
         self.metavar = metavar
         self.envvar = envvar
+        self.completer = completer
+        self.choices = choices
 
     @property
     def human_readable_name(self):
@@ -1414,6 +1417,15 @@ class Parameter(object):
 
     def get_usage_pieces(self, ctx):
         return []
+
+    def get_completion(self):
+        if self.completer:
+            for thing in self.completer():
+                yield str(thing)
+        if self.choices:
+            for thing in self.choices:
+                yield str(thing)
+
 
 
 class Option(Parameter):

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -60,3 +60,31 @@ def test_long_chain():
     assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '')) == ['csub']
     assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '-')) == ['--csub-opt']
     assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '')) == []
+
+
+def test_completer():
+
+    def custom_completer():
+        yield 'custom'
+        for i in [0, 1, 2]:
+            yield i
+        yield 'bye'
+
+    @click.command()
+    @click.option('--local-opt', completer=custom_completer)
+    def cli(local_opt):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--local-opt']
+    assert list(get_choices(cli, 'lol', ['--local-opt'], '')) == ['custom', '0', '1', '2', 'bye']
+
+
+def test_choices():
+
+    @click.command()
+    @click.option('--local-opt', choices=['foo', 'bar', 'spam', 'eggs'])
+    def cli(local_opt):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--local-opt']
+    assert list(get_choices(cli, 'lol', ['--local-opt'], '')) == ['foo', 'bar', 'spam', 'eggs']


### PR DESCRIPTION
After writing this I noticed #428  which mentioned #241 but thought I'd submit this pull request anyway.

This one uses `completer` and `choices` as keyword arguments using the same terminology as [argcomplete](https://github.com/kislyuk/argcomplete)

Dunno how hacky this is, but I got it to work for me.  I basically pass some more context (the last parsed argument) to `get_choices` which it uses to look up either `completer` or `choices` attributes on the option.
