### PR TITLE
Argument.make_metavar() defaults to type metavar

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1719,7 +1719,9 @@ class Argument(Parameter):
     def make_metavar(self):
         if self.metavar is not None:
             return self.metavar
-        var = self.name.upper()
+        var = self.type.get_metavar(self)
+        if not var:
+            var = self.name.upper()
         if not self.required:
             var = '[%s]' % var
         if self.nargs != 1:


### PR DESCRIPTION
Fixes `Argument.make_metavar()` to respect the default metavar set by a custom type ahead of defaulting to `Argument.name`
Fixes #674

I think this is the most sensible way to fix this, as it makes `Argument` behavior more similar to `Option` behavior and default `Parameter` behavior.
