### PR TITLE
Add support to invoke args as string

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Version 7.0
 - `secho`'s first argument can now be `None`, like in `echo`.
 - Usage errors now hint at the `--help` option.
 - ``launch`` now works properly under Cygwin. See #650.
+- `CliRunner.invoke` now may receive `args` as a string representing
+  a Unix shell command. See #664.
 
 Version 6.7
 -----------

--- a/click/testing.py
+++ b/click/testing.py
@@ -3,8 +3,9 @@ import sys
 import shutil
 import tempfile
 import contextlib
+import shlex
 
-from ._compat import iteritems, PY2
+from ._compat import iteritems, PY2, string_types
 
 
 # If someone wants to vendor click, we want to ensure the
@@ -260,7 +261,10 @@ class CliRunner(object):
            The ``color`` parameter was added.
 
         :param cli: the command to invoke
-        :param args: the arguments to invoke
+        :param args: the arguments to invoke. It may be given as an iterable
+                     or a string. When given as string it will be interpreted
+                     as a Unix shell command. More details at
+                     :func:`shlex.split`.
         :param input: the input data for `sys.stdin`.
         :param env: the environment overrides.
         :param catch_exceptions: Whether to catch any other exceptions than
@@ -273,6 +277,9 @@ class CliRunner(object):
         with self.isolation(input=input, env=env, color=color) as out:
             exception = None
             exit_code = 0
+
+            if isinstance(args, string_types):
+                args = shlex.split(args)
 
             try:
                 cli.main(args=args or (),

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -202,3 +202,23 @@ def test_env():
     assert result.output == 'ENV=some_value\n'
 
     assert os.environ == env_orig
+
+
+@pytest.mark.parametrize('args, expected_output', [
+    (None, 'bar\n'),
+    ([], 'bar\n'),
+    ('', 'bar\n'),
+    (['--foo', 'one two'], 'one two\n'),
+    ('--foo "one two"', 'one two\n'),
+])
+def test_args(args, expected_output):
+
+    @click.command()
+    @click.option('--foo', default='bar')
+    def cli_args(foo):
+        click.echo(foo)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_args, args=args)
+    assert result.exit_code == 0
+    assert result.output == expected_output


### PR DESCRIPTION
The idea is providing a more "directly" way to use `CliRunner.invoke`. Depending on how many arguments/options you have it is really annoying writing all of them as a list

```
CliRunner().invoke(mycmd, ["mygroup", "foo", "bar", "--hey", "ya"])
```

since all I want is

```
CliRunner().invoke(mycmd, "mygroup foo bar --hey ya")
```

Sure, I can just add a `.split()` at the end (and this PR is all about this) but why not adding this as default?

Also took the chance and added tests related to `invoke(args)` since there was none (at least as far as I can see).
