### PR TITLE
Update docs to follow PEP8 recommendation for naming styles

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -62,10 +62,10 @@ simply pass in `required=True` as an argument to the decorator.
 
     # How to use a Python reserved word such as `from` as a parameter
     @click.command()
-    @click.option('--from', '-f', '_from')
+    @click.option('--from', '-f', 'from_')
     @click.option('--to', '-t')
-    def reserved_param_name(_from, to):
-        click.echo('from %s to %s' % (_from, to))
+    def reserved_param_name(from_, to):
+        click.echo('from %s to %s' % (from_, to))
 
 And on the command line:
 


### PR DESCRIPTION
According to [PEP8](https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles), the convention for avoid conflicts with Python keywords is to include the undescore in the end of the variable name:

> In addition, the following special forms using leading or trailing underscores are recognized (these can generally be combined with any case convention):
>
>    _single_leading_underscore: weak "internal use" indicator. E.g. from M import * does not import objects whose name starts with an underscore.
>
>    **single_trailing_underscore_: used by convention to avoid conflicts with Python keyword, e.g.**
>
>    Tkinter.Toplevel(master, class_='ClassName')
