### PR TITLE
Enhancements to bash completions for better file/directory handling (take 2)

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -19,7 +19,7 @@ COMPLETION_SCRIPT = '''
     return 0
 }
 
-complete -F %(complete_func)s -o default %(script_names)s
+complete -F %(complete_func)s -o nospace %(script_names)s
 '''
 
 _invalid_ident_char_re = re.compile(r'[^a-zA-Z0-9_]')

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -109,14 +109,12 @@ def get_user_autocompletions(ctx, args, incomplete, cmd_param):
     :param cmd_param: command definition
     :return: all the possible user-specified completions for the param
     """
-    if isinstance(cmd_param.type, Choice):
-        return cmd_param.type.choices
-    elif cmd_param.autocompletion is not None:
+    if cmd_param.autocompletion is not None:
         return cmd_param.autocompletion(ctx=ctx,
                                         args=args,
                                         incomplete=incomplete)
     else:
-        return []
+        return cmd_param.type.completions(incomplete) or []
 
 def get_choices(cli, prog_name, args, incomplete):
     """
@@ -147,7 +145,7 @@ def get_choices(cli, prog_name, args, incomplete):
         # completions for options
         for param in ctx.command.params:
             if isinstance(param, Option):
-                choices.extend([param_opt for param_opt in param.opts + param.secondary_opts
+                choices.extend([param_opt + " " for param_opt in param.opts + param.secondary_opts
                                 if param_opt not in all_args or param.multiple])
         found_param = True
     if not found_param:
@@ -167,12 +165,12 @@ def get_choices(cli, prog_name, args, incomplete):
 
     if not found_param and isinstance(ctx.command, MultiCommand):
         # completion for any subcommands
-        choices.extend(ctx.command.list_commands(ctx))
+        choices.extend([cmd + " " for cmd in ctx.command.list_commands(ctx)])
 
     if not start_of_option(incomplete) and ctx.parent is not None and isinstance(ctx.parent.command, MultiCommand) and ctx.parent.command.chain:
         # completion for chained commands
         remaining_comands = set(ctx.parent.command.list_commands(ctx.parent))-set(ctx.parent.protected_args)
-        choices.extend(remaining_comands)
+        choices.extend([cmd + " " for cmd in remaining_comands])
 
     for item in choices:
         if item.startswith(incomplete):

--- a/click/types.py
+++ b/click/types.py
@@ -337,11 +337,16 @@ def _complete_path(path_type, incomplete):
         split = incomplete.rsplit(os.path.sep, 1)
         base_path = split[0]
 
-    if base_path:
-        if os.path.isdir(base_path):
-            entries = [os.path.join(base_path, e) for e in os.listdir(base_path)]
-    else:
-        entries = os.listdir(".")
+    try:
+        if base_path:
+            if os.path.isdir(base_path):
+                entries = [os.path.join(base_path, e) for e in os.listdir(base_path)]
+        else:
+            entries = os.listdir(".")
+    except OSError:
+        # If for any reason the os reports an error from os.listdir(), just
+        # ignore this and avoid a stack trace
+        pass
 
     return [
         # Append slashes to any entries which are directories, or

--- a/click/types.py
+++ b/click/types.py
@@ -337,6 +337,11 @@ def _complete_path(path_type, incomplete):
         split = incomplete.rsplit(os.path.sep, 1)
         base_path = split[0]
 
+        # If there was nothing on the left of the last separator,
+        # we are completing files in the filesystem root
+        if not base_path:
+            base_path = os.path.sep
+
     try:
         if base_path:
             if os.path.isdir(base_path):

--- a/click/types.py
+++ b/click/types.py
@@ -175,6 +175,9 @@ class Choice(ParamType):
         self.fail('invalid choice: %s. (choose from %s)' %
                   (value, ', '.join(self.choices)), param, ctx)
 
+    def completions(self, incomplete):
+        return [c + " " for c in self.choices]
+
     def __repr__(self):
         return 'Choice(%r)' % list(self.choices)
 

--- a/click/types.py
+++ b/click/types.py
@@ -360,10 +360,9 @@ def _complete_path(path_type, incomplete):
 
         for e in sorted(entries)
 
-        # Filter out undesired elements
-        if (path_type == 'Path' or
-            (path_type == 'Directory' and os.path.isdir(e)) or
-            (path_type == 'File' and not os.path.isdir(e)))
+        # Filter out non directory elements when searching for a directory,
+        # the opposite is fine, however.
+        if not (path_type == 'Directory' and not os.path.isdir(e))
     ]
 
 

--- a/click/types.py
+++ b/click/types.py
@@ -67,6 +67,23 @@ class ParamType(object):
         """Helper method to fail with an invalid value message."""
         raise BadParameter(message, ctx=ctx, param=param)
 
+    def completions(self, incomplete):
+        """Report possible completions for this parameter.
+
+        This takes the currently incomplete word for this parameter,
+        which may be an empty string if no characters have been entered yet.
+
+        This method should return a list of words that are suitable completions
+        for the parameter.
+
+        Suggested completions which cannot be completed further, should
+        be completed with a space appended. This allows support for
+        partial path like completions which may be searched in a database
+        or filesystem.
+
+        .. versionadded:: 7.0
+        """
+        return None
 
 class CompositeParamType(ParamType):
     is_composite = True

--- a/click/types.py
+++ b/click/types.py
@@ -300,6 +300,9 @@ class BoolParamType(ParamType):
             return False
         self.fail('%s is not a valid boolean' % value, param, ctx)
 
+    def completions(self, incomplete):
+        return ["yes ", "no "]
+
     def __repr__(self):
         return 'BOOL'
 

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -30,7 +30,7 @@ least a dash has been provided.  Example::
     --deep     --help     --rev      --shallow  -r
 
 Additionally, custom suggestions can be provided for arguments and options with
-the ``autocompletion`` parameter.  ``autocompletion`` should a callback function
+the ``autocompletion`` parameter.  ``autocompletion`` should be a callback function
 that returns a list of strings. This is useful when the suggestions need to be
 dynamically generated at bash completion time. The callback function will be
 passed 3 keyword arguments:
@@ -40,6 +40,11 @@ passed 3 keyword arguments:
 - ``incomplete`` - The partial word that is being completed, as a string.  May
   be an empty string ``''`` if no characters have been entered yet.
 
+The returned strings should have spaces appended to them in the case that
+they cannot be further completed, omitting the space allows the completion
+to be invoked multiple times, which can be useful for completing path-like
+strings by searching a database or filesystem.
+
 Here is an example of using a callback function to generate dynamic suggestions:
 
 .. click:example::
@@ -47,7 +52,7 @@ Here is an example of using a callback function to generate dynamic suggestions:
     import os
 
     def get_env_vars(ctx, args, incomplete):
-        return os.environ.keys()
+        return [key + ' ' for key in os.environ.keys()]
 
     @click.command()
     @click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)

--- a/examples/bashcompletion/bashcompletion.py
+++ b/examples/bashcompletion/bashcompletion.py
@@ -6,7 +6,7 @@ def cli():
     pass
 
 def get_env_vars(ctx, args, incomplete):
-    return os.environ.keys()
+    return [key + ' ' for key in os.environ.keys()]
 
 @cli.command()
 @click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)
