### PR TITLE
Rebase of #572; make example work with setuptools entry points

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -87,6 +87,10 @@ script like this:
     @click.option('--debug/--no-debug', default=False)
     @click.pass_context
     def cli(ctx, debug):
+        # ensure that ctx.obj exists and is a dict (in case `cli()` is called
+        # by means other than the `if` block below
+        ctx.ensure_object(dict)
+
         ctx.obj['DEBUG'] = debug
 
     @cli.command()


### PR DESCRIPTION
Since #572's base branch is gone, I'm not sure it can be updated. (Can you push straight to `pulls/572/head`? I don't know how.) So this is a rebase + amend to just fix it and get it merged.

Add handling for `ctx.obj is None` in an example command, with a comment noting that the handling is there so that setuptools entry points will not set ctx.obj (and that the handling is therefore needed in that case).

closes #572