### PR TITLE
Allow path_type of the Path type to accept a callable (`#405`_)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Version 7.1
 
 Unreleased
 
+-   ``Path``'s argument ``path_type`` can accept a callable now
+    (``path_type``=``pathlib.Path`` for example . (`#405`_)
+
 
 Version 7.0
 -----------
@@ -167,6 +170,7 @@ Released 2018-09-25
 .. _#323: https://github.com/pallets/click/issues/323
 .. _#334: https://github.com/pallets/click/issues/334
 .. _#393: https://github.com/pallets/click/issues/393
+.. _#405: https://github.com/pallets/click/issues/405
 .. _#409: https://github.com/pallets/click/issues/409
 .. _#414: https://github.com/pallets/click/pull/414
 .. _#423: https://github.com/pallets/click/pull/423

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -151,6 +151,21 @@ And what it does:
         println()
         invoke(touch, args=['missing.txt'])
 
+If you preffer some object oriented API for filesystem paths you can use the
+``path_type`` argument to the :class:`Path` type to pass a class that
+implements this API.
+
+Example:
+
+.. click:example::
+
+    import pathlib
+
+    @click.command()
+    @click.argument('f', type=click.Path(exists=True, path_type=pathlib.Path))
+    def touch(f):
+        click.echo(f.resolve())
+
 
 File Opening Safety
 -------------------


### PR DESCRIPTION
This would allow to convert path names to pathlib.Path instances
for example.

closes #405