### PR TITLE
fix for #732

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -372,10 +372,12 @@ def _nullpager(stream, text, color):
 class Editor(object):
 
     def __init__(self, editor=None, env=None, require_save=True,
+                 nano_autosave=False,
                  extension='.txt'):
         self.editor = editor
         self.env = env
         self.require_save = require_save
+        self.nano_autosave = nano_autosave
         self.extension = extension
 
     def get_editor(self):
@@ -396,7 +398,7 @@ class Editor(object):
         import subprocess
         editor = self.get_editor()
         # Allow nano to skip the save prompt if save is not required
-        if editor == 'nano' and not self.require_save:
+        if editor == 'nano' and self.nano_autosave:
             no_save = '-t'
         else:
             no_save = ''

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -395,13 +395,18 @@ class Editor(object):
     def edit_file(self, filename):
         import subprocess
         editor = self.get_editor()
+        # Allow nano to skip the save prompt if save is not required
+        if editor == 'nano' and not self.require_save:
+            no_save = '-t'
+        else:
+            no_save = ''
         if self.env:
             environ = os.environ.copy()
             environ.update(self.env)
         else:
             environ = None
         try:
-            c = subprocess.Popen('%s "%s"' % (editor, filename),
+            c = subprocess.Popen('%s %s "%s"' % (editor, no_save, filename),
                                  env=environ, shell=True)
             exit_code = c.wait()
             if exit_code != 0:

--- a/click/termui.py
+++ b/click/termui.py
@@ -431,7 +431,7 @@ def secho(message=None, file=None, nl=True, err=False, color=None, **styles):
 
 
 def edit(text=None, editor=None, env=None, require_save=True,
-         extension='.txt', filename=None):
+         nano_autosave=False, extension='.txt', filename=None):
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating
     system search path is used for finding the executable) it overrides
@@ -448,10 +448,13 @@ def edit(text=None, editor=None, env=None, require_save=True,
 
     :param text: the text to edit.
     :param editor: optionally the editor to use.  Defaults to automatic
-                   detection.
+                   detection based on $EDITOR and $VISUAL envvars.
     :param env: environment variables to forward to the editor.
     :param require_save: if this is true, then not saving in the editor
                          will make the return value become `None`.
+    :param nano_autosave: if True and the editor is GNU nano, then changes
+                          will be saved automatically on exit, without
+                          asking the user. (equiv. of nano --tempfile option).
     :param extension: the extension to tell the editor about.  This defaults
                       to `.txt` but changing this might change syntax
                       highlighting.
@@ -461,7 +464,7 @@ def edit(text=None, editor=None, env=None, require_save=True,
     """
     from ._termui_impl import Editor
     editor = Editor(editor=editor, env=env, require_save=require_save,
-                    extension=extension)
+                    nano_autosave=nano_autosave, extension=extension)
     if filename is None:
         return editor.edit(text)
     editor.edit_file(filename)


### PR DESCRIPTION
makes click.edit(require_save=False) make nano use the "-t" / "--tempfile" parameter and not ask for saving on exit