### PR TITLE
Treats empty strings as false

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -295,7 +295,7 @@ class BoolParamType(ParamType):
         value = value.lower()
         if value in ('true', 't', '1', 'yes', 'y'):
             return True
-        elif value in ('false', 'f', '0', 'no', 'n'):
+        elif value in ('false', 'f', '0', 'no', 'n', ''):
             return False
         self.fail('%s is not a valid boolean' % value, param, ctx)
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -49,7 +49,7 @@ different behavior and some are supported out of the box:
     A parameter that accepts boolean values.  This is automatically used
     for boolean flags.  If used with string values ``1``, ``yes``, ``y``, ``t``
     and ``true`` convert to `True` and ``0``, ``no``, ``n``, ``f`` and ``false``
-    convert to `False`.
+    convert to `False`. An empty string will also convert to `False`.
 
 :data:`click.UUID`:
     A parameter that accepts UUID values.  This is not automatically

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -192,7 +192,7 @@ def test_boolean_conversion(runner):
             assert not result.exception
             assert result.output == 'True\n'
 
-        for value in 'false', 'f', '0', 'no', 'n':
+        for value in 'false', 'f', '0', 'no', 'n', '':
             result = runner.invoke(cli, ['--flag', value])
             assert not result.exception
             assert result.output == 'False\n'


### PR DESCRIPTION
I found it surprising that empty strings weren't parsed as `False` when interpreting environment variables for default values. I understand this may have been an intentional design decision, but here's a patch in case you're open to making a change.