@@ -20,7 +20,7 @@ def group():
 
 def list_users(ctx, args, incomplete):
     # Here you can generate completions dynamically
-    users = ['bob', 'alice']
+    users = ['bob ', 'alice ']
     return users
 
 @group.command()

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -10,7 +10,7 @@ def test_single_command():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--local-opt']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--local-opt ']
     assert list(get_choices(cli, 'lol', [], '')) == []
 
 
@@ -20,7 +20,7 @@ def test_boolean_flag():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--shout', '--no-shout']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--shout ', '--no-shout ']
 
 
 def test_multi_value_option():
@@ -34,10 +34,10 @@ def test_multi_value_option():
     def sub(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--pos']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--pos ']
     assert list(get_choices(cli, 'lol', ['--pos'], '')) == []
     assert list(get_choices(cli, 'lol', ['--pos', '1.0'], '')) == []
-    assert list(get_choices(cli, 'lol', ['--pos', '1.0', '1.0'], '')) == ['sub']
+    assert list(get_choices(cli, 'lol', ['--pos', '1.0', '1.0'], '')) == ['sub ']
 
 
 def test_multi_option():
@@ -46,7 +46,7 @@ def test_multi_option():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--message', '-m']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--message ', '-m ']
     assert list(get_choices(cli, 'lol', ['-m'], '')) == []
 
 
