### PR TITLE
Added a spinner utility

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -37,7 +37,7 @@ from .utils import echo, get_binary_stream, get_text_stream, open_file, \
 # Terminal functions
 from .termui import prompt, confirm, get_terminal_size, echo_via_pager, \
      progressbar, clear, style, unstyle, secho, edit, launch, getchar, \
-     pause
+     pause, spinner
 
 # Exceptions
 from .exceptions import ClickException, UsageError, BadParameter, \
@@ -75,7 +75,7 @@ __all__ = [
     # Terminal functions
     'prompt', 'confirm', 'get_terminal_size', 'echo_via_pager',
     'progressbar', 'clear', 'style', 'unstyle', 'secho', 'edit', 'launch',
-    'getchar', 'pause',
+    'getchar', 'pause', 'spinner'
 
     # Exceptions
     'ClickException', 'UsageError', 'BadParameter', 'FileError',

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -11,8 +11,11 @@
 """
 import os
 import sys
+import threading
 import time
 import math
+import itertools
+
 from ._compat import _default_text_stdout, range_type, PY2, isatty, \
      open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types
 from .utils import echo
@@ -45,6 +48,34 @@ def _length_hint(obj):
            hint < 0:
             return None
         return hint
+
+
+class Spinner(object):
+    spinner_cycle = itertools.cycle(['-', '/', '|', '\\'])
+
+    def __init__(self):
+        self.stop_running = threading.Event()
+        self.spin_thread = threading.Thread(target=self.init_spin)
+
+    def start(self):
+        self.spin_thread.start()
+
+    def stop(self):
+        self.stop_running.set()
+        self.spin_thread.join()
+
+    def init_spin(self):
+        while not self.stop_running.is_set():
+            sys.stdout.write(next(self.spinner_cycle))
+            sys.stdout.flush()
+            time.sleep(0.25)
+            sys.stdout.write('\b')
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
 
 
 class ProgressBar(object):

--- a/click/termui.py
+++ b/click/termui.py
@@ -213,6 +213,21 @@ def echo_via_pager(text, color=None):
     return pager(text + '\n', color)
 
 
+def spinner():
+    """This function creates a context manager that is used to display a
+    spinner as long as the context has not exited.
+
+    Example usage::
+
+        with spinner():
+            do_something()
+            do_something_else()
+
+    """
+    from ._termui_impl import Spinner
+    return Spinner()
+
+
 def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 show_percent=None, show_pos=False,
                 item_show_func=None, fill_char='#', empty_char='-',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,8 @@ Utilities
 
 .. autofunction:: progressbar
 
+.. autofunction:: spinner
+
 .. autofunction:: clear
 
 .. autofunction:: style

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -396,3 +396,18 @@ iterating directly over it::
         for archive in zip_file:
             archive.extract()
             bar.update(archive.size)
+
+
+Showing Spinners
+----------------
+
+Sometimes you would just like to show the user some progress, but a progress bar
+is not suitable because you don't know how much longer it would take. In these cases
+you might want to display a simple spinner using the :func:`spinner` function.
+
+Example usage::
+
+    with spinner():
+            do_something()
+            do_something_else()
+

--- a/examples/termui/termui.py
+++ b/examples/termui/termui.py
@@ -34,6 +34,18 @@ def pager():
 
 
 @cli.command()
+def spinner():
+    """Demonstrates using the spinner."""
+    def do_work():
+        time.sleep(3)
+
+    click.echo('starting work')
+    with click.spinner():
+        do_work()
+    click.echo('all done!')
+
+
+@cli.command()
 @click.option('--count', default=8000, type=click.IntRange(1, 100000),
               help='The number of items to process.')
 def progress(count):

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1,6 +1,18 @@
 import click
 
 
+def test_spinner(runner, monkeypatch):
+
+    @click.command()
+    def cli():
+        with click.spinner():
+            for thing in range(10):
+                pass
+
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+
+
 def test_progressbar_strip_regression(runner, monkeypatch):
     label = '    padded line'
 


### PR DESCRIPTION
Sometimes you would just like to show the user some progress, but a progress bar is not suitable because you don’t know how much longer it would take. In these cases you might want to display a simple spinner using the `spinner()` function.

Example usage:

``` py
with click.spinner():
        do_something()
        do_something_else()
```

It looks like this:

![spinner](https://cloud.githubusercontent.com/assets/1288133/18229827/29629cd4-728f-11e6-8007-6c85ac50565c.gif)

Spinner class based on on a [gist by @cevaris](https://gist.github.com/cevaris/79700649f0543584009e).
