### PR TITLE
Add trove classifiers for all supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,15 @@ setup(
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )


### PR DESCRIPTION
Help library users know, at a glance, if the library is suitable for their project.

Supported version obtain from travis and tox configurations.