### PR TITLE
Recognise cygwin platform and open urls accordingly

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -8,6 +8,7 @@ from weakref import WeakKeyDictionary
 
 PY2 = sys.version_info[0] == 2
 WIN = sys.platform.startswith('win')
+CYGWIN = sys.platform.startswith('cygwin')
 DEFAULT_COLUMNS = 80
 
 

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -14,7 +14,8 @@ import sys
 import time
 import math
 from ._compat import _default_text_stdout, range_type, PY2, isatty, \
-     open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types
+     open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types, \
+     CYGWIN
 from .utils import echo
 from .exceptions import ClickException
 
@@ -478,6 +479,13 @@ def open_url(url, wait=False, locate=False):
             args = 'start %s "" "%s"' % (
                 wait and '/WAIT' or '', url.replace('"', ''))
         return os.system(args)
+    elif CYGWIN:
+        if locate:
+            pass
+        else:
+            args = 'cygstart %s "%s"' % (
+                wait and '-w' or '', url.replace('"', ''))
+            return os.system(args)
 
     try:
         if locate:

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -481,11 +481,12 @@ def open_url(url, wait=False, locate=False):
         return os.system(args)
     elif CYGWIN:
         if locate:
-            pass
+            url = _unquote_file(url)
+            args = 'cygstart "%s"' % (os.path.dirname(url).replace('"', ''))
         else:
             args = 'cygstart %s "%s"' % (
                 wait and '-w' or '', url.replace('"', ''))
-            return os.system(args)
+        return os.system(args)
 
     try:
         if locate:


### PR DESCRIPTION
Currently, click does not recognise when it is run inside a [cygwin](https://www.cygwin.com/) terminal.
This PR fixes [launch](http://click.pocoo.org/5/utils/#launching-applications). Instead of doing nothing when run inside a cygwin terminal, it properly opens the default application (picture viewer, browser, etc)

I did not find a way to make `locate` option work though so I just let it pass to the default case (where nothing happens).
