### PR TITLE
Fix bash completion on chained command arguments

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -169,6 +169,11 @@ def get_choices(cli, prog_name, args, incomplete):
         # completion for any subcommands
         choices.extend(ctx.command.list_commands(ctx))
 
+    if not start_of_option(incomplete) and ctx.parent is not None and isinstance(ctx.parent.command, MultiCommand) and ctx.parent.command.chain:
+        # completion for chained commands
+        remaining_comands = set(ctx.parent.command.list_commands(ctx.parent))-set(ctx.parent.protected_args)
+        choices.extend(remaining_comands)
+
     for item in choices:
         if item.startswith(incomplete):
             yield item

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -44,7 +44,7 @@ def resolve_ctx(cli, prog_name, args):
     """
     ctx = cli.make_context(prog_name, args, resilient_parsing=True)
     args_remaining = ctx.protected_args + ctx.args
-    while args_remaining:
+    while ctx is not None and args_remaining:
       if isinstance(ctx.command, MultiCommand):
         cmd = ctx.command.get_command(ctx, args_remaining[0])
         if cmd is None:

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -12,6 +12,7 @@ WORDBREAK = '='
 
 COMPLETION_SCRIPT = '''
 %(complete_func)s() {
+    local IFS=$'\n'
     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \\
                    COMP_CWORD=$COMP_CWORD \\
                    %(autocomplete_var)s=complete $1 ) )
@@ -42,14 +43,18 @@ def resolve_ctx(cli, prog_name, args):
     :return: the final context/command parsed
     """
     ctx = cli.make_context(prog_name, args, resilient_parsing=True)
-    while ctx.protected_args + ctx.args and isinstance(ctx.command, MultiCommand):
-        a = ctx.protected_args + ctx.args
-        cmd = ctx.command.get_command(ctx, a[0])
+    args_remaining = ctx.protected_args + ctx.args
+    while args_remaining:
+      if isinstance(ctx.command, MultiCommand):
+        cmd = ctx.command.get_command(ctx, args_remaining[0])
         if cmd is None:
             return None
-        ctx = cmd.make_context(a[0], a[1:], parent=ctx, resilient_parsing=True)
-    return ctx
+        ctx = cmd.make_context(args_remaining[0], args_remaining[1:], parent=ctx, resilient_parsing=True)
+        args_remaining = ctx.protected_args + ctx.args
+      else:
+        ctx = ctx.parent
 
+    return ctx
 
 def start_of_option(param_str):
     """

--- a/click/core.py
+++ b/click/core.py
@@ -25,6 +25,15 @@ SUBCOMMAND_METAVAR = 'COMMAND [ARGS]...'
 SUBCOMMANDS_METAVAR = 'COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...'
 
 
+def fast_exit(code):
+    """Exit without garbage collection, this speeds up exit by about 10ms for
+    things like bash completion.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(code)
+
+
 def _bashcomplete(cmd, prog_name, complete_var=None):
     """Internal handler for the bash completion support."""
     if complete_var is None:
@@ -35,7 +44,7 @@ def _bashcomplete(cmd, prog_name, complete_var=None):
 
     from ._bashcomplete import bashcomplete
     if bashcomplete(cmd, prog_name, complete_var, complete_instr):
-        sys.exit(1)
+        fast_exit(1)
 
 
 def _check_multicommand(base_command, cmd_name, cmd, register=False):

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -46,7 +46,7 @@ Here is an example of using a callback function to generate dynamic suggestions:
 
     import os
 
-    def get_env_vars(ctx, incomplete, cwords, cword):
+    def get_env_vars(ctx, args, incomplete):
         return os.environ.keys()
 
     @click.command()

--- a/examples/bashcompletion/bashcompletion.py
+++ b/examples/bashcompletion/bashcompletion.py
@@ -1,31 +1,16 @@
 import click
 import os
 
-@click.group()
+@click.group(chain=True)
 def cli():
-    pass
-
-def get_env_vars(ctx, args, incomplete):
-    return os.environ.keys()
+	pass
 
 @cli.command()
-@click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)
-def cmd1(envvar):
-    click.echo('Environment variable: %s' % envvar)
-    click.echo('Value: %s' % os.environ[envvar])
+@click.option('-n', is_flag=True)
+def cmd1(n):
+	pass
 
-@click.group()
-def group():
-    pass
-
-def list_users(ctx, args, incomplete):
-    # Here you can generate completions dynamically
-    users = ['bob', 'alice']
-    return users
-
-@group.command()
-@click.argument("user", type=click.STRING, autocompletion=list_users)
-def subcmd(user):
-    click.echo('Chosen user is %s' % user)
-
-cli.add_command(group)
+@cli.command()
+@click.option('-b', is_flag=True)
+def cmd2(b):
+	pass

--- a/examples/bashcompletion/bashcompletion.py
+++ b/examples/bashcompletion/bashcompletion.py
@@ -1,16 +1,31 @@
 import click
 import os
 
-@click.group(chain=True)
+@click.group()
 def cli():
-	pass
+    pass
+
+def get_env_vars(ctx, args, incomplete):
+    return os.environ.keys()
 
 @cli.command()
-@click.option('-n', is_flag=True)
-def cmd1(n):
-	pass
+@click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)
+def cmd1(envvar):
+    click.echo('Environment variable: %s' % envvar)
+    click.echo('Value: %s' % os.environ[envvar])
 
-@cli.command()
-@click.option('-b', is_flag=True)
-def cmd2(b):
-	pass
+@click.group()
+def group():
+    pass
+
+def list_users(ctx, args, incomplete):
+    # Here you can generate completions dynamically
+    users = ['bob', 'alice']
+    return users
+
+@group.command()
+@click.argument("user", type=click.STRING, autocompletion=list_users)
+def subcmd(user):
+    click.echo('Chosen user is %s' % user)
+
+cli.add_command(group)

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -112,6 +112,32 @@ def test_long_chain():
     assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], 'b')) == ['blue']
 
 
+def test_chaining():
+    @click.group('cli', chain=True)
+    @click.option('--cli-opt')
+    def cli(cli_opt):
+        pass
+
+    @cli.command('asub')
+    @click.option('--asub-opt')
+    def asub(asub_opt):
+        pass
+
+    @cli.command('bsub')
+    @click.option('--bsub-opt')
+    @click.argument('arg', type=click.Choice(['arg1', 'arg2']))
+    def bsub(bsub_opt, arg):
+        pass
+
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt']
+    assert list(get_choices(cli, 'lol', [], '')) == ['asub', 'bsub']
+    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt']
+    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub']
+    assert list(get_choices(cli, 'lol', ['bsub'], '')) == ['arg1', 'arg2', 'asub']
+    assert list(get_choices(cli, 'lol', ['asub', '--asub-opt', '5', 'bsub'], '-')) == ['--bsub-opt']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt']
+
+
 def test_argument_choice():
     @click.command()
     @click.argument('arg1', required=False, type=click.Choice(['arg11', 'arg12']))


### PR DESCRIPTION
Enables bash completion on chained command arguments, allows completions with spaces in them, makes bash completion about 10ms faster by exiting python using os._exit() rather than sys.exit(), and updates documentation that was incorrect from PR #755

Fixes #754 
Fixes #769