### PR TITLE
Remove reference to deprecated easy_install

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,12 +32,7 @@ install separate copies of Python, but it does provide a clever way to
 keep different project environments isolated.  Let's see how virtualenv
 works.
 
-If you are on Mac OS X or Linux, chances are that one of the following two
-commands will work for you::
-
-    $ sudo easy_install virtualenv
-
-or even better::
+If you are on Mac OS X or Linux::
 
     $ sudo pip install virtualenv
 


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice and only recommended supported tools.