### PR TITLE
Fix issue #892

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -134,7 +134,7 @@ class Choice(ParamType):
     name = 'choice'
 
     def __init__(self, choices):
-        self.choices = choices
+        self.choices = list(choices)
 
     def get_metavar(self, param):
         return '[%s]' % '|'.join(self.choices)


### PR DESCRIPTION
If the *choices* argument is not a list but a generator expression, it will eventually exhaust and lead to strange erros (e.g., the list of available choices looks empty, the order in which you pass choices is relevant). By wrapping it with `list()`, this should no longer be a problem.