### PR TITLE
Annotate required choices with braces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Unreleased
 -   The result object returned by the test runner's ``invoke()`` method
     has a ``return_value`` attribute with the value returned by the
     invoked command. :pr:`1312`
+-   Required arguments with the ``Choice`` type show the choices in
+    curly braces to indicate that one is required (``{a|b|c}``).
+    :issue:`1272`
 
 
 Version 7.1.2

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -157,7 +157,14 @@ class Choice(ParamType):
         self.case_sensitive = case_sensitive
 
     def get_metavar(self, param):
-        return f"[{'|'.join(self.choices)}]"
+        choices_str = "|".join(self.choices)
+
+        # Use curly braces to indicate a required argument.
+        if param.required and param.param_type_name == "argument":
+            return f"{{{choices_str}}}"
+
+        # Use square braces to indicate an option or optional argument.
+        return f"[{choices_str}]"
 
     def get_missing_message(self, param):
         choice_str = ",\n\t".join(self.choices)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -352,6 +352,27 @@ def test_choice_option(runner):
     assert "--method [foo|bar|baz]" in result.output
 
 
+def test_choice_argument(runner):
+    @click.command()
+    @click.argument("method", type=click.Choice(["foo", "bar", "baz"]))
+    def cli(method):
+        click.echo(method)
+
+    result = runner.invoke(cli, ["foo"])
+    assert not result.exception
+    assert result.output == "foo\n"
+
+    result = runner.invoke(cli, ["meh"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '{foo|bar|baz}': invalid choice: meh. "
+        "(choose from foo, bar, baz)" in result.output
+    )
+
+    result = runner.invoke(cli, ["--help"])
+    assert "{foo|bar|baz}" in result.output
+
+
 def test_datetime_option_default(runner):
     @click.command()
     @click.option("--start_date", type=click.DateTime())


### PR DESCRIPTION
Display the metavar for Choice options with curly braces on required
params, to reduce user confusion.

fixes #1272