### PR TITLE
Fix variable precedence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 build
 docs/_build
 click.egg-info
+venv/
 .tox
 .cache
 .ropeproject

--- a/click/core.py
+++ b/click/core.py
@@ -1328,12 +1328,13 @@ class Parameter(object):
     def add_to_parser(self, parser, ctx):
         pass
 
+
     def consume_value(self, ctx, opts):
         value = opts.get(self.name)
         if value is None:
-            value = ctx.lookup_default(self.name)
-        if value is None:
             value = self.value_from_envvar(ctx)
+        if value is None:
+            value = ctx.lookup_default(self.name)
         return value
 
     def type_cast_value(self, ctx, value):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27,py34,py35,py36,pypy
+skip_missing_interpreters = true
 
 [testenv]
 passenv = LANG


### PR DESCRIPTION
This patch fixes the variable precedence in order to have the default
values read last:

1. Values from CLI
2. Values from the environment
3. Default values

Tests were added accordingly.

Drive-by:
* Update `.gitignore` file
* Update `tox.ini` to skip missing environments

Fixes: #873