### PR TITLE
Fix/default value proc

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -101,7 +101,7 @@ def prompt(text, default=None, hide_input=False, confirmation_prompt=False,
             # prompt is always skipped because that's the only thing
             # that really makes sense.
             elif default is not None:
-                return default
+                return value_proc(default)
         try:
             result = value_proc(value)
         except UsageError as e:


### PR DESCRIPTION
https://github.com/pallets/click/issues/870

# Changes
- Passes the `default` value through `value_proc` and then returns it. At the moment, the default value is just returned. Thus the input to the function call cannot determine if the value is changed.