### PR TITLE
Rebased fix to get_winterm_size() returning (0, 0)

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -176,6 +176,8 @@ def get_terminal_size():
             sz = shutil_get_terminal_size()
             return sz.columns, sz.lines
 
+    # We provide a sensible default for get_winterm_size() when being invoked
+    # inside a subprocess. Without this, it would not provide a useful input.
     if get_winterm_size is not None:
         size = get_winterm_size()
         if size == (0, 0):

--- a/click/termui.py
+++ b/click/termui.py
@@ -177,7 +177,11 @@ def get_terminal_size():
             return sz.columns, sz.lines
 
     if get_winterm_size is not None:
-        return get_winterm_size()
+        size = get_winterm_size()
+        if size == (0, 0):
+            return (79, 24)
+        else:
+            return size
 
     def ioctl_gwinsz(fd):
         try:


### PR DESCRIPTION
Rebased #610 against current master.