### PR TITLE
Bug fix #793; use deterministic option name; can't rely on list.sort

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Version 6.8
 - Fix bug in test runner when calling ``sys.exit`` with ``None``. See #739.
 - Fix crash on Windows console, see #744.
 - Fix bashcompletion on chained commands. See #754.
+- Fix option naming routine to match documentation.  See #793
 
 Version 6.7
 -----------

--- a/click/core.py
+++ b/click/core.py
@@ -1548,8 +1548,8 @@ class Option(Parameter):
                     opts.append(decl)
 
         if name is None and possible_names:
-            possible_names.sort(key=lambda x: len(x[0]))
-            name = possible_names[-1][1].replace('-', '_').lower()
+            possible_names.sort(key=lambda x: -len(x[0]))  # group long options first
+            name = possible_names[0][1].replace('-', '_').lower()
             if not isidentifier(name):
                 name = None
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -335,3 +335,25 @@ def test_aliases_for_flags(runner):
     assert result.output == 'False\n'
     result = runner.invoke(cli_alt, ['-w'])
     assert result.output == 'True\n'
+
+@pytest.mark.parametrize('option_args,expected', [
+    (['--aggressive', '--all', '-a'], 'aggressive'),
+    (['--first', '--second', '--third', '-a', '-b', '-c'], 'first'),
+    (['--apple', '--banana', '--cantaloupe', '-a', '-b', '-c'], 'apple'),
+    (['--cantaloupe', '--banana', '--apple', '-c', '-b', '-a'], 'cantaloupe'),
+    (['-a', '-b', '-c'], 'a'),
+    (['-c', '-b', '-a'], 'c'),
+    (['-a', '--apple', '-b', '--banana', '-c', '--cantaloupe'], 'apple'),
+    (['-c', '-a', '--cantaloupe', '-b', '--banana', '--apple'], 'cantaloupe'),
+])
+def test_multiple_long_options(runner, option_args, expected):
+    @click.command()
+    @click.option(*option_args, is_flag=True)
+    def cmd(**kwargs):
+        click.echo(str(kwargs[expected]))
+
+    assert cmd.params[0].name == expected
+
+    for form in option_args:
+        result = runner.invoke(cmd, [form])
+        assert result.output == 'True\n'


### PR DESCRIPTION
Please merge; this matches the implementation to the documentation.

Currently an option defined as...
```python
@click.option('--ambitious', '--all', '-a', is_flag=True)
```
...will target `all` instead of `ambitious`