### PR TITLE
ProgressBar should use stderr by default

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -192,43 +192,40 @@ class ProgressBar(object):
 
     def render_progress(self):
         from .termui import get_terminal_size
-        nl = False
 
         if self.is_hidden:
-            buf = [self.label]
-            nl = True
-        else:
-            buf = []
-            # Update width in case the terminal has been resized
-            if self.autowidth:
-                old_width = self.width
-                self.width = 0
-                clutter_length = term_len(self.format_progress_line())
-                new_width = max(0, get_terminal_size()[0] - clutter_length)
-                if new_width < old_width:
-                    buf.append(BEFORE_BAR)
-                    buf.append(' ' * self.max_width)
-                    self.max_width = new_width
-                self.width = new_width
+            return
 
-            clear_width = self.width
-            if self.max_width is not None:
-                clear_width = self.max_width
+        buf = []
+        # Update width in case the terminal has been resized
+        if self.autowidth:
+            old_width = self.width
+            self.width = 0
+            clutter_length = term_len(self.format_progress_line())
+            new_width = max(0, get_terminal_size()[0] - clutter_length)
+            if new_width < old_width:
+                buf.append(BEFORE_BAR)
+                buf.append(' ' * self.max_width)
+                self.max_width = new_width
+            self.width = new_width
 
-            buf.append(BEFORE_BAR)
-            line = self.format_progress_line()
-            line_len = term_len(line)
-            if self.max_width is None or self.max_width < line_len:
-                self.max_width = line_len
-            buf.append(line)
+        clear_width = self.width
+        if self.max_width is not None:
+            clear_width = self.max_width
 
-            buf.append(' ' * (clear_width - line_len))
+        buf.append(BEFORE_BAR)
+        line = self.format_progress_line()
+        line_len = term_len(line)
+        if self.max_width is None or self.max_width < line_len:
+            self.max_width = line_len
+
+        buf.append(line)
+        buf.append(' ' * (clear_width - line_len))
         line = ''.join(buf)
-
         # Render the line only if it changed.
         if line != self._last_line:
             self._last_line = line
-            echo(line, file=self.file, color=self.color, nl=nl)
+            echo(line, file=self.file, color=self.color, nl=True)
             self.file.flush()
 
     def make_step(self, n_steps):

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -44,6 +44,19 @@ def test_progressbar_length_hint(runner, monkeypatch):
     assert result.exception is None
 
 
+def test_progressbar_hidden(runner, monkeypatch):
+    label = 'whatever'
+
+    @click.command()
+    def cli():
+        with click.progressbar(tuple(range(10)), label=label) as progress:
+            for thing in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: False)
+    assert runner.invoke(cli, []).output == ''
+
+
 def test_choices_list_in_prompt(runner, monkeypatch):
     @click.command()
     @click.option('-g', type=click.Choice(['none', 'day', 'week', 'month']),


### PR DESCRIPTION
A minor change (I think), but it makes sense when we have commands that we want to pipe or redirect the "real" output, not the  progressbar.

If accepted I'll add a note in documentation.
I'm not sure if this change is testable, but I can try to add a test too.

I saw other PR targeting master branch instead of the maintenance branches pointed in the contributing guideline, tell me if I need to change the target branch.