### PR TITLE
Pass ctx to NoSuchOption exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Unreleased
 -   Update doc to match arg name for ``path_type``. (`#801`_)
 -   Raw strings added so correct escaping occurs. (`#807`_)
 -   Add bool conversion for "t" and "f". (`#842`_)
+-   ``NoSuchOption`` errors take ``ctx`` so that ``--help`` hint gets printed in error output. (`#860`_)
 -   Fixed the behavior of Click error messages with regards to unicode on 2.x and 3.x. Message is now always unicode and the str and unicode special methods work as you expect on that platform. (`#862`_)
 -   Progress bar now uses stderr by default. (`#863`_)
 -   Add support for auto-completion documentation. (`#866`_, `#869`_)
@@ -142,6 +143,7 @@ Unreleased
 .. _#807: https://github.com/pallets/click/pull/807
 .. _#809: https://github.com/pallets/click/pull/809
 .. _#842: https://github.com/pallets/click/pull/842
+.. _#860: https://github.com/pallets/click/issues/860
 .. _#862: https://github.com/pallets/click/issues/862
 .. _#863: https://github.com/pallets/click/pull/863
 .. _#865: https://github.com/pallets/click/pull/865

--- a/click/parser.py
+++ b/click/parser.py
@@ -321,7 +321,7 @@ class OptionParser(object):
         if opt not in self._long_opt:
             possibilities = [word for word in self._long_opt
                              if word.startswith(opt)]
-            raise NoSuchOption(opt, possibilities=possibilities)
+            raise NoSuchOption(opt, possibilities=possibilities, ctx=self.ctx)
 
         option = self._long_opt[opt]
         if option.takes_value:
@@ -364,7 +364,7 @@ class OptionParser(object):
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(opt)
+                raise NoSuchOption(opt, ctx=self.ctx)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.


### PR DESCRIPTION
This is a naive change without tests or any real understanding of the implications, but it seems correct on the surface.

To provide the user with better help (e.g. "Try 'CMD --help' for help.") the context needs to come along with the exception, unless there's another approach I'm missing.