### PR TITLE
Allow non-standalone ctx.exit() calls to return values rather than call sys.exit()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Version 7.0
 
 (upcoming release with new features, release date to be decided)
 
+- Non-standalone calls to Context.exit return the exit code, rather than
+  calling ``sys.exit`` (`#667`_)(`#533`_)
 - Updated test env matrix. (`#1027`_)
 - Fixes a ZeroDivisionError in ProgressBar.make_step,
   when the arg passed to the first call of ProgressBar.update is 0. (`#1012`_)(`#447`_)

--- a/click/core.py
+++ b/click/core.py
@@ -9,7 +9,7 @@ from functools import update_wrapper
 from .types import convert_type, IntRange, BOOL
 from .utils import make_str, make_default_short_help, echo, get_os_args
 from .exceptions import ClickException, UsageError, BadParameter, Abort, \
-     MissingParameter
+     MissingParameter, Exit
 from .termui import prompt, confirm, style
 from .formatting import HelpFormatter, join_options
 from .parser import OptionParser, split_opt
@@ -498,7 +498,7 @@ class Context(object):
 
     def exit(self, code=0):
         """Exits the application with a given exit code."""
-        sys.exit(code)
+        raise Exit(code, self)
 
     def get_usage(self):
         """Helper method to get formatted usage string for the current
@@ -718,6 +718,12 @@ class BaseCommand(object):
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()
+            except Exit as e:
+                if not standalone_mode:
+                    if e.exit_code:
+                        raise
+                    return None
+                sys.exit(e.exit_code)
             except ClickException as e:
                 if not standalone_mode:
                     raise

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -13,7 +13,6 @@ class ClickException(Exception):
 
     #: The exit code for this exception
     exit_code = 1
-    show_prefix = 'Error: '
 
     def __init__(self, message):
         ctor_msg = message
@@ -38,17 +37,19 @@ class ClickException(Exception):
     def show(self, file=None):
         if file is None:
             file = get_text_stderr()
-        echo('%s%s' % (self.show_prefix, self.format_message()), file=file)
+        echo('Error: %s' % self.format_message(), file=file)
 
 
-class ContextAwareException(ClickException):
-    """An exception that knows how to use a :class:`~click.Context` object
-    to properly display itself.
+class UsageError(ClickException):
+    """An internal exception that signals a usage error.  This typically
+    aborts any further handling.
 
     :param message: the error message to display.
     :param ctx: optionally the context that caused this error.  Click will
                 fill in the context automatically in some situations.
     """
+    exit_code = 2
+
     def __init__(self, message, ctx=None):
         ClickException.__init__(self, message)
         self.ctx = ctx
@@ -66,33 +67,7 @@ class ContextAwareException(ClickException):
         if self.ctx is not None:
             color = self.ctx.color
             echo(self.ctx.get_usage() + '\n%s' % hint, file=file, color=color)
-        echo('%s%s' % (self.show_prefix, self.format_message()), file=file, color=color)
-
-
-class Exit(ContextAwareException):
-    """An exception that indicates that the application should exit with some
-    status code.
-
-    :param code: the status code to exit with.
-    :param ctx: optionally the context that caused this error.  Click will
-                fill in the context automatically in some situations.
-    """
-    show_prefix = 'Exit: '
-
-    def __init__(self, code, ctx=None):
-        ContextAwareException.__init__(self, str(code), ctx=None)
-        self.exit_code = code
-
-
-class UsageError(ContextAwareException):
-    """An internal exception that signals a usage error.  This typically
-    aborts any further handling.
-
-    :param message: the error message to display.
-    :param ctx: optionally the context that caused this error.  Click will
-                fill in the context automatically in some situations.
-    """
-    exit_code = 2
+        echo('Error: %s' % self.format_message(), file=file, color=color)
 
 
 class BadParameter(UsageError):
@@ -248,3 +223,13 @@ class FileError(ClickException):
 
 class Abort(RuntimeError):
     """An internal signalling exception that signals Click to abort."""
+
+
+class Exit(RuntimeError):
+    """An exception that indicates that the application should exit with some
+    status code.
+
+    :param code: the status code to exit with.
+    """
+    def __init__(self, code):
+        self.exit_code = code

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -231,5 +231,5 @@ class Exit(RuntimeError):
 
     :param code: the status code to exit with.
     """
-    def __init__(self, code):
+    def __init__(self, code=0):
         self.exit_code = code

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -206,6 +206,7 @@ def test_close_before_pop(runner):
     assert result.output == 'aha!\n'
     assert called == [True]
 
+
 def test_make_pass_decorator_args(runner):
     """
     Test to check that make_pass_decorator doesn't consume arguments based on
