### PR TITLE
allow click to interoperate with jupyter notebooks

### DIFF
--- a/click/utils.py
+++ b/click/utils.py
@@ -211,11 +211,17 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
     :param color: controls if the terminal supports ANSI colors or not.  The
                   default is autodetection.
     """
-    if file is None:
+    if is_running_jupyter():
         if err:
-            file = _default_text_stderr()
+            file = sys.stderr
         else:
-            file = _default_text_stdout()
+            file = sys.stdout
+    else:
+        if file is None:
+            if err:
+                file = _default_text_stderr()
+            else:
+                file = _default_text_stdout()
 
     # Convert non bytes/text into the native string type.
     if message is not None and not isinstance(message, echo_native_types):
@@ -346,6 +352,11 @@ def get_os_args():
     if PY2 and WIN and _initial_argv_hash == _hash_py_argv():
         return _get_windows_argv()
     return sys.argv[1:]
+
+
+def is_running_jupyter():
+    """Return if running inside a Jupyter Notebook"""
+    return bool(os.getenv("JPY_PARENT_PID"))
 
 
 def format_filename(filename, shorten=False):


### PR DESCRIPTION
Based on: https://github.com/elgalu/click/commit/1cb7aaba8c9dd6ec760d3e7e414d0b4e5f788543#diff-d17772ee4f65879b69a53dbc4b3d42bd

Jupyter captures stdout and stderr causing `click` to break with:

```
/Users/dbarroso/.virtualenvs/click_test/lib/python3.6/site-packages/utils.py in echo(message, file, nl, err, color)
    257 
    258     if message:
--> 259         file.write(message)
    260     file.flush()
    261 

UnsupportedOperation: not writable
```