@@ -61,10 +61,10 @@ def test_small_chain():
     def sub(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '')) == ['sub']
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--global-opt']
+    assert list(get_choices(cli, 'lol', [], '')) == ['sub ']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--global-opt ']
     assert list(get_choices(cli, 'lol', ['sub'], '')) == []
-    assert list(get_choices(cli, 'lol', ['sub'], '-')) == ['--local-opt']
+    assert list(get_choices(cli, 'lol', ['sub'], '-')) == ['--local-opt ']
 
 
 def test_long_chain():
@@ -86,7 +86,7 @@ def test_long_chain():
     COLORS = ['red', 'green', 'blue']
     def get_colors(ctx, args, incomplete):
         for c in COLORS:
-            yield c
+            yield c + ' '
 
     CSUB_OPT_CHOICES = ['foo', 'bar']
     CSUB_CHOICES = ['bar', 'baz']
@@ -97,19 +97,19 @@ def test_long_chain():
     def csub(csub_opt, color):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt']
-    assert list(get_choices(cli, 'lol', [], '')) == ['asub']
-    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt']
-    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '')) == ['csub']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '-')) == ['--csub-opt', '--csub']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub-opt'], '')) == CSUB_OPT_CHOICES
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '--csub')) == ['--csub-opt', '--csub']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub'], '')) == CSUB_CHOICES
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub-opt'], 'f')) == ['foo']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '')) == COLORS
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], 'b')) == ['blue']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt ']
+    assert list(get_choices(cli, 'lol', [], '')) == ['asub ']
+    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt ']
+    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '')) == ['csub ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '-')) == ['--csub-opt ', '--csub ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub-opt'], '')) == [o + ' ' for o in CSUB_OPT_CHOICES]
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '--csub')) == ['--csub-opt ', '--csub ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub'], '')) == [o + ' ' for o in CSUB_CHOICES]
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub', '--csub-opt'], 'f')) == ['foo ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], '')) == [o + ' ' for o in COLORS]
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub', 'csub'], 'b')) == ['blue ']
 
 
 def test_chaining():
@@ -129,13 +129,13 @@ def test_chaining():
     def bsub(bsub_opt, arg):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt']
-    assert list(get_choices(cli, 'lol', [], '')) == ['asub', 'bsub']
-    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt']
-    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub']
-    assert list(get_choices(cli, 'lol', ['bsub'], '')) == ['arg1', 'arg2', 'asub']
-    assert list(get_choices(cli, 'lol', ['asub', '--asub-opt', '5', 'bsub'], '-')) == ['--bsub-opt']
-    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--cli-opt ']
+    assert list(get_choices(cli, 'lol', [], '')) == ['asub ', 'bsub ']
+    assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt ']
+    assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub ']
+    assert list(get_choices(cli, 'lol', ['bsub'], '')) == ['arg1 ', 'arg2 ', 'asub ']
+    assert list(get_choices(cli, 'lol', ['asub', '--asub-opt', '5', 'bsub'], '-')) == ['--bsub-opt ']
+    assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt ']
 
 
 def test_argument_choice():
