### PR TITLE
format commands normalize format -> remove short_help option

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -746,8 +746,7 @@ class Command(BaseCommand):
     :param help: the help string to use for this command.
     :param epilog: like the help string but it's printed at the end of the
                    help page after everything else.
-    :param short_help: the short help to use for this command.  This is
-                       shown on the command listing of the parent command.
+    :param short_help: deprecated in favor of help
     :param add_help_option: by default each command registers a ``--help``
                             option.  This can be disabled by this parameter.
     :param hidden: hide this command from help outputs.
@@ -765,20 +764,9 @@ class Command(BaseCommand):
         #: should show up in the help page and execute.  Eager parameters
         #: will automatically be handled before non eager ones.
         self.params = params or []
-        self.help = help
+        self.help = help or short_help
         self.epilog = epilog
         self.options_metavar = options_metavar
-        if short_help is None and help:
-            if (context_settings is not None and
-                isinstance(context_settings.get('max_content_width'), int)):
-                    max_width = min(context_settings.get('max_content_width'),
-                                    get_terminal_size()[0])
-                    # arbitrary trim width, if a subcommond is longer than the
-                    # it get printed poorly
-                    short_help = make_default_short_help(help, max_width - 20)
-            else:
-                short_help = make_default_short_help(help)
-        self.short_help = short_help
         self.add_help_option = add_help_option
         self.hidden = hidden
 

--- a/click/core.py
+++ b/click/core.py
@@ -9,7 +9,7 @@ from .types import convert_type, IntRange, BOOL
 from .utils import make_str, make_default_short_help, echo, get_os_args
 from .exceptions import ClickException, UsageError, BadParameter, Abort, \
      MissingParameter
-from .termui import prompt, confirm
+from .termui import prompt, confirm, get_terminal_size
 from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
 from .globals import push_context, pop_context
@@ -769,7 +769,13 @@ class Command(BaseCommand):
         self.epilog = epilog
         self.options_metavar = options_metavar
         if short_help is None and help:
-            short_help = make_default_short_help(help)
+            try:
+                max_width = min(context_settings.get('max_content_width'),
+                                get_terminal_size()[0])
+                echo('trying to max width with %s' % max_width)
+                short_help = make_default_short_help(help, max_width)
+            except (AttributeError, TypeError) as e:
+                short_help = make_default_short_help(help)
         self.short_help = short_help
         self.add_help_option = add_help_option
         self.hidden = hidden

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -103,34 +103,6 @@ Example:
     invoke(hello, args=['--help'])
 
 
-Command Short Help
-------------------
-
-For commands, a short help snippet is generated.  By default, it's the first
-sentence of the help message of the command, unless it's too long.  This can
-also be overridden:
-
-.. click:example::
-
-    @click.group()
-    def cli():
-        """A simple command line tool."""
-
-    @cli.command('init', short_help='init the repo')
-    def init():
-        """Initializes the repository."""
-
-    @cli.command('delete', short_help='delete the repo')
-    def delete():
-        """Deletes the repository."""
-
-And what it looks like:
-
-.. click:run::
-
-    invoke(cli, prog_name='repo.py')
-
-
 Help Parameter Customization
 ----------------------------
 

--- a/examples/complex/complex/cli.py
+++ b/examples/complex/complex/cli.py
@@ -4,6 +4,7 @@ import click
 
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='COMPLEX')
+CONTEXT_SETTINGS['max_content_width'] = 700
 
 
 class Context(object):

--- a/examples/complex/complex/cli.py
+++ b/examples/complex/complex/cli.py
@@ -4,7 +4,6 @@ import click
 
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='COMPLEX')
-CONTEXT_SETTINGS['max_content_width'] = 700
 
 
 class Context(object):

--- a/examples/complex/complex/commands/cmd_init.py
+++ b/examples/complex/complex/commands/cmd_init.py
@@ -2,7 +2,7 @@ import click
 from complex.cli import pass_context
 
 
-@click.command('init', short_help='Initializes a repo.')
+@click.command('init', help='Initializes a repo.')
 @click.argument('path', required=False, type=click.Path(resolve_path=True))
 @pass_context
 def cli(ctx, path):

--- a/examples/complex/complex/commands/cmd_long.py
+++ b/examples/complex/complex/commands/cmd_long.py
@@ -1,0 +1,10 @@
+import click
+from complex.cli import pass_context
+
+
+@click.command('long', context_settings={'max_content_width': 700}, help='Shows a realy long message meant for the purposes of debugging the short help default option shortener function in util'*20)
+@pass_context
+def cli(ctx):
+    """Shows file changes in the current working directory."""
+    ctx.log('long: stuff happened')
+    ctx.vlog('bla bla bla, volatile long long long long long long unsigned debug info')

--- a/examples/complex/complex/commands/cmd_status.py
+++ b/examples/complex/complex/commands/cmd_status.py
@@ -2,7 +2,7 @@ import click
 from complex.cli import pass_context
 
 
-@click.command('status', short_help='Shows file changes.')
+@click.command('status', help='Shows file changes.')
 @pass_context
 def cli(ctx):
     """Shows file changes in the current working directory."""

--- a/examples/repo/repo.py
+++ b/examples/repo/repo.py
@@ -137,7 +137,7 @@ def commit(repo, files, message):
     click.echo('Commit message:\n' + msg)
 
 
-@cli.command(short_help='Copies files.')
+@cli.command(help='Copies files.')
 @click.option('--force', is_flag=True,
               help='forcibly copy over an existing managed file')
 @click.argument('src', nargs=-1, type=click.Path())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,7 +40,7 @@ def test_other_command_forward(runner):
 
 
 def test_auto_shorthelp(runner):
-    @click.group()
+    @click.group(context_settings={'max_content_width': 67})
     def cli():
         pass
 


### PR DESCRIPTION
The short_help option is only used in the commands view and seems to have caused some confusion about its interaction with the actual help for a command.

I propose we deprecate it and allow the format_commands to handle this