### PR TITLE
Remove unused compat shim for 'bytes'

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -155,7 +155,6 @@ class _FixupStream(object):
 
 if PY2:
     text_type = unicode
-    bytes = str
     raw_input = raw_input
     string_types = (str, unicode)
     int_types = (int, long)


### PR DESCRIPTION
Never used. Both Python 2.7 and Python 3 have the type bytes. On Python
2.7 it is an alias for str, same as what was previously defined.