### PR TITLE
Support Sphinx 1.7+

### DIFF
--- a/docs/clickdoctools.py
+++ b/docs/clickdoctools.py
@@ -15,7 +15,7 @@ from docutils import nodes
 from docutils.statemachine import ViewList
 
 from sphinx.domains import Domain
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 PY2 = sys.version_info[0] == 2
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup(
     maintainer_email='contact@palletsprojects.com',
     long_description=readme,
     packages=['click'],
+    extras_require={
+        'docs': [
+            'sphinx',
+        ],
+    },
     description='A simple wrapper around optparse for '
                 'powerful command line utilities.',
     license='BSD',


### PR DESCRIPTION
For #975 
Change:

1. `from sphinx.util.compat import Directive` to `from docutils.parsers.rst import Directive`
1. Add docs requirements into setup.py