### PR TITLE
remove hard dependency on 'locale' binary for PY3

### DIFF
--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -62,8 +62,11 @@ def _verify_python3_env():
     extra = ''
     if os.name == 'posix':
         import subprocess
-        rv = subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE).communicate()[0]
+        try:
+            rv = subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE).communicate()[0]
+        except FileNotFoundError:
+            rv = ''
         good_locales = set()
         has_c_utf8 = False
 


### PR DESCRIPTION
Generating Click's error message/`RuntimeError` for Python 3 under a non-unicode locale requires the `locale` command to be available. `locale` might not be available, though, for instance in minimal images used for CI services, e.g., https://github.com/bitnami/minideb.

With this minimal change the "extra" information for the error will be
```python
extra = (
    '\n\n'
    'Additional information: on this system no suitable UTF-8\n'
    'locales were discovered.  This most likely requires resolving\n'
    'by reconfiguring the locale system.'
)
```
if `locale` is not available, which is still seems reasonable in my eyes.