@@ -146,11 +146,11 @@ def test_argument_choice():
     def cli():
         pass
 
-    assert list(get_choices(cli, 'lol', [], '')) == ['arg11', 'arg12']
-    assert list(get_choices(cli, 'lol', [], 'arg')) == ['arg11', 'arg12']
-    assert list(get_choices(cli, 'lol', ['arg11'], '')) == ['arg21', 'arg22']
-    assert list(get_choices(cli, 'lol', ['arg12', 'arg21'], '')) == ['arg', 'argument']
-    assert list(get_choices(cli, 'lol', ['arg12', 'arg21'], 'argu')) == ['argument']
+    assert list(get_choices(cli, 'lol', [], '')) == ['arg11 ', 'arg12 ']
+    assert list(get_choices(cli, 'lol', [], 'arg')) == ['arg11 ', 'arg12 ']
+    assert list(get_choices(cli, 'lol', ['arg11'], '')) == ['arg21 ', 'arg22 ']
+    assert list(get_choices(cli, 'lol', ['arg12', 'arg21'], '')) == ['arg ', 'argument ']
+    assert list(get_choices(cli, 'lol', ['arg12', 'arg21'], 'argu')) == ['argument ']
 
 
 def test_option_choice():
@@ -161,21 +161,21 @@ def test_option_choice():
     def cli():
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--opt1', '--opt2', '--opt3']
-    assert list(get_choices(cli, 'lol', [], '--opt')) == ['--opt1', '--opt2', '--opt3']
-    assert list(get_choices(cli, 'lol', [], '--opt1=')) == ['opt11', 'opt12']
-    assert list(get_choices(cli, 'lol', [], '--opt2=')) == ['opt21', 'opt22']
-    assert list(get_choices(cli, 'lol', ['--opt2'], '=')) == ['opt21', 'opt22']
-    assert list(get_choices(cli, 'lol', ['--opt2', '='], 'opt')) == ['opt21', 'opt22']
-    assert list(get_choices(cli, 'lol', ['--opt1'], '')) == ['opt11', 'opt12']
-    assert list(get_choices(cli, 'lol', ['--opt2'], '')) == ['opt21', 'opt22']
-    assert list(get_choices(cli, 'lol', ['--opt1', 'opt11', '--opt2'], '')) == ['opt21', 'opt22']
-    assert list(get_choices(cli, 'lol', ['--opt2', 'opt21'], '-')) == ['--opt1', '--opt3']
-    assert list(get_choices(cli, 'lol', ['--opt1', 'opt11'], '-')) == ['--opt2', '--opt3']
-    assert list(get_choices(cli, 'lol', ['--opt1'], 'opt')) == ['opt11', 'opt12']
-    assert list(get_choices(cli, 'lol', ['--opt3'], 'opti')) == ['option']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--opt1 ', '--opt2 ', '--opt3 ']
+    assert list(get_choices(cli, 'lol', [], '--opt')) == ['--opt1 ', '--opt2 ', '--opt3 ']
+    assert list(get_choices(cli, 'lol', [], '--opt1=')) == ['opt11 ', 'opt12 ']
+    assert list(get_choices(cli, 'lol', [], '--opt2=')) == ['opt21 ', 'opt22 ']
+    assert list(get_choices(cli, 'lol', ['--opt2'], '=')) == ['opt21 ', 'opt22 ']
+    assert list(get_choices(cli, 'lol', ['--opt2', '='], 'opt')) == ['opt21 ', 'opt22 ']
+    assert list(get_choices(cli, 'lol', ['--opt1'], '')) == ['opt11 ', 'opt12 ']
+    assert list(get_choices(cli, 'lol', ['--opt2'], '')) == ['opt21 ', 'opt22 ']
+    assert list(get_choices(cli, 'lol', ['--opt1', 'opt11', '--opt2'], '')) == ['opt21 ', 'opt22 ']
+    assert list(get_choices(cli, 'lol', ['--opt2', 'opt21'], '-')) == ['--opt1 ', '--opt3 ']
+    assert list(get_choices(cli, 'lol', ['--opt1', 'opt11'], '-')) == ['--opt2 ', '--opt3 ']
+    assert list(get_choices(cli, 'lol', ['--opt1'], 'opt')) == ['opt11 ', 'opt12 ']
+    assert list(get_choices(cli, 'lol', ['--opt3'], 'opti')) == ['option ']
 
