### PR TITLE
Prevent environment variables from containing '-' characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Unreleased
     interpreter. :issue:`1139`
 -   Fix how default values for file-type options are shown during
     prompts. :issue:`914`
+-   Fix environment variable automatic generation for commands
+    containing ``-``. :issue:`1253`
 
 
 Version 7.0

--- a/click/core.py
+++ b/click/core.py
@@ -335,6 +335,8 @@ class Context(object):
                                            self.info_name.upper())
         else:
             auto_envvar_prefix = auto_envvar_prefix.upper()
+        if auto_envvar_prefix is not None:
+            auto_envvar_prefix = auto_envvar_prefix.replace("-", "_")
         self.auto_envvar_prefix = auto_envvar_prefix
 
         if color is None and parent is not None:

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -593,8 +593,8 @@ environment variables which is supported for options only.  To enable this
 feature, the ``auto_envvar_prefix`` parameter needs to be passed to the
 script that is invoked.  Each command and parameter is then added as an
 uppercase underscore-separated variable.  If you have a subcommand
-called ``foo`` taking an option called ``bar`` and the prefix is
-``MY_TOOL``, then the variable is ``MY_TOOL_FOO_BAR``.
+called ``run`` taking an option called ``reload`` and the prefix is
+``WEB``, then the variable is ``WEB_RUN_RELOAD``.
 
 Example usage:
 
@@ -615,8 +615,11 @@ And from the command line:
     invoke(greet, env={'GREETER_USERNAME': 'john'},
            auto_envvar_prefix='GREETER')
 
-When using ``auto_envvar_prefix`` with command groups, the command name needs
-to be included in the environment variable, between the prefix and the parameter name, *i.e.* *PREFIX_COMMAND_VARIABLE*.
+When using ``auto_envvar_prefix`` with command groups, the command name
+needs to be included in the environment variable, between the prefix and
+the parameter name, *i.e.* ``PREFIX_COMMAND_VARIABLE``. If you have a
+subcommand called ``run-server`` taking an option called ``host`` and
+the prefix is ``WEB``, then the variable is ``WEB_RUN_SERVER_HOST``.
 
 Example:
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -273,6 +273,22 @@ def test_show_envvar_auto_prefix(runner):
     assert 'TEST_ARG1' in result.output
 
 
+def test_show_envvar_auto_prefix_dash_in_command(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option('--baz', show_envvar=True)
+    def foo_bar(baz):
+        pass
+
+    result = runner.invoke(cli, ['foo-bar', '--help'],
+                           auto_envvar_prefix='TEST')
+    assert not result.exception
+    assert 'TEST_FOO_BAR_BAZ' in result.output
+
+
 def test_custom_validation(runner):
     def validate_pos_int(ctx, param, value):
         if value < 0:


### PR DESCRIPTION
This PR fixes #1253.