### PR TITLE
Set blocking I/O flags for FreeBSD

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -165,11 +165,12 @@ if PY2:
     # available (which is why we use try-catch instead of the WIN variable
     # here), such as the Google App Engine development server on Windows. In
     # those cases there is just nothing we can do.
+    def set_binary_mode(f):
+        return f
+
     try:
         import msvcrt
-    except ImportError:
-        set_binary_mode = lambda x: x
-    else:
+
         def set_binary_mode(f):
             try:
                 fileno = f.fileno()
@@ -178,6 +179,23 @@ if PY2:
             else:
                 msvcrt.setmode(fileno, os.O_BINARY)
             return f
+    except ImportError:
+        pass
+
+    try:
+        import fcntl
+
+        def set_binary_mode(f):
+            try:
+                fileno = f.fileno()
+            except Exception:
+                pass
+            else:
+                flags = fcntl.fcntl(fileno, fcntl.F_GETFL)
+                fcntl.fcntl(fileno, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+            return f
+    except ImportError:
+        pass
 
     def isidentifier(x):
         return _identifier_re.search(x) is not None


### PR DESCRIPTION
FreeBSD's threading library automatically sets stdin and stdout to be non-blocking.
So have to ensure that stdio is in blocking mode.

Similar fix in other project
https://trac.edgewall.org/ticket/2066
https://trac.edgewall.org/changeset/2260