### PR TITLE
Loose ordering of options around groups and commands

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -998,7 +998,6 @@ class MultiCommand(Command):
     """
     allow_extra_args = True
     allow_interspersed_args = False
-    defer_unkown_options = False
 
     def __init__(self, name=None, invoke_without_command=False,
                  no_args_is_help=None, subcommand_metavar=None,
@@ -1105,7 +1104,7 @@ class MultiCommand(Command):
             ctx.exit()
 
         parser = self.make_parser(ctx)
-        if self.defer_unkown_options:
+        if ctx.defer_unknown_options:
             cmds = {c: self.get_command(ctx, c) for c in self.list_commands(ctx)}
         else:
             cmds = None

--- a/click/parser.py
+++ b/click/parser.py
@@ -318,12 +318,14 @@ class OptionParser(object):
                 state.rargs.insert(0, arg)
                 break
 
-        if nextcmd and len(state.largs):
+        try:
             # move deferred options to just after the next command
             # i.e. bring the next command to the front of largs
             icmd = state.largs.index(nextcmd)
             if icmd > 0:
                 state.largs.insert(0, state.largs.pop(icmd))
+        except ValueError:
+            pass
 
     def _match_long_opt(self, opt, explicit_value, state):
         # Interspersed options should be processed unless they have been

--- a/click/parser.py
+++ b/click/parser.py
@@ -219,8 +219,8 @@ class OptionParser(object):
         #: after shifting all the unknown options into the resulting args.
         self.ignore_unknown_options = False
         #: Defers unknown options until a command is found that can handle
-        #: it. Last one to the left wins, or if still none are found
-        #: and ignore_unknown_options is True, first one to the right wins.
+        #: it. Last one to the left wins, or if still none are found,
+        #: the first one to the right wins.
         self.defer_unknown_options = False
         if ctx is not None:
             self.allow_interspersed_args = ctx.allow_interspersed_args
@@ -318,14 +318,12 @@ class OptionParser(object):
                 state.rargs.insert(0, arg)
                 break
 
-        try:
+        if nextcmd and self.allow_interspersed_args:
             # move deferred options to just after the next command
             # i.e. bring the next command to the front of largs
             icmd = state.largs.index(nextcmd)
             if icmd > 0:
                 state.largs.insert(0, state.largs.pop(icmd))
-        except ValueError:
-            pass
 
     def _match_long_opt(self, opt, explicit_value, state):
         # Interspersed options should be processed unless they have been
@@ -438,7 +436,6 @@ class OptionParser(object):
             # error.
             if arg[:2] not in self._opt_prefixes:
                 return self._match_short_opt(arg, state)
-            if not (self.ignore_unknown_options or
-                    self.defer_unknown_options):
+            if not self.ignore_unknown_options:
                 raise
             state.largs.append(arg)

--- a/click/parser.py
+++ b/click/parser.py
@@ -218,9 +218,14 @@ class OptionParser(object):
         #: second mode where it will ignore it and continue processing
         #: after shifting all the unknown options into the resulting args.
         self.ignore_unknown_options = False
+        #: Defers unknown options until a command is found that can handle
+        #: it. Last one to the left wins, or if still none are found
+        #: and ignore_unknown_options is True, first one to the right wins.
+        self.defer_unknown_options = False
         if ctx is not None:
             self.allow_interspersed_args = ctx.allow_interspersed_args
             self.ignore_unknown_options = ctx.ignore_unknown_options
+            self.defer_unknown_options = ctx.defer_unknown_options
         self._short_opt = {}
         self._long_opt = {}
         self._opt_prefixes = set(['-', '--'])
@@ -431,6 +436,7 @@ class OptionParser(object):
             # error.
             if arg[:2] not in self._opt_prefixes:
                 return self._match_short_opt(arg, state)
-            if not self.ignore_unknown_options:
+            if not (self.ignore_unknown_options or
+                    self.defer_unknown_options):
                 raise
             state.largs.append(arg)

--- a/click/parser.py
+++ b/click/parser.py
@@ -363,7 +363,7 @@ class OptionParser(object):
         prefix = arg[0]
         forwarded_options = []
 
-        for i, ch in enumerate(arg[1:], start=1):
+        for i, ch in enumerate(arg[1:], start=2):
             opt = normalize_opt(prefix + ch, self.ctx)
 
             # Interspersed options should be processed unless they have been

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -257,6 +257,28 @@ def test_unprocessed_options(runner):
     ]
 
 
+def test_deferred_options(runner):
+    @click.group(context_settings=dict(
+        allow_interspersed_args=True,
+        defer_unknown_options=True,
+    ))
+    @click.option('--verbose', '-v', count=True)
+    def cli(verbose):
+        click.echo('Verbosity: %s' % verbose)
+
+    @cli.command()
+    @click.option('--quiet', '-q', count=True)
+    def conf(quiet):
+        print('Quietude: %s' % quiet)
+
+    result = runner.invoke(cli, ['-vq', 'conf', '-vq'])
+    assert not result.exception, result.output
+    assert result.output.splitlines() == [
+        'Verbosity: 2',
+        'Quietude: 2',
+    ]
+
+
 def test_deprecated_in_help_messages(runner):
     @click.command(deprecated=True)
     def cmd_with_help():


### PR DESCRIPTION
There are several closed (wont-fix) issues that center around weakening the strict grouping of options to their subcommands: #108 #245 #1104 #1150 . This proposal introduces a new context setting called ``defer_unknown_options`` that when ``True`` along-side having ``allow_interspersed_args == True`` would allow for a loose ordering of options around subcommands. For example if ``--verbose`` is a top-level option, it could be placed after a subcommand and you'd still have the ability to use options associated with the subcommand. Loose ordering, in this case, can be summarized as: the first command to the left consumes the option, if no command to the left knows about the option, the first one to the right will consume the option. If no command understands the option and ``ignore_unknown_options == False`` on the last command issued, then an error is raised.

I realize this is a feature that has been called-out as counter to click's design, but note that the default ``defer_unknown_options == False`` is exactly existing behavior and no unittests were changed as a result of this feature. Further, this is a rather small delta where most of the logic is contained in ``_process_args_for_options()``.