### PR TITLE
Adding a test checking for a custom param type

### DIFF
--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -248,3 +248,23 @@ def test_formatting_usage_custom_help(runner):
         '',
         'Error: Missing argument "ARG".'
     ]
+
+def test_formatting_custom_type_metavar(runner):
+    class MyType(click.ParamType):
+        def get_metavar(self, param):
+            return "MY_TYPE"
+
+    @click.command("foo")
+    @click.help_option()
+    @click.argument("param", type=MyType())
+    def cmd(param):
+        pass
+
+    result = runner.invoke(cmd, '--help')
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: foo [OPTIONS] MY_TYPE',
+        '',
+        'Options:',
+        '  --help  Show this message and exit.'
+    ]


### PR DESCRIPTION
Checking that a user's custom param name shows up in the help doc. Related to PR #675.