### PR TITLE
Clean up Sphinx errors.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 7.0
 -----------
 
 (upcoming release with new features, release date to be decided)
+
 - Added support for bash completions containing spaces. See #773.
 - Added support for dynamic bash completion from a user-supplied callback.
   See #755.

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -95,7 +95,7 @@ And then you would put this into your bashrc instead::
     . /path/to/foo-bar-complete.sh
 
 Zsh Compatibility
-----------------
+-----------------
 
 To enable Bash completion in Zsh, add the following lines to your .zshrc:
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -41,7 +41,7 @@ new in Click 6.0.
 
 Click now emulates output streams on Windows to support unicode to the
 Windows console through separate APIs.  For more information see
-`wincmd`_.
+:doc:`wincmd`.
 
 .. versionadded:: 3.0
 
@@ -283,7 +283,7 @@ Example::
 
 Click now emulates output streams on Windows to support unicode to the
 Windows console through separate APIs.  For more information see
-`wincmd`_.
+:doc:`wincmd`.
 
 
 Intelligent File Opening


### PR DESCRIPTION
Fixes these errors:

```
/Users/jacob/Projects/opensource/click/docs/bashcomplete.rst:98: WARNING: Title underline too short.
../CHANGES:12: WARNING: Unexpected indentation.
../CHANGES:13: WARNING: Block quote ends without a blank line; unexpected unindent.
/Users/jacob/Projects/opensource/click/docs/utils.rst:42: WARNING: Unknown target name: "wincmd".
/Users/jacob/Projects/opensource/click/docs/utils.rst:284: WARNING: Unknown target name: "wincmd".
```