### PR TITLE
Add native ZSH completion script

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Version 7.0
   See #790.
 - Allow autocompletion function to determine whether or not to return
   completions that start with the incomplete argument.
+- Add native ZSH autocompletion support See #323.
 - Subcommands that are named by the function now automatically have the
   underscore replaced with a dash.  So if you register a function named
   `my_command` it becomes `my-command` in the command line interface.

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -225,7 +225,7 @@ def do_complete(cli, prog_name):
 
 def bashcomplete(cli, prog_name, complete_var, complete_instr):
     if complete_instr.startswith('source'):
-        shell = 'zsh' if complete_instr.endswith('zsh') else 'bash'
+        shell = 'zsh' if complete_instr == 'source_zsh' else 'bash'
         echo(get_completion_script(prog_name, complete_var, shell))
         return True
     elif complete_instr == 'complete':

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -75,7 +75,11 @@ is what you would need to put into your ``.bashrc``::
 
     eval "$(_FOO_BAR_COMPLETE=source foo-bar)"
 
-From this point onwards, your script will have Bash completion enabled.
+For zsh users add this to your ``.zshrc``::
+
+    eval "$(_FOO_BAR_COMPLETE=source_zsh foo-bar)"
+
+From this point onwards, your script will have autocompletion enabled.
 
 Activation Script
 -----------------
@@ -90,17 +94,12 @@ This can be easily accomplished::
 
     _FOO_BAR_COMPLETE=source foo-bar > foo-bar-complete.sh
 
-And then you would put this into your bashrc instead::
+For zsh:
+
+    _FOO_BAR_COMPLETE=source_zsh foo-bar > foo-bar-complete.sh
+
+And then you would put this into your .bashrc or .zshrc instead::
 
     . /path/to/foo-bar-complete.sh
 
-Zsh Compatibility
------------------
 
-To enable Bash completion in Zsh, add the following lines to your .zshrc:
-
-    autoload bashcompinit
-    bashcompinit
-
-See https://github.com/pallets/click/issues/323 for more information on
-this issue.

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -20,6 +20,6 @@ if click.__version__ >= '3.0':
 
 def test_bash_func_name():
     from click._bashcomplete import get_completion_script
-    script = get_completion_script('foo-bar baz_blah', '_COMPLETE_VAR').strip()
+    script = get_completion_script('foo-bar baz_blah', '_COMPLETE_VAR', 'bash').strip()
     assert script.startswith('_foo_barbaz_blah_completion()')
     assert '_COMPLETE_VAR=complete $1' in script


### PR DESCRIPTION
Add native ZSH completion script. This allows completion in ZSH without the need for `autoload bashcompinit` and `bashcompinit` Fixes #323 