### PR TITLE
add space for readability

### DIFF
--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -116,5 +116,5 @@ def _verify_python3_env():
 
     raise RuntimeError('Click will abort further execution because Python 3 '
                        'was configured to use ASCII as encoding for the '
-                       'environment.  Consult http://click.pocoo.org/python3/'
+                       'environment.  Consult http://click.pocoo.org/python3/ '
                        'for mitigation steps.' + extra)


### PR DESCRIPTION
Currently the error reads:

```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.
```