### PR TITLE
Add context to Commands and Groups example...

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -22,6 +22,8 @@ when an inner command runs:
 
 .. click:example::
 
+    import click
+
     @click.group()
     @click.option('--debug/--no-debug', default=False)
     def cli(debug):
@@ -30,6 +32,11 @@ when an inner command runs:
     @cli.command()
     def sync():
         click.echo('Synching')
+
+    if __name__ == '__main__':
+        cli.add_command(sync)
+        cli()
+
 
 Here is what this looks like:
 


### PR DESCRIPTION
This way it works without needing to guess at the context; more
helpful for newbs.

If you read the docs straight through, you'll know this, but I ended up at this page searching by topic before I learned about `add_command`.