### PR TITLE
Modify the code about the custom multi commands.

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -202,7 +202,7 @@ A custom multi command just needs to implement a list and load method:
         def list_commands(self, ctx):
             rv = []
             for filename in os.listdir(plugin_folder):
-                if filename.endswith('.py'):
+                if filename.endswith('.py') and filename != '__init__.py':
                     rv.append(filename[:-3])
             rv.sort()
             return rv


### PR DESCRIPTION
The modification is quite minor and not essential. But some users may be trapped in the feature of custom multip commands due to `__init__.py`.