### PR TITLE
Add `case_sensitive=False` as an option to Choice types

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -133,11 +133,15 @@ class Choice(ParamType):
     generators) may lead to surprising results.
 
     See :ref:`choice-opts` for an example.
+
+    :param case_sensitive: Set to false to make choices case insensitive.
+    Defaults to true.
     """
     name = 'choice'
 
-    def __init__(self, choices):
+    def __init__(self, choices, case_sensitive=True):
         self.choices = choices
+        self.case_sensitive = case_sensitive
 
     def get_metavar(self, param):
         return '[%s]' % '|'.join(self.choices)
@@ -150,13 +154,25 @@ class Choice(ParamType):
         if value in self.choices:
             return value
 
-        # Match through normalization
+        # Match through normalization and case sensitivity
+        # first do token_normalize_func, then lowercase
+        # preserve original `value` to produce an accurate message in
+        # `self.fail`
+        normed_value = value
+        normed_choices = self.choices
+
         if ctx is not None and \
            ctx.token_normalize_func is not None:
-            value = ctx.token_normalize_func(value)
-            for choice in self.choices:
-                if ctx.token_normalize_func(choice) == value:
-                    return choice
+            normed_value = ctx.token_normalize_func(value)
+            normed_choices = [ctx.token_normalize_func(choice) for choice in
+                              self.choices]
+
+        if not self.case_sensitive:
+            normed_value = normed_value.lower()
+            normed_choices = [choice.lower() for choice in normed_choices]
+
+        if normed_value in normed_choices:
+            return normed_value
 
         self.fail('invalid choice: %s. (choose from %s)' %
                   (value, ', '.join(self.choices)), param, ctx)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -283,6 +283,37 @@ def test_missing_choice(runner):
         in result.output
 
 
+def test_case_insensitive_choice(runner):
+    @click.command()
+    @click.option('--foo', type=click.Choice(
+        ['Orange', 'Apple'], case_sensitive=False))
+    def cmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(cmd, ['--foo', 'apple'])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cmd, ['--foo', 'oRANGe'])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cmd, ['--foo', 'Apple'])
+    assert result.exit_code == 0
+
+    @click.command()
+    @click.option('--foo', type=click.Choice(['Orange', 'Apple']))
+    def cmd2(foo):
+        click.echo(foo)
+
+    result = runner.invoke(cmd2, ['--foo', 'apple'])
+    assert result.exit_code == 2
+
+    result = runner.invoke(cmd2, ['--foo', 'oRANGe'])
+    assert result.exit_code == 2
+
+    result = runner.invoke(cmd2, ['--foo', 'Apple'])
+    assert result.exit_code == 0
+
+
 def test_multiline_help(runner):
     @click.command()
     @click.option('--foo', help="""


### PR DESCRIPTION
#569 suggested that maybe options and arguments could accept their own token normalization functions, so that you can get case insensitivity on a per-option/per-argument basis without impacting the case sensitivity of other parameters.
However, it's not obvious that the other types actually would benefit from this behavior -- the desire for such a feature on `click.Choice` comes from the fact that its validation logic runs before the command gets a value. In many other cases, `.lower()` can be called after types have done their work with no ill effect.

Adds a test that validates both the new and the old behavior WRT case sensitivity. Applies lowercasing *after* token normalization, in case someone has a `token_normalize_func` which is, itself, case-sensitive.

Closes #569