### PR TITLE
Implement streaming pager. Fixes #409

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -114,6 +114,17 @@ Example:
         click.echo_via_pager('\n'.join('Line %d' % idx
                                        for idx in range(200)))
 
+If you want to use the pager for a lot of text, especially if generating everything in advance would take a lot of time, you can pass a generator (or generator function) instead of a string:
+
+.. click:example::
+    def _generate_output():
+        for idx in range(50000):
+            yield "Line %d\n" % idx
+
+    @click.command()
+    def less():
+        click.echo_via_pager(_generate_output())
+
 
 Screen Clearing
 ---------------


### PR DESCRIPTION
The streaming pager works using generators. Fixes #409

You can pass a generator function or object into echo_via_pager:

generator expression:
```
click.echo_via_pager(("{}\n".format(i) for i in range(999999)))
```

generator function / expression:
```
def gen():
    for i in range(50000):
        yield "Line {}\n".format(i)

click.echo_via_pager(gen)
click.echo_via_pager(gen()) # you can pass both
```

What do you think about this?

### TODO

- [x] Documentation
- [x] Broken tests
- [x] Rebase once #890 is merged
- [x] Implement review feedback
- [ ] Find solution for windows pager + never terminating generators

  
  