### PR TITLE
main: pass through rv to ctx.exit

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -706,7 +706,7 @@ class BaseCommand(object):
                     rv = self.invoke(ctx)
                     if not standalone_mode:
                         return rv
-                    ctx.exit()
+                    ctx.exit(rv)
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()

--- a/click/core.py
+++ b/click/core.py
@@ -706,7 +706,7 @@ class BaseCommand(object):
                     rv = self.invoke(ctx)
                     if not standalone_mode:
                         return rv
-                    ctx.exit(rv)
+                    ctx.exit(rv if rv is not None else 0)
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()


### PR DESCRIPTION
Without this the following would exit with code 0:

```
@click.command()
@click.argument('filename', required=True, nargs=-1)
def main(filename):
    return 1
```

This is from a __main__.py file, which is used as an entrypoint (I am
transitioning to using click).

Traceback to the `return 1`:

```
[0]   project/.venv/bin/covimerage(11)<module>()
-> load_entry_point('covimerage', 'console_scripts', 'covimerage')()
[1]   ~/Vcs/click/click/core.py(731)__call__()
-> return self.main(*args, **kwargs)
[2]   ~/Vcs/click/click/core.py(706)main()
-> rv = self.invoke(ctx)
[3]   ~/Vcs/click/click/core.py(907)invoke()
-> return ctx.invoke(self.callback, **ctx.params)
[4]   ~/Vcs/click/click/core.py(544)invoke()
-> return callback(*args, **kwargs)
[5] > project/covimerage/__main__.py(14)main()
-> return 1
```