### PR TITLE
Add `cli()` call to Nesting Commands section

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -199,6 +199,7 @@ implements two commands for managing databases:
 
     cli.add_command(initdb)
     cli.add_command(dropdb)
+    cli()
 
 As you can see, the :func:`group` decorator works like the :func:`command`
 decorator, but creates a :class:`Group` object instead which can be given


### PR DESCRIPTION
As a `click` beginner, I got stuck wondering why running the copy-pasted example code wouldn't parse my nested command but also wouldn't throw any errors. Adding this `cli()` call makes it work.