### PR TITLE
Use non-breaking space after "default: "

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1633,7 +1633,7 @@ class Option(Parameter):
         help = self.help or ''
         extra = []
         if self.default is not None and self.show_default:
-            extra.append('default: %s' % (
+            extra.append(u'default:\xa0%s' % (
                          ', '.join('%s' % d for d in self.default)
                          if isinstance(self.default, (list, tuple))
                          else self.default, ))


### PR DESCRIPTION
This makes textwrap not wrap just after the `[default:`.