### PR TITLE
Add show_index flag for Choice type.

### DIFF
--- a/click/termui.py
+++ b/click/termui.py
@@ -46,7 +46,8 @@ def hidden_prompt_func(prompt):
 def _build_prompt(text, suffix, show_default=False, default=None, show_choices=True, type=None):
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
-        prompt += ' (' + ", ".join(map(str, type.choices)) + ')'
+        prompt += ' (' + ", ".join(map(str, type.choices.values())) + ')' if not type.show_index else \
+                  ' (' + ", ".join(['%s:%s'%(idx,ch) for idx,ch in type.choices.items()]) + ')' 
     if default is not None and show_default:
         prompt = '%s [%s]' % (prompt, default)
     return prompt + suffix

--- a/click/types.py
+++ b/click/types.py
@@ -161,7 +161,9 @@ class Choice(ParamType):
             try:
                 idx = int(value)
             except:
-                self.fail('invaid index choice: %s. Please input integer type!' % (value))
+                if value in self.choices.values():
+                    return value
+                self.fail('invaid index choice: %s. Please input integer index or correct value!' % (value))
 
             if idx in list(self.choices.keys()):
                 return self.choices[idx]

--- a/click/types.py
+++ b/click/types.py
@@ -606,9 +606,15 @@ class Tuple(CompositeParamType):
         return len(self.types)
 
     def convert(self, value, param, ctx):
+        # Hotfix for prompt input 
+        if isinstance(value, str):
+            value = value.strip().split(',')
+            if len(value) != len(self.types):
+                value = value.strip().split(' ')
+            
         if len(value) != len(self.types):
             raise TypeError('It would appear that nargs is set to conflict '
-                            'with the composite type arity.')
+                            'with the composite type arity: len({}) != len({})'.format(value, self.types))
         return tuple(ty(x, param, ctx) for ty, x in zip(self.types, value))
 
 


### PR DESCRIPTION
I added show_index flag for Choice.
Show_index enables users to use index of choice instead of choice item itself.
I think this would help a little when users have a bunch of choice items.

Usage example:
```
@click.command()
@click.option('--v', prompt=True, type=click.Choice(['a','bb','ccc'], show_index=True), default=1)
def main(v):
    print("Choosed:", v)
```

> $ python test_click.py
> V (0:a, 1:bb, 2:ccc) [bb]: 0
> Choosed: a

To avoid confusion of indices and choices, when show_index is True, only index (integer) is allowed.
Code was tested on Ubuntu 18.04 with zsh: 196 passed, 1 xfailed in 2.02 seconds 

