### PR TITLE
Add exception assert to test_multicommand_chaining

### DIFF
--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -220,33 +220,33 @@ def test_multicommand_arg_behavior(runner):
     ]
 
 
-@pytest.mark.xfail
 def test_multicommand_chaining(runner):
     @click.group(chain=True)
     def cli():
         debug()
 
-    @cli.group()
-    def l1a():
-        debug()
+    with pytest.raises(RuntimeError):
+        @cli.group()
+        def l1a():
+            debug()
 
-    @l1a.command()
-    def l2a():
-        debug()
+        @l1a.command()
+        def l2a():
+            debug()
 
-    @l1a.command()
-    def l2b():
-        debug()
+        @l1a.command()
+        def l2b():
+            debug()
 
-    @cli.command()
-    def l1b():
-        debug()
+        @cli.command()
+        def l1b():
+            debug()
 
-    result = runner.invoke(cli, ['l1a', 'l2a', 'l1b'])
-    assert not result.exception
-    assert result.output.splitlines() == [
-        'cli=',
-        'l1a=',
-        'l2a=',
-        'l1b=',
-    ]
+        result = runner.invoke(cli, ['l1a', 'l2a', 'l1b'])
+        assert not result.exception
+        assert result.output.splitlines() is not [
+            'cli=',
+            'l1a=',
+            'l2a=',
+            'l1b=',
+        ]


### PR DESCRIPTION
Add runtime exception assertion to `test_multicommand_chaining`.

I believe that this makes the test more expressive in conveying:
- that a runtime exception is expected to be thrown by the test;
- which section of the test is expected to throw the exception.
