### PR TITLE
Ignore completions for partially typed hidden commands and options. (Fixes #1058)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,7 @@ Unreleased
 -   Use Python sorting order for ZSH completions. (`#1047`_, `#1059`_)
 -   Document that parameter names are lowercased by default. (`#1055`_)
 -   Subcommands that are named by the function now automatically have the underscore replaced with a dash. If you register a function named ``my_command`` it becomes ``my-command`` in the command line interface.
+-   Hide hidden commands and options from completion. (`#1058`_, `#1061`_)
 
 .. _#202: https://github.com/pallets/click/issues/202
 .. _#323: https://github.com/pallets/click/issues/323
@@ -193,7 +194,9 @@ Unreleased
 .. _#1027: https://github.com/pallets/click/pull/1027
 .. _#1047: https://github.com/pallets/click/pull/1047
 .. _#1055: https://github.com/pallets/click/pull/1055
+.. _#1058: https://github.com/pallets/click/pull/1058
 .. _#1059: https://github.com/pallets/click/pull/1059
+.. _#1061: https://github.com/pallets/click/pull/1061
 
 
 Version 6.7

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -371,3 +371,39 @@ def test_chained_multi():
     assert choices_without_help(cli, ['sub'], 'c') == ['csub']
     assert choices_without_help(cli, ['sub', 'csub'], '') == ['dsub', 'esub']
     assert choices_without_help(cli, ['sub', 'csub', 'dsub'], '') == ['esub']
+
+
+def test_hidden():
+    @click.group()
+    @click.option('--name', hidden=True)
+    @click.option('--choices', type=click.Choice([1, 2]), hidden=True)
+    def cli(name):
+        pass
+
+    @cli.group(hidden=True)
+    def hgroup():
+        pass
+
+    @hgroup.group()
+    def hgroupsub():
+        pass
+
+    @cli.command()
+    def asub():
+        pass
+
+    @cli.command(hidden=True)
+    @click.option('--hname')
+    def hsub():
+        pass
+
+    assert choices_without_help(cli, [], '--n') == []
+    assert choices_without_help(cli, [], '--c') == []
+    # If the user exactly types out the hidden param, complete its options.
+    assert choices_without_help(cli, ['--choices'], '') == [1, 2]
+    assert choices_without_help(cli, [], '') == ['asub']
+    assert choices_without_help(cli, [], '') == ['asub']
+    assert choices_without_help(cli, [], 'h') == []
+    # If the user exactly types out the hidden command, complete its subcommands.
+    assert choices_without_help(cli, ['hgroup'], '') == ['hgroupsub']
+    assert choices_without_help(cli, ['hsub'], '--h') == ['--hname']


### PR DESCRIPTION
Ignore completions for partially typed hidden commands and options.

Based on #930 which should be merged first.
Fixes #1058 