### PR TITLE
Fixes documentation issue #334

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -174,7 +174,9 @@ correction in case the terminal is misconfigured instead of dying with an
 As an added benefit, starting with Click 2.0, the echo function also
 has good support for ANSI colors.  It will automatically strip ANSI codes
 if the output stream is a file and if colorama is supported, ANSI colors
-will also work on Windows.  See :ref:`ansi-colors` for more information.
+will also work on Windows. Note that in Python 2, the :func:`echo` function
+does not parse color code information from bytearrays. See :ref:`ansi-colors`
+for more information.
 
 If you don't need this, you can also use the `print()` construct /
 function.

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -61,7 +61,8 @@ ANSI Colors
 Starting with Click 2.0, the :func:`echo` function gained extra
 functionality to deal with ANSI colors and styles.  Note that on Windows,
 this functionality is only available if `colorama`_ is installed.  If it
-is installed, then ANSI codes are intelligently handled.
+is installed, then ANSI codes are intelligently handled. Note that in Python
+2, the echo function doesn't parse color code information from bytearrays.
 
 Primarily this means that:
 


### PR DESCRIPTION
Docs updated to reflect that ANSI color info isn't parsed from
bytearrays in Python 2.