### PR TITLE
Fix invalid escape sequences discovered by running tests

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1230,7 +1230,7 @@ class CommandCollection(MultiCommand):
 
 
 class Parameter(object):
-    """A parameter to a command comes in two versions: they are either
+    r"""A parameter to a command comes in two versions: they are either
     :class:`Option`\s or :class:`Argument`\s.  Other subclasses are currently
     not supported by design as some of the internals for parsing are
     intentionally not finalized.

--- a/click/decorators.py
+++ b/click/decorators.py
@@ -90,7 +90,7 @@ def _make_command(f, name, attrs, cls):
 
 
 def command(name=None, cls=None, **attrs):
-    """Creates a new :class:`Command` and uses the decorated function as
+    r"""Creates a new :class:`Command` and uses the decorated function as
     callback.  This will also automatically attach all decorated
     :func:`option`\s and :func:`argument`\s as parameters to the command.
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -84,7 +84,7 @@ def test_counting(runner):
     assert result.output == 'verbosity=0\n'
 
     result = runner.invoke(cli, ['--help'])
-    assert re.search('-v\s+Verbosity', result.output) is not None
+    assert re.search(r'-v\s+Verbosity', result.output) is not None
 
 
 @pytest.mark.parametrize('unknown_flag', ['--foo', '-f'])


### PR DESCRIPTION
When running tests with Python 3.6 and warnings enabled, will see:

```
  DeprecationWarning: invalid escape sequence \s
```

Python documentation on this deprecation:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now
> generates a DeprecationWarning. Although this will eventually become a
> SyntaxError, that will not be for several Python releases.