### PR TITLE
make `getchar` work on Windows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 7.0
 
 Unreleased
 
+-   ``click.getchar()`` now returns unicode in Python 3 on Windows, same as other platforms. (`#1108`_, `#1088`_, `#822`_, `#821`_, `#537`_)
 -   Drop support for Python 2.6 and 3.3. (`#976`_)
 -   Wrap ``click.Choice``'s missing message. (`#202`_, `#1000`_)
 -   Add native ZSH autocompletion support. (`#323`_, `#865`_)

--- a/click/termui.py
+++ b/click/termui.py
@@ -557,6 +557,10 @@ def getchar(echo=False):
     Note that this will always read from the terminal, even if something
     is piped into the standard input.
 
+    Note for Windows: in rare cases when typing non-ASCII characters, this
+    function might wait for a second character and then return both at once.
+    This is because certain Unicode characters look like special-key markers.
+
     .. versionadded:: 2.0
 
     :param echo: if set to `True`, the character read will also show up on


### PR DESCRIPTION
Fixes #1088, #822, #821, and #537.

No tests because the test suite can't properly test `_termui_impl` functions, AFAICT at least. Manually tested on Windows 10 with Python 2.7 and 3.6.

The implemented behavior is not the best (see the comment; it's impossible to read French letter "à" as a single character), but it does fix a long-standing issue in a reasonable way.