### PR TITLE
Clarify multiple options

### DIFF
--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -18,10 +18,10 @@ only supports completion for Bash and Zsh.
 What it Completes
 -----------------
 
-Generally, the Bash completion support will complete subcommands, options
-and any option or argument values where the type is click.Choice.
-Subcommands and choices are always listed whereas options only if at
-least a dash has been provided.  Example::
+Generally, the Bash completion support will complete subcommands,
+options, and any option or argument values where the type is
+:class:`click.Choice`. Subcommands and choices are always listed whereas
+options are only listed if at least a dash has been provided. ::
 
     $ repo <TAB><TAB>
     clone    commit   copy     delete   setuser

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -145,6 +145,8 @@ used.  The above example is thus equivalent to this:
     def putitem(item):
         click.echo('name=%s id=%d' % item)
 
+.. _multiple-options:
+
 Multiple Options
 ----------------
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -28,7 +28,8 @@ available for options:
 
 On the other hand arguments, unlike options, can accept an arbitrary number
 of arguments.  Options can strictly ever only accept a fixed number of
-arguments (defaults to 1).
+arguments (defaults to 1), or they may be specified multiple times using
+:ref:`multiple-options`.
 
 Parameter Types
 ---------------

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -33,7 +33,7 @@ suppressed by passing ``nl=False``::
 Last but not least :func:`echo` uses click's intelligent internal output
 streams to stdout and stderr which support unicode output on the Windows
 console.  This means for as long as you are using `click.echo` you can
-output unicode character (there are some limitations on the default font
+output unicode characters (there are some limitations on the default font
 with regards to which characters can be displayed).  This functionality is
 new in Click 6.0.
 
@@ -211,7 +211,7 @@ Click supports launching editors automatically through :func:`edit`.  This
 is very useful for asking users for multi-line input.  It will
 automatically open the user's defined editor or fall back to a sensible
 default.  If the user closes the editor without saving, the return value
-will be `None` otherwise the entered text.
+will be ``None``, otherwise the entered text.
 
 Example usage::
 


### PR DESCRIPTION
Small clarification about specifying an option multiple times, and a couple grammatical fixes.