### PR TITLE
Add an internal ExitStack to click's Context object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,11 @@ Unreleased
     -   Core objects use ``super()`` consistently for better support of
         subclassing.
 
+-   Use ``Context.with_resource()`` to manage resources that would
+    normally be used in a ``with`` statement, allowing them to be used
+    across subcommands and callbacks, then cleaned up when the context
+    ends. :pr:`1191`
+
 
 Version 7.1.2
 -------------

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pytest
 
 import click
@@ -210,6 +212,22 @@ def test_close_before_pop(runner):
     assert not result.exception
     assert result.output == "aha!\n"
     assert called == [True]
+
+
+def test_with_resource():
+    @contextmanager
+    def manager():
+        val = [1]
+        yield val
+        val[0] = 0
+
+    ctx = click.Context(click.Command("test"))
+
+    with ctx.scope():
+        rv = ctx.with_resource(manager())
+        assert rv[0] == 1
+
+    assert rv == [0]
 
 
 def test_make_pass_decorator_args(runner):


### PR DESCRIPTION
This patch allows adding context managers to a command group's common code that are then usable in the group's statements. This reduces code duplication and lets us move code using the group's options closer to the options themselves.

fixes #1245 