### PR TITLE
Teach Option to accept only explicit values

### DIFF
--- a/click/parser.py
+++ b/click/parser.py
@@ -155,6 +155,9 @@ class Option(object):
         state.order.append(self.obj)
 
     def get_value_from_state(self, state, opt_name, explicit_value):
+        if getattr(self.obj, 'explicit_only', False):
+            return explicit_value
+
         # At this point it's safe to modify rargs by injecting the
         # explicit value, because no exception is raised in this
         # branch.  This means that the inserted value will be fully


### PR DESCRIPTION
Add a new attribute/argument `explicit_only` to `Option` class. When set
to true, this option will cause Options with nargs=1 to only accept
input that is explicitly associated to it.

This makes the following valid:

    command
    command --option
    command --option=value

This addresses #549 and #764.