### PR TITLE
Derive "param_hint" in errors from param itself

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1431,6 +1431,13 @@ class Parameter(object):
     def get_usage_pieces(self, ctx):
         return []
 
+    def get_error_hint(self, ctx):
+        """Get a stringified version of the param for use in error messages to
+        indicate which param caused the error.
+        """
+        hint_list = self.opts or [self.human_readable_name]
+        return ' / '.join('"%s"' % x for x in hint_list)
+
 
 class Option(Parameter):
     """Options are usually optional values on the command line and
@@ -1754,6 +1761,9 @@ class Argument(Parameter):
 
     def get_usage_pieces(self, ctx):
         return [self.make_metavar()]
+
+    def get_error_hint(self, ctx):
+        return self.make_metavar()
 
     def add_to_parser(self, parser, ctx):
         parser.add_argument(dest=self.name, nargs=self.nargs,

--- a/click/core.py
+++ b/click/core.py
@@ -1763,7 +1763,7 @@ class Argument(Parameter):
         return [self.make_metavar()]
 
     def get_error_hint(self, ctx):
-        return self.make_metavar()
+        return '"%s"' % self.make_metavar()
 
     def add_to_parser(self, parser, ctx):
         parser.add_argument(dest=self.name, nargs=self.nargs,

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -2,6 +2,12 @@ from ._compat import PY2, filename_to_ui, get_text_stderr
 from .utils import echo
 
 
+def _join_param_hints(param_hint):
+    if isinstance(param_hint, (tuple, list)):
+        return ' / '.join('"%s"' % x for x in param_hint)
+    return param_hint
+
+
 class ClickException(Exception):
     """An exception that Click can handle and show to the user."""
 
@@ -92,11 +98,11 @@ class BadParameter(UsageError):
         if self.param_hint is not None:
             param_hint = self.param_hint
         elif self.param is not None:
-            param_hint = self.param.opts or [self.param.human_readable_name]
+            param_hint = self.param.get_error_hint(self.ctx)
         else:
             return 'Invalid value: %s' % self.message
-        if isinstance(param_hint, (tuple, list)):
-            param_hint = ' / '.join('"%s"' % x for x in param_hint)
+        param_hint = _join_param_hints(param_hint)
+
         return 'Invalid value for %s: %s' % (param_hint, self.message)
 
 
@@ -121,11 +127,10 @@ class MissingParameter(BadParameter):
         if self.param_hint is not None:
             param_hint = self.param_hint
         elif self.param is not None:
-            param_hint = self.param.opts or [self.param.human_readable_name]
+            param_hint = self.param.get_error_hint(self.ctx)
         else:
             param_hint = None
-        if isinstance(param_hint, (tuple, list)):
-            param_hint = ' / '.join('"%s"' % x for x in param_hint)
+        param_hint = _join_param_hints(param_hint)
 
         param_type = self.param_type
         if param_type is None and self.param is not None:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -188,7 +188,7 @@ def test_empty_nargs(runner):
 
     result = runner.invoke(cmd2, [])
     assert result.exit_code == 2
-    assert 'Missing argument "arg"' in result.output
+    assert 'Missing argument "ARG..."' in result.output
 
 
 def test_missing_arg(runner):
@@ -199,7 +199,7 @@ def test_missing_arg(runner):
 
     result = runner.invoke(cmd, [])
     assert result.exit_code == 2
-    assert 'Missing argument "arg".' in result.output
+    assert 'Missing argument "ARG".' in result.output
 
 
 def test_implicit_non_required(runner):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -163,7 +163,7 @@ def test_formatting_usage_error(runner):
     ]
 
 
-def test_formatting_usage_error_metavar(runner):
+def test_formatting_usage_error_metavar_missing_arg(runner):
     """
     :author: @r-m-n
     Including attribution to #612
@@ -180,6 +180,22 @@ def test_formatting_usage_error_metavar(runner):
         'Try "cmd --help" for help.',
         '',
         'Error: Missing argument "metavar".'
+    ]
+
+
+def test_formatting_usage_error_metavar_bad_arg(runner):
+    @click.command()
+    @click.argument('arg', type=click.INT, metavar='metavar')
+    def cmd(arg):
+        pass
+
+    result = runner.invoke(cmd, ['3.14'])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        'Usage: cmd [OPTIONS] metavar',
+        'Try "cmd --help" for help.',
+        '',
+        'Error: Invalid value for "metavar": 3.14 is not a valid integer'
     ]
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -159,7 +159,27 @@ def test_formatting_usage_error(runner):
         'Usage: cmd [OPTIONS] ARG',
         'Try "cmd --help" for help.',
         '',
-        'Error: Missing argument "arg".'
+        'Error: Missing argument "ARG".'
+    ]
+
+
+def test_formatting_usage_error_metavar(runner):
+    """
+    :author: @r-m-n
+    Including attribution to #612
+    """
+    @click.command()
+    @click.argument('arg', metavar='metavar')
+    def cmd(arg):
+        pass
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        'Usage: cmd [OPTIONS] metavar',
+        'Try "cmd --help" for help.',
+        '',
+        'Error: Missing argument "metavar".'
     ]
 
 
@@ -179,7 +199,7 @@ def test_formatting_usage_error_nested(runner):
         'Usage: cmd foo [OPTIONS] BAR',
         'Try "cmd foo --help" for help.',
         '',
-        'Error: Missing argument "bar".'
+        'Error: Missing argument "BAR".'
     ]
 
 
@@ -194,7 +214,7 @@ def test_formatting_usage_error_no_help(runner):
     assert result.output.splitlines() == [
         'Usage: cmd [OPTIONS] ARG',
         '',
-        'Error: Missing argument "arg".'
+        'Error: Missing argument "ARG".'
     ]
 
 
@@ -210,5 +230,5 @@ def test_formatting_usage_custom_help(runner):
         'Usage: cmd [OPTIONS] ARG',
         'Try "cmd --man" for help.',
         '',
-        'Error: Missing argument "arg".'
+        'Error: Missing argument "ARG".'
     ]


### PR DESCRIPTION
Rather than trying to apply the same logic to all param types, trying to extract a meaningful value from Parameter.opts even for Arguments, make this a function computed against the Parameter itself. Then, when it's time to specialize it to use the metavar for Arguments, we just need to override the function.
Also unify a small amount of logic being shared among exception classes.
Fully backwards compatible, except for the change to error text on Arguments, which is the intended effect.

Grabs a test out of #612 which checks that this works as intended.

Resolves #704, #598, and #612