### PR TITLE
Disabled sys._getframe() on Python interpreters that don't support it

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ Click Changelog
 
 This contains all major version changes between Click releases.
 
+Version 6.8
+-----------
+
+(bugfix release; yet to be released)
+
+- Disabled sys._getframes() on Python interpreters that don't support it. See
+  #728.
+
 Version 6.7
 -----------
 

--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -14,6 +14,8 @@ click = sys.modules[__name__.rsplit('.', 1)[0]]
 
 def _find_unicode_literals_frame():
     import __future__
+    if not hasattr(sys, '_getframe'):  # not all Python implementations have it
+        return 0
     frm = sys._getframe(1)
     idx = 1
     while frm is not None:

--- a/click/decorators.py
+++ b/click/decorators.py
@@ -235,7 +235,11 @@ def version_option(version=None, *param_decls, **attrs):
     :param others: everything else is forwarded to :func:`option`.
     """
     if version is None:
-        module = sys._getframe(1).f_globals.get('__name__')
+        if hasattr(sys, '_getframe'):
+            module = sys._getframe(1).f_globals.get('__name__')
+        else:
+            module = ''
+
     def decorator(f):
         prog_name = attrs.pop('prog_name', None)
         message = attrs.pop('message', '%(prog)s, version %(version)s')


### PR DESCRIPTION
sys._getframe() is an implementation detail of CPython, which has been copied by some but not all Python interpreters. Notably IronPython does not support it.

This simple patch allows the library to function on IronPython with minimal side effects. It disables a unicode check from the future module (which is not likely to happen on that platform), and disables autodetecting module version strings in the version option decorator (which could fail anyway).