### PR TITLE
Fix missing comma in __all__ list

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
 
     # Types
     'ParamType', 'File', 'Path', 'Choice', 'IntRange', 'Tuple', 'STRING',
-    'INT', 'FLOAT', 'BOOL', 'UUID', 'UNPROCESSED', 'FloatRange'
+    'INT', 'FLOAT', 'BOOL', 'UUID', 'UNPROCESSED', 'FloatRange',
 
     # Utilities
     'echo', 'get_binary_stream', 'get_text_stream', 'open_file',


### PR DESCRIPTION
The 'FloatRange' string was incorrectly concatened with the 'echo' on
line below producing 'FloatRangeecho', because there was no comma in
between.  This caused import errors when doing

    from click import *

See e.g. https://github.com/jazzband/pip-tools/issues/636