### PR TITLE
CliRunner: add stdout / stderr, allow separating standard streams

### DIFF
--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -65,7 +65,7 @@ def test_choices_list_in_prompt(runner, monkeypatch):
 
 
 def test_secho(runner):
-    with runner.isolation() as out:
+    with runner.isolation() as outstreams:
         click.secho(None, nl=False)
-        bytes = out.getvalue()
+        bytes = outstreams[0].getvalue()
         assert bytes == b''

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -204,6 +204,30 @@ def test_env():
     assert os.environ == env_orig
 
 
+def test_stderr():
+    @click.command()
+    def cli_stderr():
+        click.echo("stdout")
+        click.echo("stderr", err=True)
+
+    runner = CliRunner(mix_stderr=False)
+
+    result = runner.invoke(cli_stderr)
+
+    assert result.output == 'stdout\n'
+    assert result.stdout == 'stdout\n'
+    assert result.stderr == 'stderr\n'
+
+    runner_mix = CliRunner(mix_stderr=True)
+    result_mix = runner_mix.invoke(cli_stderr)
+
+    assert result_mix.output == 'stdout\nstderr\n'
+    assert result_mix.stdout == 'stdout\nstderr\n'
+
+    with pytest.raises(ValueError):
+        result_mix.stderr
+
+
 @pytest.mark.parametrize('args, expected_output', [
     (None, 'bar\n'),
     ([], 'bar\n'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,13 +10,13 @@ from click._compat import WIN, PY2
 
 
 def test_echo(runner):
-    with runner.isolation() as out:
+    with runner.isolation() as outstreams:
         click.echo(u'\N{SNOWMAN}')
         click.echo(b'\x44\x44')
         click.echo(42, nl=False)
         click.echo(b'a', nl=False)
         click.echo('\x1b[31mx\x1b[39m', nl=False)
-        bytes = out.getvalue().replace(b'\r\n', b'\n')
+        bytes = outstreams[0].getvalue().replace(b'\r\n', b'\n')
         assert bytes == b'\xe2\x98\x83\nDD\n42ax'
 
     # If we are in Python 2, we expect that writing bytes into a string io
@@ -35,12 +35,12 @@ def test_echo(runner):
     def cli():
         click.echo(b'\xf6')
     result = runner.invoke(cli, [])
-    assert result.output_bytes == b'\xf6\n'
+    assert result.stdout_bytes == b'\xf6\n'
 
     # Ensure we do not strip for bytes.
-    with runner.isolation() as out:
+    with runner.isolation() as outstreams:
         click.echo(bytearray(b'\x1b[31mx\x1b[39m'), nl=False)
-        assert out.getvalue() == b'\x1b[31mx\x1b[39m'
+        assert outstreams[0].getvalue() == b'\x1b[31mx\x1b[39m'
 
 
 def test_echo_custom_file():


### PR DESCRIPTION
attempt resolution of #371 (adding stdout / stderr)

This changes the internal API such that a singular out is never returned - it's either `(stdout, stderr)` when not mixed or `(stdout_and_stderr, False)` when mixed

This defaults to mixed to preserve old use cases (and tests); the runner switches to non-mixed via `mix_stderr`