### PR TITLE
Fix to #1066 text wrapping

### DIFF
--- a/click/formatting.py
+++ b/click/formatting.py
@@ -198,7 +198,19 @@ class HelpFormatter(object):
                 self.write(' ' * (first_col + self.current_indent))
 
             text_width = max(self.width - first_col - 2, 10)
-            lines = iter(wrap_text(second, text_width).splitlines())
+
+            if '\n' in second:
+                lines = []
+                broken_lines = second.split('\n')
+                for broken_line in broken_lines:
+                    if broken_line == '':
+                        lines.append(broken_line)
+                    else:
+                        lines += list(wrap_text(broken_line, text_width).splitlines())
+                lines = iter(lines)
+            else:
+                lines = iter(wrap_text(second, text_width).splitlines())
+
             if lines:
                 self.write(next(lines) + '\n')
                 for line in lines:


### PR DESCRIPTION
### Problem
Closes #1066 

**To Reproduce:** 

Add the python snippet below on a new file using `master` branch.
On your terminal.
Run
```sh
python sample.py --help
```
```python
import click
TEXT = 'This will break the next paragraph.\n\nI am going to get broken in the wrong place.'
@click.command()
@click.option('--test', help=TEXT)
def hello(test):
    """This script prints hello NAME COUNT times."""
    pass
if __name__ == '__main__':
	hello()
```

Result

<img width="781" alt="issue-produce" src="https://user-images.githubusercontent.com/18662248/57288172-ff242c00-7086-11e9-8ed9-37ec2e3cded7.png">

--------

### Proof of fix


Follow the same reproduce-able steps above on this branch

<img width="805" alt="1066-fix" src="https://user-images.githubusercontent.com/18662248/57289423-562b0080-7089-11e9-84d9-f1b36beba41d.png">

 