### PR TITLE
Allow path_type of the Path type to accept a callable (`#405`_) (7.x branch)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,11 +11,14 @@ Unreleased
 - Fix link in ``unicode_literals`` error message. (`#1151`_)
 - Add support for colored output on UNIX Jupyter notebooks. (`#1185`_)
 - Remove unused compat shim for ``bytes``. (`#1195`_)
+- ``Path``'s argument ``path_type`` can accept a callable now
+  (``path_type``=``pathlib.Path`` for example . (`#405`_)
 
 .. _#1167: https://github.com/pallets/click/pull/1167
 .. _#1151: https://github.com/pallets/click/pull/1151
 .. _#1185: https://github.com/pallets/click/issues/1185
 .. _#1195: https://github.com/pallets/click/pull/1195
+.. _#405: https://github.com/pallets/click/issues/405
 
 Version 7.0
 -----------

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -151,6 +151,21 @@ And what it does:
         println()
         invoke(touch, args=['missing.txt'])
 
+If you preffer some object oriented API for filesystem paths you can use the
+``path_type`` argument to the :class:`Path` type to pass a class that
+implements this API.
+
+Example:
+
+.. click:example::
+
+    import pathlib
+
+    @click.command()
+    @click.argument('f', type=click.Path(exists=True, path_type=pathlib.Path))
+    def touch(f):
+        click.echo(f.resolve())
+
 
 File Opening Safety
 -------------------


### PR DESCRIPTION
Cherry-pick #1234  to 7.x branch:

This would allow to convert path names to pathlib.Path instances
for example.
