### PR TITLE
Fix issue #926 - copy option attrs so that custom classes can be re-used.

### DIFF
--- a/click/decorators.py
+++ b/click/decorators.py
@@ -164,10 +164,13 @@ def option(*param_decls, **attrs):
                 :class:`Option`.
     """
     def decorator(f):
-        if 'help' in attrs:
-            attrs['help'] = inspect.cleandoc(attrs['help'])
-        OptionClass = attrs.pop('cls', Option)
-        _param_memo(f, OptionClass(param_decls, **attrs))
+        # Issue 926, copy attrs, so pre-defined options can re-use the same cls=
+        option_attrs = attrs.copy()
+
+        if 'help' in option_attrs:
+            option_attrs['help'] = inspect.cleandoc(option_attrs['help'])
+        OptionClass = option_attrs.pop('cls', Option)
+        _param_memo(f, OptionClass(param_decls, **option_attrs))
         return f
     return decorator
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -311,6 +311,35 @@ def test_option_custom_class(runner):
     assert 'you wont see me' not in result.output
 
 
+def test_option_custom_class_reusable(runner):
+    """Ensure we can reuse a custom class option. See Issue #926"""
+
+    class CustomOption(click.Option):
+        def get_help_record(self, ctx):
+            '''a dumb override of a help text for testing'''
+            return ('--help', 'I am a help text')
+
+    # Assign to a variable to re-use the decorator.
+    testoption = click.option('--testoption', cls=CustomOption, help='you wont see me')
+
+    @click.command()
+    @testoption
+    def cmd1(testoption):
+        click.echo(testoption)
+
+    @click.command()
+    @testoption
+    def cmd2(testoption):
+        click.echo(testoption)
+
+    # Both of the commands should have the --help option now.
+    for cmd in (cmd1, cmd2):
+
+        result = runner.invoke(cmd, ['--help'])
+        assert 'I am a help text' in result.output
+        assert 'you wont see me' not in result.output
+
+
 def test_aliases_for_flags(runner):
     @click.command()
     @click.option('--warnings/--no-warnings', ' /-W', default=True)


### PR DESCRIPTION
Fix issue #926 - copy option attrs so that custom classes can be re-used.