### PR TITLE
Unprintable MissingParameter exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Unreleased
     ``type=bool``. :issue:`1287`
 -   Newlines in option help text are replaced with spaces before
     re-wrapping to avoid uneven line breaks. :issue:`834`
+-   ``MissingParameter`` exceptions are printable in the Python
+    interpreter. :issue:`1139`
 
 
 Version 7.0

--- a/click/exceptions.py
+++ b/click/exceptions.py
@@ -152,6 +152,19 @@ class MissingParameter(BadParameter):
             msg or '',
         )
 
+    def __str__(self):
+        if self.message is None:
+            param_name = self.param.name if self.param else None
+            return "missing parameter: {}".format(param_name)
+        else:
+            return self.message
+
+    if PY2:
+        __unicode__ = __str__
+
+        def __str__(self):
+            return self.__unicode__().encode("utf-8")
+
 
 class NoSuchOption(UsageError):
     """Raised if click attempted to handle an option that does not

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -203,6 +203,15 @@ def test_missing_arg(runner):
     assert 'Missing argument "ARG".' in result.output
 
 
+def test_missing_argument_string_cast():
+    ctx = click.Context(click.Command(""))
+
+    with pytest.raises(click.MissingParameter) as excinfo:
+        click.Argument(["a"], required=True).full_process_value(ctx, None)
+
+    assert str(excinfo.value) == "missing parameter: a"
+
+
 def test_implicit_non_required(runner):
     @click.command()
     @click.argument('f', default='test')

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -321,6 +321,15 @@ def test_legacy_options(runner):
     assert result.output == '23\n'
 
 
+def test_missing_option_string_cast():
+    ctx = click.Context(click.Command(""))
+
+    with pytest.raises(click.MissingParameter) as excinfo:
+        click.Option(['-a'], required=True).full_process_value(ctx, None)
+
+    assert str(excinfo.value) == "missing parameter: a"
+
+
 def test_missing_choice(runner):
     @click.command()
     @click.option('--foo', type=click.Choice(['foo', 'bar']),


### PR DESCRIPTION
Resolves #1139

I attempted to resolve the issue by setting message to a default string if `message is None` is true. However, this broke multiple tests in test_formatting.py by appending the 'missing parameter ...' default message set in the MissingParameter init method.

Overriding __str__ seems like the clearer and more direct fix to allow casting of MissingParameter objects to strings without breaking existing behavior.