### PR TITLE
Ensure auto_envvar_prefix is always uppercased

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,7 @@ Unreleased
 -   Document that parameter names are lowercased by default. (`#1055`_)
 -   Subcommands that are named by the function now automatically have the underscore replaced with a dash. If you register a function named ``my_command`` it becomes ``my-command`` in the command line interface.
 -   Hide hidden commands and options from completion. (`#1058`_, `#1061`_)
+-   Fix issue where a lowercase ``auto_envvar_prefix`` would not be converted to uppercase. (`#1105`_)
 
 .. _#202: https://github.com/pallets/click/issues/202
 .. _#323: https://github.com/pallets/click/issues/323
@@ -197,6 +198,7 @@ Unreleased
 .. _#1058: https://github.com/pallets/click/pull/1058
 .. _#1059: https://github.com/pallets/click/pull/1059
 .. _#1061: https://github.com/pallets/click/pull/1061
+.. _#1105: https://github.com/pallets/click/pull/1105
 
 
 Version 6.7

--- a/click/core.py
+++ b/click/core.py
@@ -327,7 +327,7 @@ class Context(object):
                 auto_envvar_prefix = '%s_%s' % (parent.auto_envvar_prefix,
                                            self.info_name.upper())
         else:
-            self.auto_envvar_prefix = auto_envvar_prefix.upper()
+            auto_envvar_prefix = auto_envvar_prefix.upper()
         self.auto_envvar_prefix = auto_envvar_prefix
 
         if color is None and parent is not None:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -202,6 +202,19 @@ def test_dynamic_default_help_text(runner):
     assert 'lambda' not in result.output
     assert '(current user)' in result.output
 
+
+def test_toupper_envvar_prefix(runner):
+    @click.command()
+    @click.option('--arg')
+    def cmd(arg):
+        click.echo(arg)
+
+    result = runner.invoke(cmd, [], auto_envvar_prefix='test',
+                           env={'TEST_ARG': 'foo'})
+    assert not result.exception
+    assert result.output == 'foo\n'
+
+
 def test_nargs_envvar(runner):
     @click.command()
     @click.option('--arg', nargs=2)


### PR DESCRIPTION
Add a failing test and the modification to make it pass.

Given a lowercase auto_envvar_prefix, it's clearly supposed to be converted to uppercase by the Context init. However, there's a slight bug -- the prefix is uppercased, then reset to its prior value.

Test that setting a prefix of `test` results in `--arg` using `TEST_ARG` (all uppercase).
Fix `Context.__init__` to do the right thing.

Noticed when linking to the relevant code for a `pipenv` conversation ( https://github.com/pypa/pipenv/pull/2819 ).