### PR TITLE
progressbar: fix regression with hidden bars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,6 +174,8 @@ Unreleased
 -   Allow styled output in Jupyter on Windows. :issue:`1271`
 -   ``style()`` supports the ``strikethrough`` style. :issue:`805`
 -   Multiline marker is removed from short help text. :issue:`1597`
+-   Restore progress bar behavior of echoing only the label if the file
+    is not a TTY. :issue:`1138`
 
 
 Version 7.1.2

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -227,6 +227,12 @@ class ProgressBar:
         import shutil
 
         if self.is_hidden:
+            # Only output the label as it changes if the output is not a
+            # TTY. Use file=stderr if you expect to be piping stdout.
+            if self._last_line != self.label:
+                self._last_line = self.label
+                echo(self.label, file=self.file, color=self.color)
+
             return
 
         buf = []

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -381,14 +381,18 @@ def progressbar(
     :param info_sep: the separator between multiple info items (eta etc.)
     :param width: the width of the progress bar in characters, 0 means full
                   terminal width
-    :param file: the file to write to.  If this is not a terminal then
-                 only the label is printed.
+    :param file: The file to write to. If this is not a terminal then
+        only the label is printed.
     :param color: controls if the terminal supports ANSI colors or not.  The
                   default is autodetection.  This is only needed if ANSI
                   codes are included anywhere in the progress bar output
                   which is not the case by default.
     :param update_min_steps: Render only when this many updates have
         completed. This allows tuning for very fast iterators.
+
+    .. versionchanged:: 8.0
+        Labels are echoed if the output is not a TTY. Reverts a change
+        in 7.0 that removed all output.
 
     .. versionadded:: 8.0
        Added the ``update_min_steps`` parameter.

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -76,17 +76,16 @@ def test_progressbar_length_hint(runner, monkeypatch):
 
 def test_progressbar_hidden(runner, monkeypatch):
     fake_clock = FakeClock()
-    label = "whatever"
 
     @click.command()
     def cli():
-        with _create_progress(label=label) as progress:
+        with _create_progress(label="working") as progress:
             for _ in progress:
                 fake_clock.advance_time()
 
     monkeypatch.setattr(time, "time", fake_clock.time)
     monkeypatch.setattr(click._termui_impl, "isatty", lambda _: False)
-    assert runner.invoke(cli, []).output == ""
+    assert runner.invoke(cli, []).output == "working\n"
 
 
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])


### PR DESCRIPTION
The documentation of the progress bar states that the progress bar will output only the label of the bar if it is outputting to a file that is not a tty. However, this was broken a few versions ago, without the documentation being adjusted, and even a test added.

Restore this behaviour so we follow the documentation again, and adjust the test to match. Fixes #1138.