### PR TITLE
Fix setuptools code snippet (dict, module path)

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -126,14 +126,15 @@ These would be the modified contents of ``setup.py``::
 
     setup(
         name='yourpackage',
-        version='0.1',
+        version='0.1.0',
         packages=find_packages(),
         include_package_data=True,
         install_requires=[
             'Click',
         ],
-        entry_points='''
-            [console_scripts]
-            yourscript=yourpackage.scripts.yourscript:cli
-        ''',
+        entry_points={
+            'console_scripts': [
+                'yourscript = yourpackage.scripts.yourscript:cli',
+            ],
+        },
     )


### PR DESCRIPTION
I can't help but I find using a dictionary-style entry_points definition more pythonic.