### PR TITLE
allow specify short width to address cmd formatting

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -769,7 +769,12 @@ class Command(BaseCommand):
         self.epilog = epilog
         self.options_metavar = options_metavar
         if short_help is None and help:
-            short_help = make_default_short_help(help)
+            if (context_settings is not None and
+                'short_help_width' in context_settings):
+                    short_width = context_settings.get('short_help_width')
+                    short_help = make_default_short_help(help, short_width)
+            else:
+                short_help = make_default_short_help(help)
         self.short_help = short_help
         self.add_help_option = add_help_option
         self.hidden = hidden

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -59,12 +59,18 @@ def test_auto_shorthelp(runner):
         """This is a long text that is too long to show as short help
         and will be truncated instead."""
 
+    @cli.command(context_settings={'short_help_width': 20})
+    def width():
+        """This is a long text that is too long to show as short help
+        and will be truncated instead."""
+
     result = runner.invoke(cli, ['--help'])
     assert re.search(
         r'Commands:\n\s+'
         r'long\s+This is a long text that is too long to show\.\.\.\n\s+'
         r'short\s+This is a short text\.\n\s+'
-        r'special-chars\s+Login and store the token in ~/.netrc\.\s*',
+        r'special-chars\s+Login and store the token in ~/.netrc\.\s+'
+        r'width\s+This is a long text\.\.\.\n\s*',
         result.output) is not None
 
 


### PR DESCRIPTION
add a flag to address the too short short_help width as requested in #936 

