### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/click/parser.py
+++ b/click/parser.py
@@ -221,7 +221,7 @@ class OptionParser(object):
             self.ignore_unknown_options = ctx.ignore_unknown_options
         self._short_opt = {}
         self._long_opt = {}
-        self._opt_prefixes = set(['-', '--'])
+        self._opt_prefixes = {'-', '--'}
         self._args = []
 
     def add_option(self, opts, dest, action=None, nargs=1, const=None,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -29,11 +29,11 @@ import json
 click.echo(json.dumps(rv))
 '''
 
-ALLOWED_IMPORTS = set([
+ALLOWED_IMPORTS = {
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
     'threading', 'colorama', 'errno'
-])
+}
 
 if WIN:
     ALLOWED_IMPORTS.update(['ctypes', 'ctypes.wintypes', 'msvcrt', 'time',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy
+envlist = py27,py33,py34,pypy
 
 [testenv]
 passenv = LANG


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
