### PR TITLE
Fix in `click.edit()` for fast editors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Unreleased
     name instead of ``True`` or ``False``. :issue:`1538`
 -   Non-string objects passed to ``style()`` and ``secho()`` will be
     converted to string. :pr:`1146`
+-   ``edit(require_save=True)`` will detect saves for editors that exit
+    very fast on filesystems with 1 second resolution. :pr:`1050`
 
 
 Version 7.1.2

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -493,6 +493,13 @@ class Editor:
             f = os.fdopen(fd, "wb")
             f.write(text)
             f.close()
+            # If the filesystem resolution is 1 second, like Mac OS
+            # 10.12 Extended, or 2 seconds, like FAT32, and the editor
+            # closes very fast, require_save can fail. Set the modified
+            # time to be 2 seconds in the past to work around this.
+            os.utime(name, (os.path.getatime(name), os.path.getmtime(name) - 2))
+            # Depending on the resolution, the exact value might not be
+            # recorded, so get the new recorded value.
             timestamp = os.path.getmtime(name)
 
             self.edit_file(name)

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -379,3 +379,9 @@ def test_getchar_windows_exceptions(runner, monkeypatch, key_char, exc):
 
     with pytest.raises(exc):
         click.getchar()
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="No sed on Windows.")
+def test_fast_edit(runner):
+    result = click.edit("a\nb", editor="sed -i~ 's/$/Test/'")
+    assert result == "aTest\nbTest\n"


### PR DESCRIPTION
If a fast editor is used and the filesystem
only provides a resolution of 1s, `click.edit()`
returns None if the file is edited and saved very quickly.

This is a workaround that should work on all systems.

The added test would fail on my system before the fix.