### PR TITLE
Fix #616: allow setting prog_name as extra in CliRunner.invoke

### DIFF
--- a/click/testing.py
+++ b/click/testing.py
@@ -318,8 +318,12 @@ class CliRunner(object):
                 args = shlex.split(args)
 
             try:
-                cli.main(args=args or (),
-                         prog_name=self.get_default_prog_name(cli), **extra)
+                prog_name = extra.pop("prog_name")
+            except KeyError:
+                prog_name = self.get_default_prog_name(cli)
+
+            try:
+                cli.main(args=args or (), prog_name=prog_name, **extra)
             except SystemExit as e:
                 exc_info = sys.exc_info()
                 exit_code = e.code

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -246,3 +246,14 @@ def test_args(args, expected_output):
     result = runner.invoke(cli_args, args=args)
     assert result.exit_code == 0
     assert result.output == expected_output
+
+
+def test_setting_prog_name_in_extra():
+    @click.command()
+    def cli():
+        click.echo("ok")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, prog_name="foobar")
+    assert not result.exception
+    assert result.output == 'ok\n'


### PR DESCRIPTION
Fixes `TypeError` caused by when trying to set `prog_name` as an an `extra` parameter.

`invoke()` was already explicitly setting the `prog_name` parameter,  so sending it in `extra` was providing multiple values for it.