### PR TITLE
feature: support customisation of "Commands:" section label.

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -955,7 +955,8 @@ class MultiCommand(Command):
 
     def __init__(self, name=None, invoke_without_command=False,
                  no_args_is_help=None, subcommand_metavar=None,
-                 chain=False, result_callback=None, **attrs):
+                 chain=False, result_callback=None,
+                 section_label='Commands', **attrs):
         Command.__init__(self, name, **attrs)
         if no_args_is_help is None:
             no_args_is_help = not invoke_without_command
@@ -971,6 +972,7 @@ class MultiCommand(Command):
         #: The result callback that is stored.  This can be set or
         #: overridden with the :func:`resultcallback` decorator.
         self.result_callback = result_callback
+        self.section_label = section_label
 
         if self.chain:
             for param in self.params:
@@ -1049,7 +1051,7 @@ class MultiCommand(Command):
                 rows.append((subcommand, help))
 
             if rows:
-                with formatter.section('Commands'):
+                with formatter.section(self.section_label):
                     formatter.write_dl(rows)
 
     def parse_args(self, ctx, args):

--- a/click/core.py
+++ b/click/core.py
@@ -949,6 +949,9 @@ class MultiCommand(Command):
                   multiple commands to be chained together.
     :param result_callback: the result callback to attach to this multi
                             command.
+    :param section_label: this controls the label above the list of sub
+                          commands in the formatted text displayed for a
+                          given MultiCommand. Defaults to "Commands".
     """
     allow_extra_args = True
     allow_interspersed_args = False

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,6 +68,21 @@ def test_auto_shorthelp(runner):
         result.output) is not None
 
 
+def test_formtter_section_label(runner):
+    @click.group(section_label='Elephants')
+    def cli():
+        pass
+
+    @cli.command()
+    def short():
+        """This is a short text."""
+
+    result = runner.invoke(cli, ['--help'])
+    assert re.search(
+        r'Elephants:\n\s+',
+        result.output) is not None
+
+
 def test_default_maps(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
The formatted text output currently defaults to a hardcoded `Commands` string.
This patch adds a kwarg that can override the formatted text outputed for a
given MultiCommand or Group.

So, for example, initialising `Group(section_label='Resources')` would print
`Resources:` as the formatted section label for a command group that represents
a list of resources with nested sub commands.