### PR TITLE
Prevent error messages/exit code 120 after exiting on EPIPE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Unreleased
 -   Add documentation for ``ignore_unkown_options``. (`#684`_)
 -   Add bright colors support for ``click.style`` and fix the reset option for parameters ``fg`` and ``bg``. (`#703`_, `#809`_)
 -   Add ``show_envvar`` for showing environment variables in help. (`#710`_)
+-   Avoid ``BrokenPipeError`` during interpreter shutdown when stdout or stderr is a closed pipe. (`#712`_, `#1106`_)
 -   Document customizing option names. (`#725`_, `#1016`_)
 -   Disable ``sys._getframes()`` on Python interpreters that don't support it. (`#728`_)
 -   Fix bug in test runner when calling ``sys.exit`` with ``None``. (`#739`_)
@@ -129,6 +130,7 @@ Unreleased
 .. _#706: https://github.com/pallets/click/pull/706
 .. _#709: https://github.com/pallets/click/pull/709
 .. _#710: https://github.com/pallets/click/pull/710
+.. _#712: https://github.com/pallets/click/pull/712
 .. _#719: https://github.com/pallets/click/issues/719
 .. _#725: https://github.com/pallets/click/issues/725
 .. _#728: https://github.com/pallets/click/pull/728
@@ -214,6 +216,7 @@ Unreleased
 .. _#1061: https://github.com/pallets/click/pull/1061
 .. _#1088: https://github.com/pallets/click/issues/1088
 .. _#1105: https://github.com/pallets/click/pull/1105
+.. _#1106: https://github.com/pallets/click/pull/1106
 .. _#1108: https://github.com/pallets/click/pull/1108
 .. _#1115: https://github.com/pallets/click/pull/1115
 

--- a/click/core.py
+++ b/click/core.py
@@ -7,7 +7,8 @@ from itertools import repeat
 from functools import update_wrapper
 
 from .types import convert_type, IntRange, BOOL
-from .utils import make_str, make_default_short_help, echo, get_os_args
+from .utils import PacifyFlushWrapper, make_str, make_default_short_help, \
+     echo, get_os_args
 from .exceptions import ClickException, UsageError, BadParameter, Abort, \
      MissingParameter, Exit
 from .termui import prompt, confirm, style
@@ -734,6 +735,8 @@ class BaseCommand(object):
                 sys.exit(e.exit_code)
             except IOError as e:
                 if e.errno == errno.EPIPE:
+                    sys.stdout = PacifyFlushWrapper(sys.stdout)
+                    sys.stderr = PacifyFlushWrapper(sys.stderr)
                     sys.exit(1)
                 else:
                     raise


### PR DESCRIPTION
Fixes https://github.com/pallets/click/issues/712 . Compared to the workarounds there, this is a little more careful about the possibility of odd interactions if sys.stdout/sys.stderr being replaced and then some kind of other cleanup running after sys.exit(...) or the possibility of EPIPE not being related to stdout/stderr (in which case they really should be flushed at program exit).

Side point: I'm not sure if the current approach is the best possible. In particular I think the choice of exiting with an exit code of 1 is somewhat questionable. At least the sigpipe handler should probably be customisable "at the click level" now the current behaviour has been released.