### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -295,8 +295,8 @@ In the end you end up with something like this:
     @click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode')
     @click.argument('timeit_args', nargs=-1, type=click.UNPROCESSED)
     def cli(verbose, timeit_args):
-        """A wrapper around Python's timeit."""
-        cmdline = ['python', '-mtimeit'] + list(timeit_args)
+        """A fake wrapper around Python's timeit."""
+        cmdline = ['echo', 'python', '-mtimeit'] + list(timeit_args)
         if verbose:
             click.echo('Invoking: %s' % ' '.join(cmdline))
         call(cmdline)

--- a/docs/complex.rst
+++ b/docs/complex.rst
@@ -210,7 +210,7 @@ As such it runs standalone:
     @click.command()
     @pass_repo
     def cp(repo):
-        click.echo(repo)
+        click.echo(isinstance(repo, Repo))
 
 As you can see:
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that click could not be built reproducibly.

This is due to the documentation containing non-determinstic output
such as memory contents or the output of timeit.

This was originally filed in Debian as #895270 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/895270

Signed-off-by: Chris Lamb <lamby@debian.org>