### PR TITLE
Change pypi.python.org urls to pypi.org

### DIFF
--- a/click/utils.py
+++ b/click/utils.py
@@ -184,7 +184,7 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
     -   hide ANSI codes automatically if the destination file is not a
         terminal.
 
-    .. _colorama: http://pypi.python.org/pypi/colorama
+    .. _colorama: https://pypi.org/project/colorama/
 
     .. versionchanged:: 6.0
        As of Click 6.0 the echo function will properly support unicode

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -7,7 +7,7 @@
 <h3>Useful Links</h3>
 <ul>
   <li><a href="http://click.pocoo.org/">The Click Website</a></li>
-  <li><a href="http://pypi.python.org/pypi/click">click @ PyPI</a></li>
+  <li><a href="https://pypi.org/project/click/">click @ PyPI</a></li>
   <li><a href="http://github.com/pallets/click">click @ github</a></li>
   <li><a href="http://github.com/pallets/click/issues">Issue Tracker</a></li>
 </ul>

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -95,7 +95,7 @@ a single function called :func:`secho`::
     click.secho('ATTENTION', blink=True, bold=True)
 
 
-.. _colorama: https://pypi.python.org/pypi/colorama
+.. _colorama: https://pypi.org/project/colorama/
 
 Pager Support
 -------------


### PR DESCRIPTION
More details about this change can be found at:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html