### PR TITLE
Add no_args_is_help to click.Command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Version 7.1
 
 Unreleased
 
+- Add ``no_args_is_help`` option to ``click.Command``, defaults to False (`#1167`_)
+
+.. _#1167: https://github.com/pallets/click/pull/1167
 
 Version 7.0
 -----------

--- a/click/core.py
+++ b/click/core.py
@@ -785,6 +785,10 @@ class Command(BaseCommand):
                        shown on the command listing of the parent command.
     :param add_help_option: by default each command registers a ``--help``
                             option.  This can be disabled by this parameter.
+    :param no_args_is_help: this controls what happens if no arguments are
+                            provided.  This option is disabled by default.
+                            If enabled this will add ``--help`` as argument
+                            if no arguments are passed
     :param hidden: hide this command from help outputs.
 
     :param deprecated: issues a message indicating that
@@ -794,7 +798,7 @@ class Command(BaseCommand):
     def __init__(self, name, context_settings=None, callback=None,
                  params=None, help=None, epilog=None, short_help=None,
                  options_metavar='[OPTIONS]', add_help_option=True,
-                 hidden=False, deprecated=False):
+                 no_args_is_help=False, hidden=False, deprecated=False):
         BaseCommand.__init__(self, name, context_settings)
         #: the callback to execute when the command fires.  This might be
         #: `None` in which case nothing happens.
@@ -812,6 +816,7 @@ class Command(BaseCommand):
         self.options_metavar = options_metavar
         self.short_help = short_help
         self.add_help_option = add_help_option
+        self.no_args_is_help = no_args_is_help
         self.hidden = hidden
         self.deprecated = deprecated
 
@@ -932,6 +937,10 @@ class Command(BaseCommand):
                 formatter.write_text(self.epilog)
 
     def parse_args(self, ctx, args):
+        if not args and self.no_args_is_help and not ctx.resilient_parsing:
+            echo(ctx.get_help(), color=ctx.color)
+            ctx.exit()
+
         parser = self.make_parser(ctx)
         opts, args, param_order = parser.parse_args(args=args)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -68,6 +68,16 @@ def test_auto_shorthelp(runner):
         result.output) is not None
 
 
+def test_no_args_is_help(runner):
+    @click.command(no_args_is_help=True)
+    def cli():
+        pass
+
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert 'Show this message and exit.' in result.output
+
+
 def test_default_maps(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
The functionality for no_args_is_help, available on MultiCommands, can easily be added on Commands as well. The result is not much more code, and a more consistent interface between MultiCommands and Commands.
It's also nice to be able to write a click command `foo` and then just hit `foo` for help, regardless of whether its a Group or Command.

closes #1156

Will add changelog edit in a moment, after this PR is assigned a number.