### PR TITLE
Allow empty responses from prompts

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -34,7 +34,8 @@ def _build_prompt(text, suffix, show_default=False, default=None):
 def prompt(text, default=None, hide_input=False,
            confirmation_prompt=False, type=None,
            value_proc=None, prompt_suffix=': ',
-           show_default=True, err=False):
+           show_default=True, err=False,
+           allow_empty=False):
     """Prompts a user for input.  This is a convenience function that can
     be used to prompt a user for input later.
 
@@ -61,6 +62,8 @@ def prompt(text, default=None, hide_input=False,
     :param show_default: shows or hides the default value in the prompt.
     :param err: if set to true the file defaults to ``stderr`` instead of
                 ``stdout``, the same as with echo.
+    :param allow_empty: if set to true and the user doesn't input anything,
+                        return ``None``.
     """
     result = None
 
@@ -94,6 +97,8 @@ def prompt(text, default=None, hide_input=False,
             # that really makes sense.
             elif default is not None:
                 return default
+            elif allow_empty:
+                return None
         try:
             result = value_proc(value)
         except UsageError as e:


### PR DESCRIPTION
This adds a new optional parameter to click.prompt() that allows a
developer to specify that it's okay for a user to type nothing into a
prompt, and to receive None back to indicate that that is what happened.

I believe a similar thing can be achieved by setting the default value
for the prompt to an empty string (`default=''`) as the code appears to
check to specifically check if the default is `None` before using it.
I believe it is better to make this situation explicit, but if other
developers feel as though this is unwarranted, I am happy for this
patch to be rejected.