@@ -240,6 +241,7 @@ def test_make_pass_decorator_args(runner):
     result = runner.invoke(cli, ['test2'])
     assert not result.exception
     assert result.output == 'foocmd\n'
+
 
 def test_exit_not_standalone_failure():
     @click.command()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 import click
 
 
@@ -204,7 +206,6 @@ def test_close_before_pop(runner):
     assert result.output == 'aha!\n'
     assert called == [True]
 
-
 def test_make_pass_decorator_args(runner):
     """
     Test to check that make_pass_decorator doesn't consume arguments based on
@@ -239,3 +240,26 @@ def test_make_pass_decorator_args(runner):
     result = runner.invoke(cli, ['test2'])
     assert not result.exception
     assert result.output == 'foocmd\n'
+
+def test_exit_not_standalone_failure():
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        ctx.exit(1)
+
+    with pytest.raises(click.exceptions.Exit) as e:
+        cli.main([], 'test_exit_not_standalone', standalone_mode=False)
+    assert e.value.exit_code == 1
+
+
+def test_exit_not_standalone_success():
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        ctx.exit(0)
+
+    assert cli.main(
+        [],
+        'test_exit_not_standalone',
+        standalone_mode=False,
+    ) is None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import click
 
 
@@ -195,6 +193,7 @@ def test_close_before_pop(runner):
     @click.pass_context
     def cli(ctx):
         ctx.obj = 'test'
+
         @ctx.call_on_close
         def foo():
             assert click.get_current_context().obj == 'test'
@@ -243,25 +242,17 @@ def test_make_pass_decorator_args(runner):
     assert result.output == 'foocmd\n'
 
 
-def test_exit_not_standalone_failure():
+def test_exit_not_standalone():
     @click.command()
     @click.pass_context
     def cli(ctx):
         ctx.exit(1)
 
-    with pytest.raises(click.exceptions.Exit) as e:
-        cli.main([], 'test_exit_not_standalone', standalone_mode=False)
-    assert e.value.exit_code == 1
+    assert cli.main([], 'test_exit_not_standalone', standalone_mode=False) == 1
 
-
-def test_exit_not_standalone_success():
     @click.command()
     @click.pass_context
     def cli(ctx):
         ctx.exit(0)
 
-    assert cli.main(
-        [],
-        'test_exit_not_standalone',
-        standalone_mode=False,
-    ) is None
+    assert cli.main([], 'test_exit_not_standalone', standalone_mode=False) == 0

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -154,14 +154,32 @@ def test_exit_code_and_output_from_sys_exit():
         sys.exit('error')
 
     @click.command()
+    @click.pass_context
+    def cli_string_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit('error')
+
+    @click.command()
     def cli_int():
         click.echo('hello world')
         sys.exit(1)
 
     @click.command()
+    @click.pass_context
+    def cli_int_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit(1)
+
+    @click.command()
     def cli_float():
         click.echo('hello world')
         sys.exit(1.0)
+
+    @click.command()
+    @click.pass_context
+    def cli_float_ctx_exit(ctx):
+        click.echo('hello world')
+        ctx.exit(1.0)
 
     @click.command()
     def cli_no_error():
@@ -173,11 +191,23 @@ def test_exit_code_and_output_from_sys_exit():
     assert result.exit_code == 1
     assert result.output == 'hello world\nerror\n'
 
+    result = runner.invoke(cli_string_ctx_exit)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\nerror\n'
+
     result = runner.invoke(cli_int)
     assert result.exit_code == 1
     assert result.output == 'hello world\n'
 
+    result = runner.invoke(cli_int_ctx_exit)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n'
+
     result = runner.invoke(cli_float)
+    assert result.exit_code == 1
+    assert result.output == 'hello world\n1.0\n'
+
+    result = runner.invoke(cli_float_ctx_exit)
     assert result.exit_code == 1
     assert result.output == 'hello world\n1.0\n'
 


### PR DESCRIPTION
Based on the work in #533 

However, I think that PR did more than was necessary and got itself into trouble. Exits don't need to pretty print themselves, and that would actually be a destructive or at least annoying change for many `click` consumers.
Rather than squashing that work away, I've preserved those commits but made further changes to pare things back.

This makes a new class of exception `Exit(RuntimeError)`, which is just a container for an exit code.
`Context.exit` raises an `Exit` instead of calling `sys.exit` directly, and `BaseCommand.main` looks at `Exit` exceptions a lot like it looks at `Abort`s, either returning the result (when non-standalone) or calling `sys.exit` (when standalone).
(This is all very much in line with @jamesmyatt's feedback on that original work, which I largely agree with.)

closes #533
closes #667