### PR TITLE
Fix test runner not saving caller env correctly

### DIFF
--- a/click/testing.py
+++ b/click/testing.py
@@ -213,7 +213,7 @@ class CliRunner(object):
         old_env = {}
         try:
             for key, value in iteritems(env):
-                old_env[key] = os.environ.get(value)
+                old_env[key] = os.environ.get(key)
                 if value is None:
                     try:
                         del os.environ[key]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -183,3 +184,21 @@ def test_exit_code_and_output_from_sys_exit():
     result = runner.invoke(cli_no_error)
     assert result.exit_code == 0
     assert result.output == 'hello world\n'
+
+
+def test_env():
+    @click.command()
+    def cli_env():
+        click.echo('ENV=%s' % os.environ['TEST_CLICK_ENV'])
+
+    runner = CliRunner()
+
+    env_orig = dict(os.environ)
+    env = dict(env_orig)
+    assert 'TEST_CLICK_ENV' not in env
+    env['TEST_CLICK_ENV'] = 'some_value'
+    result = runner.invoke(cli_env, env=env)
+    assert result.exit_code == 0
+    assert result.output == 'ENV=some_value\n'
+
+    assert os.environ == env_orig


### PR DESCRIPTION
isolate() captures current env variable values, overwrites them, yields,
then restores them. Unfortunately the capturing code was broken and the
env variables were wiped out during the restore phase.
