### PR TITLE
Guard against attribute error when getting default program name. 

### DIFF
--- a/click/testing.py
+++ b/click/testing.py
@@ -126,7 +126,7 @@ class CliRunner(object):
         for it.  The default is the `name` attribute or ``"root"`` if not
         set.
         """
-        return getattr(cli, 'name', 'root')
+        return getattr(cli, 'name', 'root') or 'root'
 
     def make_env(self, overrides=None):
         """Returns the environment overrides for invoking a script."""

--- a/click/testing.py
+++ b/click/testing.py
@@ -126,7 +126,7 @@ class CliRunner(object):
         for it.  The default is the `name` attribute or ``"root"`` if not
         set.
         """
-        return cli.name or 'root'
+        return getattr(cli, 'name', 'root')
 
     def make_env(self, overrides=None):
         """Returns the environment overrides for invoking a script."""


### PR DESCRIPTION
Apologies for not opening up an issue first but it seemed a simple fix. 

I'm sure this is an extreme edge case, but I inherited a project built with click and I was putting some work in getting the testing to actually run when I ran into this issue.

My tests showed:
```
E           assert '' == 0
E            +  where '' = <Result AttributeError("'module' object has no attribute 'name'",)>.output
```

When I dug a little deeper I found the culprit to be the line 129 in `testing.py`. 

Ran tests with `tox`, everything seems okay. 

