### PR TITLE
Always return originally passed choice for Choice()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,12 +13,16 @@ Unreleased
 - Remove unused compat shim for ``bytes``. (`#1195`_)
 - Expand unit testing around termui, especially getchar (Windows). (`#1116`_)
 -   Fix output on Windows Python 2.7 built with MSVC 14. #1342
+- Always return of of the passed choices for ``click.Choice`` (`#1277`, `#1318`)
 
 .. _#1167: https://github.com/pallets/click/pull/1167
 .. _#1151: https://github.com/pallets/click/pull/1151
 .. _#1185: https://github.com/pallets/click/issues/1185
 .. _#1195: https://github.com/pallets/click/pull/1195
 .. _#1116: https://github.com/pallets/click/issues/1116
+.. _#1277: https://github.com/pallets/click/issues/1277
+.. _#1318: https://github.com/pallets/click/pull/1318
+
 
 Version 7.0
 -----------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -315,14 +315,17 @@ Choice Options
 
 Sometimes, you want to have a parameter be a choice of a list of values.
 In that case you can use :class:`Choice` type.  It can be instantiated
-with a list of valid values.
+with a list of valid values.  The originally passed choice will be returned,
+not the str passed on the command line.  Token normalization functions and
+``case_sensitive=False`` can cause the two to be different but still match.
 
 Example:
 
 .. click:example::
 
     @click.command()
-    @click.option('--hash-type', type=click.Choice(['md5', 'sha1']))
+    @click.option('--hash-type',
+                  type=click.Choice(['MD5', 'SHA1'], case_sensitive=False))
     def digest(hash_type):
         click.echo(hash_type)
 
@@ -330,6 +333,8 @@ What it looks like:
 
 .. click:run::
 
+    invoke(digest, args=['--hash-type=MD5'])
+    println()
     invoke(digest, args=['--hash-type=md5'])
     println()
     invoke(digest, args=['--hash-type=foo'])
@@ -340,6 +345,9 @@ What it looks like:
 
     You should only pass the choices as list or tuple.  Other iterables (like
     generators) may lead to surprising results.
+
+    Choices should be unique after considering the effects of
+    ``case_sensitive`` and any specified token normalization function.
 
 .. _option-prompting:
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -20,7 +20,7 @@ def test_choice_normalization(runner):
     @click.command(context_settings=CONTEXT_SETTINGS)
     @click.option('--choice', type=click.Choice(['Foo', 'Bar']))
     def cli(choice):
-        click.echo('Foo')
+        click.echo(choice)
 
     result = runner.invoke(cli, ['--CHOICE', 'FOO'])
     assert result.output == 'Foo\n'

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -335,12 +335,15 @@ def test_case_insensitive_choice(runner):
 
     result = runner.invoke(cmd, ['--foo', 'apple'])
     assert result.exit_code == 0
+    assert result.output == 'Apple\n'
 
     result = runner.invoke(cmd, ['--foo', 'oRANGe'])
     assert result.exit_code == 0
+    assert result.output == 'Orange\n'
 
     result = runner.invoke(cmd, ['--foo', 'Apple'])
     assert result.exit_code == 0
+    assert result.output == 'Apple\n'
 
     @click.command()
     @click.option('--foo', type=click.Choice(['Orange', 'Apple']))
@@ -355,6 +358,18 @@ def test_case_insensitive_choice(runner):
 
     result = runner.invoke(cmd2, ['--foo', 'Apple'])
     assert result.exit_code == 0
+
+
+def test_case_insensitive_choice_returned_exactly(runner):
+    @click.command()
+    @click.option('--foo', type=click.Choice(
+        ['Orange', 'Apple'], case_sensitive=False))
+    def cmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(cmd, ['--foo', 'apple'])
+    assert result.exit_code == 0
+    assert result.output == 'Apple\n'
 
 
 def test_multiline_help(runner):


### PR DESCRIPTION
closes #1277
replaces #1278