### PR TITLE
WIP Wrap click.Choice's missing message

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -147,7 +147,7 @@ class Choice(ParamType):
         return '[%s]' % '|'.join(self.choices)
 
     def get_missing_message(self, param):
-        return 'Choose from %s.' % ', '.join(self.choices)
+        return 'Choose from:\n\t%s.' % ',\n\t'.join(self.choices)
 
     def convert(self, value, param, ctx):
         # Exact match

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -306,8 +306,11 @@ def test_missing_choice(runner):
 
     result = runner.invoke(cmd)
     assert result.exit_code == 2
-    assert 'Error: Missing option "--foo".  Choose from foo, bar.' \
-        in result.output
+    error, separator, choices = result.output.partition('Choose from')
+    assert 'Error: Missing option "--foo". ' in error
+    assert 'Choose from' in separator
+    assert 'foo' in choices
+    assert 'bar' in choices
 
 
 def test_case_insensitive_choice(runner):


### PR DESCRIPTION
For #202,

Given the cli.py file:
```python
import click

OPTIONS=[
'option000',
'option001',
'option002',
]

@click.command()
@click.argument('board', type=click.Choice(OPTIONS))
def login(board):
    """ Login to a board """
    pass

login()
```

Before the PR:

```
$ python cli.py
Usage: cli.py [OPTIONS] BOARD
Try "cli.py --help" for help.

Error: Missing argument "BOARD".  Choose from option000, option001, option002.
```

After the PR:

```
$ python cli.py
Usage: cli.py [OPTIONS] BOARD
Try "cli.py --help" for help.

Error: Missing argument "BOARD".  Choose from:
	option000,
	option001,
	option002.
```