-    assert list(get_choices(cli, 'lol', ['--opt1', 'invalid_opt'], '-')) == ['--opt2', '--opt3']
+    assert list(get_choices(cli, 'lol', ['--opt1', 'invalid_opt'], '-')) == ['--opt2 ', '--opt3 ']
 
 
 def test_option_and_arg_choice():
@@ -186,10 +186,10 @@ def test_option_and_arg_choice():
     def cli():
         pass
 
-    assert list(get_choices(cli, 'lol', ['--opt1'], '')) == ['opt11', 'opt12']
-    assert list(get_choices(cli, 'lol', [''], '--opt1=')) == ['opt11', 'opt12']
-    assert list(get_choices(cli, 'lol', [], '')) == ['arg11', 'arg12']
-    assert list(get_choices(cli, 'lol', ['--opt2'], '')) == ['opt21', 'opt22']
+    assert list(get_choices(cli, 'lol', ['--opt1'], '')) == ['opt11 ', 'opt12 ']
+    assert list(get_choices(cli, 'lol', [''], '--opt1=')) == ['opt11 ', 'opt12 ']
+    assert list(get_choices(cli, 'lol', [], '')) == ['arg11 ', 'arg12 ']
+    assert list(get_choices(cli, 'lol', ['--opt2'], '')) == ['opt21 ', 'opt22 ']
 
 
 def test_boolean_flag_choice():
@@ -199,8 +199,8 @@ def test_boolean_flag_choice():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', [], '-')) == ['--shout', '--no-shout']
-    assert list(get_choices(cli, 'lol', ['--shout'], '')) == ['arg1', 'arg2']
+    assert list(get_choices(cli, 'lol', [], '-')) == ['--shout ', '--no-shout ']
+    assert list(get_choices(cli, 'lol', ['--shout'], '')) == ['arg1 ', 'arg2 ']
 
 
 def test_multi_value_option_choice():
@@ -210,9 +210,9 @@ def test_multi_value_option_choice():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', ['--pos'], '')) == ['pos1', 'pos2']
-    assert list(get_choices(cli, 'lol', ['--pos', 'pos1'], '')) == ['pos1', 'pos2']
-    assert list(get_choices(cli, 'lol', ['--pos', 'pos1', 'pos2'], '')) == ['arg1', 'arg2']
+    assert list(get_choices(cli, 'lol', ['--pos'], '')) == ['pos1 ', 'pos2 ']
+    assert list(get_choices(cli, 'lol', ['--pos', 'pos1'], '')) == ['pos1 ', 'pos2 ']
+    assert list(get_choices(cli, 'lol', ['--pos', 'pos1', 'pos2'], '')) == ['arg1 ', 'arg2 ']
     assert list(get_choices(cli, 'lol', ['--pos', 'pos1', 'pos2', 'arg1'], '')) == []
 
 
@@ -223,9 +223,9 @@ def test_multi_option_choice():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', ['-m'], '')) == ['m1', 'm2']
-    assert list(get_choices(cli, 'lol', ['-m', 'm1', '-m'], '')) == ['m1', 'm2']
-    assert list(get_choices(cli, 'lol', ['-m', 'm1'], '')) == ['arg1', 'arg2']
+    assert list(get_choices(cli, 'lol', ['-m'], '')) == ['m1 ', 'm2 ']
+    assert list(get_choices(cli, 'lol', ['-m', 'm1', '-m'], '')) == ['m1 ', 'm2 ']
+    assert list(get_choices(cli, 'lol', ['-m', 'm1'], '')) == ['arg1 ', 'arg2 ']
 
 
 def test_variadic_argument_choice():
