### PR TITLE
A TextIOWrapper that wraps _winconsole._WindowsConsoleWriter expects a buffered stream

### DIFF
--- a/click/_winconsole.py
+++ b/click/_winconsole.py
@@ -210,14 +210,14 @@ def _get_text_stdin(buffer_stream):
 
 def _get_text_stdout(buffer_stream):
     text_stream = _NonClosingTextIOWrapper(
-        _WindowsConsoleWriter(STDOUT_HANDLE),
+        io.BufferedWriter(_WindowsConsoleWriter(STDOUT_HANDLE)),
         'utf-16-le', 'strict', line_buffering=True)
     return ConsoleStream(text_stream, buffer_stream)
 
 
 def _get_text_stderr(buffer_stream):
     text_stream = _NonClosingTextIOWrapper(
-        _WindowsConsoleWriter(STDERR_HANDLE),
+        io.BufferedWriter(_WindowsConsoleWriter(STDERR_HANDLE)),
         'utf-16-le', 'strict', line_buffering=True)
     return ConsoleStream(text_stream, buffer_stream)
 


### PR DESCRIPTION
`TextIOWrapper` expects a *buffered* stream not an unbuffered one. It wont check how much data was written and will drop data if you don't write it all.

This reproduces quite well on Python 3.6. Likely due to changes in `TextIOWrapper`.

Fixes: #816

P.S. I think `get_buffer` is a use after free... I think you are supposed to keep the `Py_buffer` alive while you are using the buffer... 😖

Alternative to: https://github.com/pallets/click/pull/818