### PR TITLE
fix link in unicode_literals error message

### DIFF
--- a/click/_unicodefun.py
+++ b/click/_unicodefun.py
@@ -43,7 +43,7 @@ def _check_for_unicode_literals():
                  'because it can introduce subtle bugs in your '
                  'code.  You should instead use explicit u"" literals '
                  'for your unicode strings.  For more information see '
-                 'https://click.palletsprojects.com/python3/'),
+                 'https://click.palletsprojects.com/en/7.x/python3/'),
          stacklevel=bad_frame)
 
 


### PR DESCRIPTION
The current error message when using unicode_literals prints the URL `https://click.palletsprojects.com/python3/` that shows a `SORRY  This page does not exist yet.` message. Use the working URL found in the file instead.