### PR TITLE
Fixed URL with python3 unicode error description

### DIFF
--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -116,5 +116,5 @@ def _verify_python3_env():
 
     raise RuntimeError('Click will abort further execution because Python 3 '
                        'was configured to use ASCII as encoding for the '
-                       'environment.  Consult http://click.pocoo.org/python3/'
+                       'environment.  Consult http://click.pocoo.org/python3/ '
                        'for mitigation steps.' + extra)


### PR DESCRIPTION
Originally this string looks like `http://click.pocoo.org/python3/for` (without space between actual link and "for mitigation steps").

I hope this PR's so small that test running isn't necessary.