### PR TITLE
Fix broken `test_legacy_callbacks` on Python 3.6 builder

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -68,7 +68,6 @@ def invoke_param_callback(callback, ctx, param, value):
     args = getattr(code, 'co_argcount', 3)
 
     if args < 3:
-        # This will become a warning in Click 3.0:
         from warnings import warn
         warn(Warning('Invoked legacy parameter callback "%s".  The new '
                      'signature for such callbacks starting with '

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = -p no:warnings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     version=version,
     url='http://github.com/mitsuhiko/click',
     packages=['click'],
+    tests_require=['pytest>=2.8'],
     description='A simple wrapper around optparse for '
                 'powerful command line utilities.',
     classifiers=[

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,3 +1,5 @@
+import pytest
+
 import click
 
 
@@ -11,10 +13,19 @@ if click.__version__ >= '3.0':
         def cli(foo):
             click.echo(foo)
 
-        result = runner.invoke(cli, ['--foo', 'wat'])
+        with pytest.warns(Warning) as records:
+            result = runner.invoke(cli, ['--foo', 'wat'])
+
+        [warning_record] = records
+        warning_message = str(warning_record.message)
+        assert 'Invoked legacy parameter callback' in warning_message
         assert result.exit_code == 0
+        # Depending on the pytest version, the warning message may be
+        # in `result.output`.
+        #
+        # In pytest version 3.1 pytest started capturing warnings by default.
+        # See https://docs.pytest.org/en/latest/warnings.html#warnings-capture.
         assert 'WAT' in result.output
-        assert 'Invoked legacy parameter callback' in result.output
 
 
 def test_bash_func_name():


### PR DESCRIPTION
Fixes #823 

Or, at least, this attempts to fix the builder and it makes the tests pass locally.