### PR TITLE
Fixes #574

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -1324,7 +1324,7 @@ class Parameter(object):
         self.is_eager = is_eager
         self.metavar = metavar
         self.envvar = envvar
-        self.autocompletion =  autocompletion
+        self.autocompletion = autocompletion
 
     @property
     def human_readable_name(self):
@@ -1354,7 +1354,6 @@ class Parameter(object):
 
     def add_to_parser(self, parser, ctx):
         pass
-
 
     def consume_value(self, ctx, opts):
         value = opts.get(self.name)
@@ -1805,11 +1804,9 @@ class Argument(Parameter):
         if len(decls) == 1:
             name = arg = decls[0]
             name = name.replace('-', '_').lower()
-        elif len(decls) == 2:
-            name, arg = decls
         else:
-            raise TypeError('Arguments take exactly one or two '
-                            'parameter declarations, got %d' % len(decls))
+            raise TypeError('Arguments take exactly one '
+                            'parameter declaration, got %d' % len(decls))
         return name, [arg], []
 
     def get_usage_pieces(self, ctx):

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -290,7 +290,7 @@ def test_defaults_for_nargs(runner):
     assert 'argument a takes 2 values' in result.output
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(strict=True)
 def test_multiple_param_decls_not_allowed(runner):
     @click.command()
     @click.argument('x', click.Choice(['a', 'b']))

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -290,9 +290,9 @@ def test_defaults_for_nargs(runner):
     assert 'argument a takes 2 values' in result.output
 
 
-@pytest.mark.xfail(strict=True)
 def test_multiple_param_decls_not_allowed(runner):
-    @click.command()
-    @click.argument('x', click.Choice(['a', 'b']))
-    def copy(x):
-        click.echo(x)
+    with pytest.raises(TypeError):
+        @click.command()
+        @click.argument('x', click.Choice(['a', 'b']))
+        def copy(x):
+            click.echo(x)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 import click
 from click._compat import PY2
 
@@ -287,3 +288,11 @@ def test_defaults_for_nargs(runner):
     result = runner.invoke(cmd, ['3'])
     assert result.exception is not None
     assert 'argument a takes 2 values' in result.output
+
+
+@pytest.mark.xfail
+def test_multiple_param_decls_not_allowed(runner):
+    @click.command()
+    @click.argument('x', click.Choice(['a', 'b']))
+    def copy(x):
+        click.echo(x)


### PR DESCRIPTION
This attempts to satisfy issue #574 by avoiding the situation encountered in #568. It was actually not necessary to validate the `*args` passed since I could not find uses/instances of multiple parameter declarations for `Argument`s. Instead, this change simply requires exactly one parameter declaration. See #574 for a more thorough explanation of my rationale.