### PR TITLE
additional param for Parameters to specify complex default_map lookup

### DIFF
--- a/examples/complex/complex/commands/cmd_default_map.py
+++ b/examples/complex/complex/commands/cmd_default_map.py
@@ -1,0 +1,28 @@
+import click
+
+CONTEXT_SETTINGS = dict(
+    default_map={
+        'broker_addr':'tcp://127.0.0.1:5552',
+        'worker':{
+            'addr':'tcp://127.0.0.1:5553',
+            'algorithm':{
+                'max_array_size':10,
+            }
+        }
+    }
+)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+def cli():
+    pass
+
+@cli.command()
+@click.option('--broker-addr',default='tcp://127.0.0.1:5551')
+@click.option('--worker-addr',default='tcp://127.0.0.1:5552',default_path=['worker','addr'])
+@click.option('--max-array-size',default=20,default_path='worker.algorithm.max_array_size')
+def test_my_algorithm(broker_addr,worker_addr,max_array_size):
+    """Just one simple test subcommand using the global configuration"""
+    print('Using broker_addr: %s'%broker_addr)
+    print('Using worker_addr: %s'%worker_addr)
+    print('Using max_array_size: %s'%max_array_size)


### PR DESCRIPTION
I added an additional keyword for any parameters to make a complex lookup in the default_map.

I find this useful since the configuration file structure might not be the same as the command structure, quite certainly it won't be. 

To understand what I mean please have a look at the new example `default_map.py` I added under examples/complex/complex/commands.

Since I used a new key this shouldn't break anything.

Would be really cool if this could be merged.