### PR TITLE
Allow unspecified values for composite types

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1298,7 +1298,7 @@ class Parameter(object):
         metavar = self.type.get_metavar(self)
         if metavar is None:
             metavar = self.type.name.upper()
-        if self.nargs != 1:
+        if self.nargs != 1 and not self.type.is_composite:
             metavar += '...'
         return metavar
 

--- a/click/core.py
+++ b/click/core.py
@@ -1334,8 +1334,8 @@ class Parameter(object):
                                 'not supported; nargs needs to be set to '
                                 'a fixed value > 1.' % self.nargs)
             if self.multiple:
-                return tuple(self.type(x or (), self, ctx) for x in value or ())
-            return self.type(value or (), self, ctx)
+                return tuple(self.type(x, self, ctx) for x in value or ())
+            return self.type(value, self, ctx) or ()
 
         def _convert(value, level):
             if level == 0:

--- a/click/types.py
+++ b/click/types.py
@@ -455,13 +455,13 @@ class Tuple(CompositeParamType):
 
     :param types: a list of types that should be used for the tuple items.
     """
+    name = 'tuple'
 
     def __init__(self, types):
         self.types = [convert_type(ty) for ty in types]
 
-    @property
-    def name(self):
-        return "<" + " ".join(ty.name for ty in self.types) + ">"
+    def get_metavar(self, param):
+        return '<%s>' % ' '.join(ty.name for ty in self.types).upper()
 
     @property
     def arity(self):

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -59,13 +59,18 @@ def test_nargs_tup_composite(runner):
         @click.command()
         @click.argument('item', **opts)
         def copy(item):
-            click.echo('name=%s id=%d' % item)
+            if item:
+                click.echo('name=%s id=%d' % item)
 
         result = runner.invoke(copy, ['peter', '1'])
         assert not result.exception
         assert result.output.splitlines() == [
             'name=peter id=1',
         ]
+
+        result = runner.invoke(copy, [])
+        assert result.exit_code == 2
+        assert 'Missing argument "item"' in result.output
 
 
 def test_nargs_err(runner):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -63,6 +63,25 @@ def test_nargs_tup_composite_mult(runner):
     ]
 
 
+def test_nargs_tup_composite(runner):
+    @click.command()
+    @click.option('--item', type=(str, int))
+    def copy(item):
+        assert type(item) is tuple
+        if item:
+            click.echo('name=%s id=%d' % item)
+
+    result = runner.invoke(copy, ['--item', 'peter', '1'])
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'name=peter id=1',
+    ]
+
+    result = runner.invoke(copy, [])
+    assert not result.exception
+    assert result.exit_code == 0
+
+
 def test_counting(runner):
     @click.command()
     @click.option('-v', count=True, help='Verbosity',


### PR DESCRIPTION
With this, behavior is (or should be) similar to when only `nargs` is used. The `Tuple` parameter type can't actually handle empty tuples and thus we get the `TypeError` exception about differing value length and type arity.

Hopefully this fixes #472 but I'm not sure if this is the correct approach into fixing this since composite parameter types aren't exactly required to return tuples. Besides, ideally, for `nargs` unequal to 1 `nargs` parameters should be designed on top of the `Tuple` parameter type, in my opinion, and like any other type without defaults, composite types should return `None` when unspecified in the command line (unless `multiple` is `True`, which, as is already the case, should return an empty tuple). Of course that's a way different approach and I'd rather discuss that in here first.

I'm definitely open to suggestions or something as I'm not really familiar with `click`'s internals. All tests runs passed for me so I hope I didn't break anything.

(Also, last commit can be ignored if necessary, I just found it appropriate in this case.)