### PR TITLE
Feature/1075 - Adding newline after multi-line help strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Unreleased
 -   Option help text replaces newlines with spaces when rewrapping, but
     preserves paragraph breaks, fixing multiline formatting.
     :issue:`834, 1066, 1397`
+-   Option help text that is wrapped adds an extra newline at the end to
+    distinguish it from the next option. :issue:`1075`
 
 
 Version 7.0

--- a/click/formatting.py
+++ b/click/formatting.py
@@ -206,6 +206,10 @@ class HelpFormatter(object):
 
                 for line in lines[1:]:
                     self.write('%*s%s\n' % (first_col + self.current_indent, '', line))
+
+                if len(lines) > 1:
+                    # separate long help from next option
+                    self.write("\n")
             else:
                 self.write('\n')
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -313,3 +313,39 @@ def test_global_show_default(runner):
         '  -f TEXT  Output file name  [default: out.txt]',
         '  --help   Show this message and exit.  [default: False]'
     ]
+
+
+def test_formatting_usage_multiline_option_padding(runner):
+    @click.command('foo')
+    @click.option('--bar', help='This help message will be padded if it wraps.')
+    def cli():
+        pass
+
+    result = runner.invoke(cli, '--help', terminal_width=45)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: foo [OPTIONS]',
+        '',
+        'Options:',
+        '  --bar TEXT  This help message will be',
+        '              padded if it wraps.',
+        '',
+        '  --help      Show this message and exit.'
+    ]
+
+
+def test_formatting_usage_no_option_padding(runner):
+    @click.command('foo')
+    @click.option('--bar', help='This help message will be padded if it wraps.')
+    def cli():
+        pass
+
+    result = runner.invoke(cli, '--help', terminal_width=80)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        'Usage: foo [OPTIONS]',
+        '',
+        'Options:',
+        '  --bar TEXT  This help message will be padded if it wraps.',
+        '  --help      Show this message and exit.'
+    ]


### PR DESCRIPTION
fixes #1075

It was suggested adding an extra newline after options with help messages where the line wraps, to make the usage strings more readable.

This contains the necessary changes to make this the standard, as well as some additional tests for formatting. 