### PR TITLE
Allows click to be vendored on Windows

### DIFF
--- a/click/_winconsole.py
+++ b/click/_winconsole.py
@@ -15,7 +15,7 @@ import zlib
 import time
 import ctypes
 import msvcrt
-from click._compat import _NonClosingTextIOWrapper, text_type, PY2
+from ._compat import _NonClosingTextIOWrapper, text_type, PY2
 from ctypes import byref, POINTER, c_int, c_char, c_char_p, \
      c_void_p, py_object, c_ssize_t, c_ulong, windll, WINFUNCTYPE
 try:


### PR DESCRIPTION
Fixes: Github issue #1068
 
    * Removes import references to click within click package and 
      uses relative imports

