### PR TITLE
Preventing prompts without tty from echoing their outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Version 8.0
 
 Unreleased
 
+-   Preventing prompts without tty from echoing their outputs. (`#906`_)
+
+.. _#906: https://github.com/pallets/click/issues/906
+
 
 Version 7.1
 -----------

--- a/click/termui.py
+++ b/click/termui.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import struct
@@ -5,7 +6,7 @@ import inspect
 import itertools
 
 from ._compat import raw_input, text_type, string_types, \
-     isatty, strip_ansi, get_winterm_size, DEFAULT_COLUMNS, WIN
+    isatty, strip_ansi, get_winterm_size, DEFAULT_COLUMNS, WIN
 from .utils import echo
 from .exceptions import Abort, UsageError
 from .types import convert_type, Choice, Path
@@ -39,8 +40,13 @@ _ansi_reset_all = '\033[0m'
 
 
 def hidden_prompt_func(prompt):
-    import getpass
-    return getpass.getpass(prompt)
+    if isatty(sys.stdin):
+        import getpass
+        p = getpass.getpass(prompt)
+    else:
+        print(prompt, end=""),
+        p = sys.stdin.readline().rstrip()
+    return p
 
 
 def _build_prompt(text, suffix, show_default=False, default=None, show_choices=True, type=None):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,7 +32,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading', 'colorama', 'errno', 'fcntl', 'datetime'
+    'threading', 'colorama', 'errno', 'fcntl', 'datetime', '__future__'
 ])
 
 if WIN:


### PR DESCRIPTION
fixes #906