### PR TITLE
Copy flask issue template to Click

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+**This issue tracker is a tool to address bugs in Click itself.
+Please use the #pocoo IRC channel on freenode, the Discord server or 
+Stack Overflow for general questions about using Flask or issues
+not related to Click.**
+
+If you'd like to report a bug in Click, fill out the template below. Provide
+any extra information that may be useful / related to your problem.
+Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
+understand the problem and helps check that it is not caused by something in
+your code.
+
+---
+
+### Expected Behavior
+
+Tell us what should happen.
+
+```python
+Paste a minimal example that causes the problem.
+```
+
+### Actual Behavior
+
+Tell us what happens instead.
+
+```pytb
+Paste the full traceback if there was an exception.
+```
+
+### Environment
+
+* Python version:
+* Click version:


### PR DESCRIPTION
Adds the .github issue template
This is still using the older style of github templates to keep consistency with other flask projects

Closes: #624 