### PR TITLE
'x' and 'a' filemodes use stdout when file is '-'

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -423,7 +423,7 @@ def open_stream(filename, mode='r', encoding=None, errors='strict',
     # Standard streams first.  These are simple because they don't need
     # special handling for the atomic flag.  It's entirely ignored.
     if filename == '-':
-        if 'w' in mode:
+        if any(m in mode for m in ['w', 'a', 'x']):
             if 'b' in mode:
                 return get_binary_stdout(), False
             return get_text_stdout(encoding=encoding, errors=errors), False


### PR DESCRIPTION
Fixes #776 

[The python documentation](https://docs.python.org/2/library/functions.html#open) specifies 'a' and 'x' as "write" filemodes. Therefore, click should respect that and open stdout instead of stdin whenever opening `-` under filemodes `a` or `x`