### PR TITLE
Allow iterable

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -215,6 +215,10 @@ if PY2:
         if isinstance(value, bytes):
             value = value.decode(get_filesystem_encoding(), 'replace')
         return value
+
+    def is_iterable(value):
+        return hasattr(value, '__iter__') and not isinstance(value, basestring)
+
 else:
     import io
     text_type = str
@@ -403,6 +407,9 @@ else:
             value = value.encode('utf-8', 'surrogateescape') \
                 .decode('utf-8', 'replace')
         return value
+
+    def is_iterable(value):
+        return not isinstance(value, str) and isinstance(value, Iterable)
 
 
 def get_streerror(e, default=None):

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -15,7 +15,7 @@ import time
 import math
 from ._compat import _default_text_stdout, range_type, PY2, isatty, \
      open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types, \
-     CYGWIN
+     CYGWIN, is_iterable
 from .utils import echo
 from .exceptions import ClickException
 
@@ -325,7 +325,11 @@ def _pipepager(text, cmd, color):
                          env=env)
     encoding = get_best_encoding(c.stdin)
     try:
-        c.stdin.write(text.encode(encoding, 'replace'))
+        if is_iterable(text):
+            for s in text:
+                c.stdin.write(s.encode(encoding, 'replace'))
+        else:
+            c.stdin.write(text.encode(encoding, 'replace'))
         c.stdin.close()
     except (IOError, KeyboardInterrupt):
         pass

--- a/click/core.py
+++ b/click/core.py
@@ -77,7 +77,6 @@ def invoke_param_callback(callback, ctx, param, value):
     args = getattr(code, 'co_argcount', 3)
 
     if args < 3:
-        # This will become a warning in Click 3.0:
         from warnings import warn
         warn(Warning('Invoked legacy parameter callback "%s".  The new '
                      'signature for such callbacks starting with '

--- a/click/termui.py
+++ b/click/termui.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import struct
+import itertools
 
 from ._compat import raw_input, text_type, string_types, \
-     isatty, strip_ansi, get_winterm_size, DEFAULT_COLUMNS, WIN
+     isatty, strip_ansi, get_winterm_size, DEFAULT_COLUMNS, WIN, \
+     is_iterable
 from .utils import echo
 from .exceptions import Abort, UsageError
 from .types import convert_type, Choice
@@ -215,10 +217,14 @@ def echo_via_pager(text, color=None):
                   default is autodetection.
     """
     color = resolve_color_default(color)
-    if not isinstance(text, string_types):
-        text = text_type(text)
+    if is_iterable(text):
+        text = itertools.chain(text, ['\n'])
+    else:
+        if not isinstance(text, string_types):
+            text = text_type(text)
+        text += '\n'
     from ._termui_impl import pager
-    return pager(text + '\n', color)
+    return pager(text, color)
 
 
 def progressbar(iterable=None, length=None, label=None, show_eta=True,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:warnings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,3 +1,5 @@
+import pytest
+
 import click
 
 
@@ -11,10 +13,19 @@ if click.__version__ >= '3.0':
         def cli(foo):
             click.echo(foo)
 
-        result = runner.invoke(cli, ['--foo', 'wat'])
+        with pytest.warns(Warning) as records:
+            result = runner.invoke(cli, ['--foo', 'wat'])
+
+        [warning_record] = records
+        warning_message = str(warning_record.message)
+        assert 'Invoked legacy parameter callback' in warning_message
         assert result.exit_code == 0
+        # Depending on the pytest version, the warning message may be
+        # in `result.output`.
+        #
+        # In pytest version 3.1 pytest started capturing warnings by default.
+        # See https://docs.pytest.org/en/latest/warnings.html#warnings-capture.
         assert 'WAT' in result.output
-        assert 'Invoked legacy parameter callback' in result.output
 
 
 def test_bash_func_name():


### PR DESCRIPTION
This allows to pass an iterable to `echo_via_pager` this way the complete output doesn't have to be completely buffered on the python side.