### PR TITLE
Capture command return value in Result / CliRunner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ Unreleased
     normally be used in a ``with`` statement, allowing them to be used
     across subcommands and callbacks, then cleaned up when the context
     ends. :pr:`1191`
+-   The result object returned by the test runner's ``invoke()`` method
+    has a ``return_value`` attribute with the value returned by the
+    invoked command. :pr:`1312`
 
 
 Version 7.1.2

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -295,3 +295,16 @@ def test_setting_prog_name_in_extra():
     result = runner.invoke(cli, prog_name="foobar")
     assert not result.exception
     assert result.output == "ok\n"
+
+
+def test_command_standalone_mode_returns_value():
+    @click.command()
+    def cli():
+        click.echo("ok")
+        return "Hello, World!"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, standalone_mode=False)
+    assert result.output == "ok\n"
+    assert result.return_value == "Hello, World!"
+    assert result.exit_code == 0


### PR DESCRIPTION
I'm using click (with `standalone_mode=False`) as the command-parsing module for a chat bot. It's awesome! In the simplest case, I have commands structured like this:

```python
@sammich.command()
@click.option("--filling", default="sad, empty")
def make(filling):
    """Demo for click options."""
    return f"Here you go, have a {filling} sammich"
```

For more complex stuff there's other ways to send messages back from the bot, but using the return value of the command to send simple messages has worked really well.

Testing commands like this is a bit of a pain. I can use the `CliRunner` and see that the "exit code" is 0, however, while the `CliRunner` (via the Result object) allows access to stdout, stderr, exit code etc, it doesn't capture the invocation result/return value. While it's a fairly unusual use case, it looked like it might be fairly straightforward to do and it turns out it is (at least... I think so!).

With this PR, I can more easily test my simple commands' return values (the new test in `test_testing.py` is exactly what I want to do for my own simple commands.)