### PR TITLE
Better handling of help text for dynamic default option values

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -45,6 +45,19 @@ And on the command line:
 In this case the option is of type :data:`INT` because the default value
 is an integer.
 
+To show the default values when showing command help, use ``show_default=True``
+
+.. click:example::
+
+    @click.command()
+    @click.option('--n', default=1, show_default=True)
+    def dots(n):
+        click.echo('.' * n)
+
+.. click:run::
+
+   invoke(dots, args=['--help'])
+
 Multi Value Options
 -------------------
 
@@ -388,6 +401,21 @@ from the environment:
                   default=lambda: os.environ.get('USER', ''))
     def hello(username):
         print("Hello,", username)
+
+To describe what the default value will be, set it in ``show_default``.
+
+.. click:example::
+
+    @click.command()
+    @click.option('--username', prompt=True,
+                  default=lambda: os.environ.get('USER', ''),
+                  show_default='current user')
+    def hello(username):
+        print("Hello,", username)
+
+.. click:run::
+
+   invoke(hello, args=['--help'])
 
 Callbacks and Eager Options
 ---------------------------

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,20 @@ setup(
     maintainer_email='contact@palletsprojects.com',
     long_description=readme,
     packages=['click'],
-    extras_require={
-        'docs': [
-            'sphinx',
-        ],
-    },
     description='A simple wrapper around optparse for '
                 'powerful command line utilities.',
     license='BSD',
+    extras_require={
+        'dev': [
+            'pytest>=3',
+            'coverage',
+            'tox',
+            'sphinx',
+        ],
+        'docs': [
+            'sphinx',
+        ]
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -174,6 +174,33 @@ def test_multiple_default_type(runner):
                            'two --arg2 4 four'.split())
     assert not result.exception
 
+def test_dynamic_default_help_unset(runner):
+    @click.command()
+    @click.option('--username', prompt=True,
+                  default=lambda: os.environ.get('USER', ''),
+                  show_default=True)
+    def cmd(username):
+        print("Hello,", username)
+
+    result = runner.invoke(cmd, ['--help'])
+    assert result.exit_code == 0
+    assert '--username' in result.output
+    assert 'lambda' not in result.output
+    assert '(dynamic)' in result.output
+
+def test_dynamic_default_help_text(runner):
+    @click.command()
+    @click.option('--username', prompt=True,
+                  default=lambda: os.environ.get('USER', ''),
+                  show_default='current user')
+    def cmd(username):
+        print("Hello,", username)
+
+    result = runner.invoke(cmd, ['--help'])
+    assert result.exit_code == 0
+    assert '--username' in result.output
+    assert 'lambda' not in result.output
+    assert '(current user)' in result.output
 
 def test_nargs_envvar(runner):
     @click.command()
@@ -301,7 +328,6 @@ def test_multiline_help(runner):
     assert '  --foo TEXT  hello' in out
     assert '              i am' in out
     assert '              multiline' in out
-
 
 def test_argument_custom_class(runner):
     class CustomArgument(click.Argument):


### PR DESCRIPTION
Rather than showing raw `lambda` code as default value for dynamic options, use `dynamic_default_text` to document what would be used as the default value.

Closes #844 and closes #547 