### PR TITLE
Fix overzealous completion when required options/arguments are being completed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,8 @@ Version 7.0
 - Fix bug that caused bashcompletion to give inproper completions on
   chained commands when a required option/argument was being completed.
   See #790.
+- Allow autocompletion function to determine whether or not to return
+  completions that start with the incomplete argument.
 
 Version 6.8
 -----------

--- a/CHANGES
+++ b/CHANGES
@@ -23,9 +23,9 @@ Version 7.0
 - ``launch`` now works properly under Cygwin. See #650.
 - `CliRunner.invoke` now may receive `args` as a string representing
   a Unix shell command. See #664.
-- Fix bug that caused bashcompletion to give inproper completions on 
+- Fix bug that caused bashcompletion to give improper completions on 
   chained commands. See #774.
-- Fix bug that caused bashcompletion to give inproper completions on
+- Fix bug that caused bashcompletion to give improper completions on
   chained commands when a required option/argument was being completed.
   See #790.
 

--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,9 @@ Version 7.0
   a Unix shell command. See #664.
 - Fix bug that caused bashcompletion to give inproper completions on 
   chained commands. See #774.
+- Fix bug that caused bashcompletion to give inproper completions on
+  chained commands when a required option/argument was being completed.
+  See #790.
 
 Version 6.8
 -----------

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -45,14 +45,15 @@ def resolve_ctx(cli, prog_name, args):
     ctx = cli.make_context(prog_name, args, resilient_parsing=True)
     args_remaining = ctx.protected_args + ctx.args
     while ctx is not None and args_remaining:
-      if isinstance(ctx.command, MultiCommand):
-        cmd = ctx.command.get_command(ctx, args_remaining[0])
-        if cmd is None:
-            return None
-        ctx = cmd.make_context(args_remaining[0], args_remaining[1:], parent=ctx, resilient_parsing=True)
-        args_remaining = ctx.protected_args + ctx.args
-      else:
-        ctx = ctx.parent
+        if isinstance(ctx.command, MultiCommand):
+            cmd = ctx.command.get_command(ctx, args_remaining[0])
+            if cmd is None:
+                return None
+            ctx = cmd.make_context(
+                args_remaining[0], args_remaining[1:], parent=ctx, resilient_parsing=True)
+            args_remaining = ctx.protected_args + ctx.args
+        else:
+            ctx = ctx.parent
 
     return ctx
 
@@ -105,6 +106,7 @@ def is_incomplete_argument(current_params, cmd_param):
             and cmd_param.nargs > 1 and len(current_param_values) < cmd_param.nargs:
         return True
     return False
