### PR TITLE
minor: do not wrap exception messages

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1719,8 +1719,7 @@ class Argument(Parameter):
                 required = attrs.get('nargs', 1) > 0
         Parameter.__init__(self, param_decls, required=required, **attrs)
         if self.default is not None and self.nargs < 0:
-            raise TypeError('nargs=-1 in combination with a default value '
-                            'is not supported.')
+            raise TypeError('nargs=-1 in combination with a default value is not supported.')  # noqa: E501
 
     @property
     def human_readable_name(self):


### PR DESCRIPTION
Apart from that: could this be supported?
It is useful with a custom `callback` that should get applied always (even for the default).