### PR TITLE
don't complete args that start with dash after double dash separator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ Unreleased
 -   Add ZSH completion autoloading and error handling. :issue:`1348`
 -   Add a repr to ``Command``, ``Group``, ``Option``, and ``Argument``,
     showing the name for friendlier debugging. :issue:`1267`
+-   Completion doesn't consider option names if a value starts with
+    ``-`` after the ``--`` separator. :issue:`1247`
 
 
 Version 7.0

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -237,6 +237,8 @@ def get_choices(cli, prog_name, args, incomplete):
     if ctx is None:
         return []
 
+    has_double_dash = "--" in all_args
+
     # In newer versions of bash long opts with '='s are partitioned, but it's easier to parse
     # without the '='
     if start_of_option(incomplete) and WORDBREAK in incomplete:
@@ -247,7 +249,7 @@ def get_choices(cli, prog_name, args, incomplete):
         incomplete = ''
 
     completions = []
-    if start_of_option(incomplete):
+    if not has_double_dash and start_of_option(incomplete):
         # completions for partial options
         for param in ctx.command.params:
             if isinstance(param, Option) and not param.hidden:


### PR DESCRIPTION
Preventing Click from trying to complete args that starts with dash after a double dash separator

fixes #1247