+
 
 def get_user_autocompletions(ctx, args, incomplete, cmd_param):
     """
@@ -160,14 +162,16 @@ def get_choices(cli, prog_name, args, incomplete):
         # completion for option values from user supplied values
         for param in ctx.command.params:
             if is_incomplete_option(all_args, param):
-                user_choices.extend(get_user_autocompletions(ctx, all_args, incomplete, param))
+                user_choices.extend(get_user_autocompletions(
+                    ctx, all_args, incomplete, param))
                 found_param = True
                 break
         # completion for argument values from user supplied values
         if not found_param:
             for param in ctx.command.params:
                 if is_incomplete_argument(ctx.params, param):
-                    user_choices.extend(get_user_autocompletions(ctx, all_args, incomplete, param))
+                    user_choices.extend(get_user_autocompletions(
+                        ctx, all_args, incomplete, param))
                     # Stop looking for other completions only if this argument is required
                     found_param = param.required
                     break
@@ -181,7 +185,8 @@ def get_choices(cli, prog_name, args, incomplete):
             while ctx.parent is not None:
                 ctx = ctx.parent
                 if isinstance(ctx.command, MultiCommand) and ctx.command.chain:
-                    remaining_commands = sorted(set(ctx.command.list_commands(ctx))-set(ctx.protected_args))
+                    remaining_commands = sorted(
+                        set(ctx.command.list_commands(ctx)) - set(ctx.protected_args))
                     choices.extend(remaining_commands)
 
     for item in user_choices:
@@ -190,7 +195,6 @@ def get_choices(cli, prog_name, args, incomplete):
     for item in choices:
         if item.startswith(incomplete):
             yield item
-
 
 
 def do_complete(cli, prog_name):

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -154,7 +154,7 @@ def get_choices(cli, prog_name, args, incomplete):
 
     ctx = resolve_ctx(cli, prog_name, args)
     if ctx is None:
-        return
+        return []
 
     # In newer versions of bash long opts with '='s are partitioned, but it's easier to parse
     # without the '='

--- a/examples/bashcompletion/bashcompletion.py
+++ b/examples/bashcompletion/bashcompletion.py
@@ -1,12 +1,17 @@
 import click
 import os
 
+
 @click.group()
 def cli():
     pass
 
+
 def get_env_vars(ctx, args, incomplete):
-    return os.environ.keys()
+    for key in os.environ.keys():
+        if incomplete in key:
+            yield key
+
 
 @cli.command()
 @click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)
@@ -14,14 +19,19 @@ def cmd1(envvar):
     click.echo('Environment variable: %s' % envvar)
     click.echo('Value: %s' % os.environ[envvar])
 
+
 @click.group()
 def group():
     pass
 
+
 def list_users(ctx, args, incomplete):
     # Here you can generate completions dynamically
     users = ['bob', 'alice']
-    return users
+    for user in users:
+        if user.startswith(incomplete):
+            yield user
+
 
 @group.command()
 @click.argument("user", type=click.STRING, autocompletion=list_users)

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -125,7 +125,7 @@ def test_chaining():
 
     @cli.command('bsub')
     @click.option('--bsub-opt')
-    @click.argument('arg', type=click.Choice(['arg1', 'arg2']))
+    @click.argument('arg', type=click.Choice(['arg1', 'arg2']), required=True)
     def bsub(bsub_opt, arg):
         pass
 
@@ -133,7 +133,8 @@ def test_chaining():
     assert list(get_choices(cli, 'lol', [], '')) == ['asub', 'bsub']
     assert list(get_choices(cli, 'lol', ['asub'], '-')) == ['--asub-opt']
     assert list(get_choices(cli, 'lol', ['asub'], '')) == ['bsub']
-    assert list(get_choices(cli, 'lol', ['bsub'], '')) == ['arg1', 'arg2', 'asub']
+    assert list(get_choices(cli, 'lol', ['bsub'], '')) == ['arg1', 'arg2']
+    assert list(get_choices(cli, 'lol', ['asub', '--asub-opt'], '')) == []
     assert list(get_choices(cli, 'lol', ['asub', '--asub-opt', '5', 'bsub'], '-')) == ['--bsub-opt']
     assert list(get_choices(cli, 'lol', ['asub', 'bsub'], '-')) == ['--bsub-opt']
 
@@ -255,10 +256,10 @@ def test_long_chain_choice():
     def bsub(bsub_opt):
         pass
 
-    assert list(get_choices(cli, 'lol', ['sub'], '')) == ['subarg1', 'subarg2']
+    assert list(get_choices(cli, 'lol', ['sub'], '')) == ['subarg1', 'subarg2', 'bsub']
     assert list(get_choices(cli, 'lol', ['sub', '--sub-opt'], '')) == ['subopt1', 'subopt2']
     assert list(get_choices(cli, 'lol', ['sub', '--sub-opt', 'subopt1'], '')) == \
-        ['subarg1', 'subarg2']
+        ['subarg1', 'subarg2', 'bsub']
     assert list(get_choices(cli, 'lol',
         ['sub', '--sub-opt', 'subopt1', 'subarg1', 'bsub'], '-')) == ['--bsub-opt']
     assert list(get_choices(cli, 'lol',


### PR DESCRIPTION
Don't offer bash completions for subcommands or chained commands when completing a required argument or option.
Fixes #790