### PR TITLE
Use human readable param hint when metavar supplied

### DIFF
--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -81,8 +81,10 @@ class BadParameter(UsageError):
     def format_message(self):
         if self.param_hint is not None:
             param_hint = self.param_hint
+        elif self.param.metavar is not None:
+            param_hint = self.param.human_readable_name
         elif self.param is not None:
-            param_hint = self.param.opts or [self.param.human_readable_name]
+            param_hint = self.param.opts
         else:
             return 'Invalid value: %s' % self.message
         if isinstance(param_hint, (tuple, list)):
@@ -110,8 +112,10 @@ class MissingParameter(BadParameter):
     def format_message(self):
         if self.param_hint is not None:
             param_hint = self.param_hint
+        elif self.param.metavar is not None:
+            param_hint = self.param.human_readable_name
         elif self.param is not None:
-            param_hint = self.param.opts or [self.param.human_readable_name]
+            param_hint = self.param.opts
         else:
             param_hint = None
         if isinstance(param_hint, (tuple, list)):

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -202,6 +202,28 @@ def test_missing_arg(runner):
     assert 'Missing argument "arg".' in result.output
 
 
+def test_missing_arg_human_readable(runner):
+    @click.command()
+    @click.argument('arg', metavar='arg-metavar')
+    def cmd(arg):
+        click.echo('arg:' + arg)
+
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 2
+    assert 'Missing argument arg-metavar.' in result.output
+
+
+def test_bad_arg_human_readable(runner):
+    @click.command()
+    @click.argument('arg', type=click.INT, metavar='arg-metavar')
+    def cmd(arg):
+        click.echo('arg: ' + str(arg))
+
+    result = runner.invoke(cmd, ['3.14'])
+    assert result.exit_code == 2
+    assert 'Invalid value for arg-metavar' in result.output
+
+
 def test_implicit_non_required(runner):
     @click.command()
     @click.argument('f', default='test')


### PR DESCRIPTION
The existing format_message methods for MissingParameter and BadParameter always set the param hint to param.opts which is the argument name, short circuiting the human readable name. This change removes the or logic and instead first sets param hint to human readable name if metavar is supplied.

Two test were added to ensure the exceptions for MissingParameter and BadParameter use the human readable name instead of the argument name.

Closes #855 
Closes #598 
Closes #273 