### PR TITLE
Progress tweaks

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -94,6 +94,8 @@ class ProgressBar(object):
         self.throttle = throttle
 
     def __enter__(self):
+        if self.entered:
+            raise RuntimeError('This progress bar is already active.')
         self.entered = True
         self.render_progress()
         return self

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -212,8 +212,7 @@ class ProgressBar(object):
             clutter_length = term_len(self.format_progress_line())
             new_width = max(0, get_terminal_size()[0] - clutter_length)
             if new_width < old_width:
-                buf.append(BEFORE_BAR)
-                buf.append(' ' * self.max_width)
+                self.clear_line()
                 self.max_width = new_width
             self.width = new_width
 
@@ -290,6 +289,29 @@ class ProgressBar(object):
                 self.update(1)
             self.finish()
 
+    def clear_line(self):
+        if self._last_line is None:
+            return
+
+        self._last_line = None
+
+        buf = [
+            BEFORE_BAR,
+            ' ' * self.max_width,
+            BEFORE_BAR,
+        ]
+        echo(''.join(buf), file=self.file, color=self.color, nl=False)
+
+    def echo(self, message=None, nl=True):
+        self.clear_line()
+
+        echo(message, file=self.file, color=self.color, nl=nl)
+
+    def secho(self, message=None, nl=True, **styles):
+        self.clear_line()
+
+        from .termui import secho
+        secho(message, file=self.file, color=self.color, nl=nl, **styles)
 
 def pager(generator, color=None):
     """Decide what method to use for paging through text."""

--- a/click/termui.py
+++ b/click/termui.py
@@ -262,7 +262,7 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 show_percent=None, show_pos=False,
                 item_show_func=None, fill_char='#', empty_char='-',
                 bar_template='%(label)s  [%(bar)s]  %(info)s',
-                info_sep='  ', width=36, file=None, color=None):
+                info_sep='  ', width=36, file=None, color=None, throttle=0.5):
     """This function creates an iterable context manager that can be used
     to iterate over something while showing a progress bar.  It will
     either iterate over the `iterable` or `length` items (that are counted
@@ -340,6 +340,9 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                   default is autodetection.  This is only needed if ANSI
                   codes are included anywhere in the progress bar output
                   which is not the case by default.
+    :param throttle: Restrict output to this interval, in seconds,
+                  with a default of 0.5. For example, a value of 1
+                  ensures that a value is only printed every seconds.
     """
     from ._termui_impl import ProgressBar
     color = resolve_color_default(color)
@@ -348,7 +351,7 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                        item_show_func=item_show_func, fill_char=fill_char,
                        empty_char=empty_char, bar_template=bar_template,
                        info_sep=info_sep, file=file, label=label,
-                       width=width, color=color)
+                       width=width, color=color, throttle=throttle)
 
 
 def clear():


### PR DESCRIPTION
This PR contains a few tweaks to the progress support to:

* Let me print out something during the run.
* Throttle the output so that it doesn't waste CPU resources on terminal rendering.
* Print out total time when a run is complete.