### PR TITLE
[Issue 1289] Advise users not to use prompt in conjunction with multiple in the documentation

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -382,6 +382,10 @@ What it looks like:
 
     invoke(hello, input=['John'])
 
+It is advised that prompt not be used in conjunction with the multiple
+flag set to True. Instead, prompt in the function interactively.
+
+
 Password Prompts
 ----------------
 


### PR DESCRIPTION
fixes #1289 