### PR TITLE
Allow spaces in bash completion results

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 7.0
 -----------
 
 (upcoming release with new features, release date to be decided)
+- Added support for bash completions containing spaces. See #773.
 - Added support for dynamic bash completion from a user-supplied callback.
   See #755
 - Added support for bash completion of type=click.Choice for Options and

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -12,6 +12,7 @@ WORDBREAK = '='
 
 COMPLETION_SCRIPT = '''
 %(complete_func)s() {
+    local IFS=$'\n'
     COMPREPLY=( $( env COMP_WORDS="${COMP_WORDS[*]}" \\
                    COMP_CWORD=$COMP_CWORD \\
                    %(autocomplete_var)s=complete $1 ) )


### PR DESCRIPTION
Allows spaces in returns from bash autocompletion.

Fixes #769 