### PR TITLE
don't add newlines by default for progressbars

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -233,7 +233,7 @@ class ProgressBar(object):
 
         if line != self._last_line and not self.is_fast():
             self._last_line = line
-            echo(line, file=self.file, color=self.color, nl=True)
+            echo(line, file=self.file, color=self.color, nl=False)
             self.file.flush()
 
     def make_step(self, n_steps):


### PR DESCRIPTION
Fixes a regression introduced by 61abbef7cec63a9dcd15ec471d866271933e45bb which changed the default behavior of progressbars to rendering with newlines producing output like this:

```
Downloading reference  [#######-----------------------------]   20%
Downloading reference  [##########--------------------------]   30%
Downloading reference  [##############----------------------]   40%  00:00:01
Downloading reference  [##################------------------]   50%  00:00:01
Downloading reference  [#####################---------------]   60%  00:00:01
Downloading reference  [#########################-----------]   70%  00:00:00
Downloading reference  [############################--------]   80%  00:00:00
Downloading reference  [################################----]   90%  00:00:00
Downloading reference  [####################################]  100%
```

Now it looks like this:
```
Downloading reference  [####################################]  100%
```

