### PR TITLE
Improve pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ universal=1
 
 [metadata]
 license_file = LICENSE
-
-[tool:pytest]
-addopts = -p no:warnings --tb=short


### PR DESCRIPTION
- Remove --tb=short: the default (auto) is better.  "short" was taken from
  the Makefile in b471d346.
- Remove "-p no:warnings".  This was added in 3ded26d and does not seem
  to be necessary anymore.