### PR TITLE
Clarify Group invocation in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -227,6 +227,12 @@ script can instead be written like this:
     def dropdb():
         click.echo('Dropped the database')
 
+You would then invoke the :class:`Group` in your setuptools entry points or
+other invocations::
+
+    if __name__ == '__main__':
+        cli()
+
 Adding Parameters
 -----------------
 


### PR DESCRIPTION
For new users and, as noted in #663 , especially those whose introduction to click may coincide with their introduction to python, it may not be clear that a Group is a callable. More specifically: the "root" of your command tree is the callable you actually want to invoke to run your CLI.

closes #663