### PR TITLE
Handle non text in style/secho by converting to text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Unreleased
     :issue:`1475`
 -   Help for boolean flags with ``show_default=True`` shows the flag
     name instead of ``True`` or ``False``. :issue:`1538`
+-   Non-string objects passed to ``style()`` and ``secho()`` will be
+    converted to string. :pr:`1146`
 
 
 Version 7.1.2

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -482,11 +482,6 @@ def style(
     * ``bright_white``
     * ``reset`` (reset the color code only)
 
-    .. versionadded:: 2.0
-
-    .. versionadded:: 7.0
-       Added support for bright colors.
-
     :param text: the string to style with ansi codes.
     :param fg: if provided this will become the foreground color.
     :param bg: if provided this will become the background color.
@@ -501,7 +496,18 @@ def style(
     :param reset: by default a reset-all code is added at the end of the
                   string which means that styles do not carry over.  This
                   can be disabled to compose styles.
+
+    .. versionchanged:: 8.0
+        A non-string ``message`` is converted to a string.
+
+    .. versionchanged:: 7.0
+        Added support for bright colors.
+
+    .. versionadded:: 2.0
     """
+    if not isinstance(text, str):
+        text = str(text)
+
     bits = []
     if fg:
         try:
@@ -550,6 +556,9 @@ def secho(message=None, file=None, nl=True, err=False, color=None, **styles):
 
     All keyword arguments are forwarded to the underlying functions
     depending on which one they go with.
+
+    .. versionchanged:: 8.0
+        A non-string ``message`` is converted to a string.
 
     .. versionadded:: 2.0
     """

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -7,6 +7,7 @@ import sys
 
 from ._compat import DEFAULT_COLUMNS
 from ._compat import get_winterm_size
+from ._compat import is_bytes
 from ._compat import isatty
 from ._compat import strip_ansi
 from ._compat import WIN
@@ -557,13 +558,20 @@ def secho(message=None, file=None, nl=True, err=False, color=None, **styles):
     All keyword arguments are forwarded to the underlying functions
     depending on which one they go with.
 
+    Non-string types will be converted to :class:`str`. However,
+    :class:`bytes` are passed directly to :meth:`echo` without applying
+    style. If you want to style bytes that represent text, call
+    :meth:`bytes.decode` first.
+
     .. versionchanged:: 8.0
-        A non-string ``message`` is converted to a string.
+        A non-string ``message`` is converted to a string. Bytes are
+        passed through without style applied.
 
     .. versionadded:: 2.0
     """
-    if message is not None:
+    if message is not None and not is_bytes(message):
         message = style(message, **styles)
+
     return echo(message, file=file, nl=nl, err=err, color=color)
 
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -257,6 +257,13 @@ def test_secho(runner):
         assert bytes == b""
 
 
+def test_secho_non_text(runner):
+    with runner.isolation() as outstreams:
+        click.secho(Exception("spam"), nl=False)
+        bytes = outstreams[0].getvalue()
+        assert bytes == b"spam"
+
+
 def test_progressbar_yields_all_items(runner):
     with click.progressbar(range(3)) as progress:
         assert len(list(progress)) == 3

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1,3 +1,4 @@
+import platform
 import time
 
 import pytest
@@ -257,11 +258,15 @@ def test_secho(runner):
         assert bytes == b""
 
 
-def test_secho_non_text(runner):
-    with runner.isolation() as outstreams:
-        click.secho(Exception("spam"), nl=False)
-        bytes = outstreams[0].getvalue()
-        assert bytes == b"spam"
+@pytest.mark.skipif(platform.system() == "Windows", reason="No style on Windows.")
+@pytest.mark.parametrize(
+    ("value", "expect"), [(123, b"\x1b[45m123\x1b[0m"), (b"test", b"test")]
+)
+def test_secho_non_text(runner, value, expect):
+    with runner.isolation() as (out, _):
+        click.secho(value, nl=False, color=True, bg="magenta")
+        result = out.getvalue()
+        assert result == expect
 
 
 def test_progressbar_yields_all_items(runner):


### PR DESCRIPTION
Call `str()` on any non-string type. `echo()` also supports printing `bytes`, but this PR doesn't support that, ending up printing its repr (`b'bytes'`). I'm not sure how to handle it, since making `style()` support bytes might be rather ugly.