@@ -234,7 +234,7 @@ def test_variadic_argument_choice():
     def cli(local_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', ['src1', 'src2'], '')) == ['src1', 'src2']
+    assert list(get_choices(cli, 'lol', ['src1', 'src2'], '')) == ['src1 ', 'src2 ']
 
 
 def test_long_chain_choice():
@@ -255,15 +255,15 @@ def test_long_chain_choice():
     def bsub(bsub_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', ['sub'], '')) == ['subarg1', 'subarg2']
-    assert list(get_choices(cli, 'lol', ['sub', '--sub-opt'], '')) == ['subopt1', 'subopt2']
+    assert list(get_choices(cli, 'lol', ['sub'], '')) == ['subarg1 ', 'subarg2 ']
+    assert list(get_choices(cli, 'lol', ['sub', '--sub-opt'], '')) == ['subopt1 ', 'subopt2 ']
     assert list(get_choices(cli, 'lol', ['sub', '--sub-opt', 'subopt1'], '')) == \
-        ['subarg1', 'subarg2']
+        ['subarg1 ', 'subarg2 ']
     assert list(get_choices(cli, 'lol',
-        ['sub', '--sub-opt', 'subopt1', 'subarg1', 'bsub'], '-')) == ['--bsub-opt']
+        ['sub', '--sub-opt', 'subopt1', 'subarg1', 'bsub'], '-')) == ['--bsub-opt ']
     assert list(get_choices(cli, 'lol',
         ['sub', '--sub-opt', 'subopt1', 'subarg1', 'bsub', '--bsub-opt'], '')) == \
-        ['bsubopt1', 'bsubopt2']
+        ['bsubopt1 ', 'bsubopt2 ']
     assert list(get_choices(cli, 'lol',
         ['sub', '--sub-opt', 'subopt1', 'subarg1', 'bsub', '--bsub-opt', 'bsubopt1', 'bsubarg1'],
-                            '')) == ['bbsubarg1', 'bbsubarg2']
+                            '')) == ['bbsubarg1 ', 'bbsubarg2 ']

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -356,7 +356,10 @@ def test_files_only():
         os.mkdir(os.path.join(temp, 'dirb'))
         with open(os.path.join(temp, 'file.txt'), 'w') as f:
             f.write('content')
+        with open(os.path.join(temp, 'dirb', 'file.txt'), 'w') as f:
+            f.write('content')
 
-        assert list(get_choices(cli, 'lol', ['--path'], '')) == ['file.txt ']
+        assert list(get_choices(cli, 'lol', ['--path'], '')) == ['dira' + os.path.sep, 'dirb' + os.path.sep, 'file.txt ']
         assert list(get_choices(cli, 'lol', ['--path'], 'fil')) == ['file.txt ']
-        assert list(get_choices(cli, 'lol', ['--path'], 'dir')) == []
+        assert list(get_choices(cli, 'lol', ['--path'], 'dir')) == ['dira' + os.path.sep, 'dirb' + os.path.sep]
+        assert list(get_choices(cli, 'lol', ['--path'], 'dirb/')) == [os.path.join('dirb', 'file.txt') + ' ']


### PR DESCRIPTION
This addresses the issues outlined in #780 

* Changes the bash entry point to use *"complete -o nospace"*
* Adds abstract method to ParamType allowing the parameters to participate in the completion
* Migrates Choice completion implementation into types.py on the actual Choice type
* Implement the `completions()` method for BoolParamType, File and Path parameter types too

This behaves all around much better:
* No more completing of filenames when that is undesirable
* Completes filenames or directories selectively, depending on the parameter

**Note**: This is take two of pull request #781 ... I rebased my branch to have a more coherent history and did not expect github to delete the PR as a result, sorry.
