### PR TITLE
Document adding no_args_is_help to Command for 7.1

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -776,6 +776,8 @@ class Command(BaseCommand):
 
     .. versionchanged:: 2.0
        Added the `context_settings` parameter.
+    .. versionchanged:: 7.1
+       Added the `no_args_is_help` parameter.
 
     :param name: the name of the command to use unless a group overrides it.
     :param context_settings: an optional dictionary with defaults that are


### PR DESCRIPTION
In #1167, a parameter was added to the `Command` class, changing the documentation accordingly. However, it was not specified that it was a change for an unreleased version. This change indicates that the `no_args_is_help` parameter is added in 7.1. 

Tests are passing. Closes #1259. 