### PR TITLE
Remove one unused import and one redundant import

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -258,7 +258,6 @@ if PY2:
             value = value.decode(get_filesystem_encoding(), 'replace')
         return value
 else:
-    import io
     text_type = str
     raw_input = input
     string_types = (str,)

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -16,7 +16,7 @@ import sys
 import time
 import math
 import contextlib
-from ._compat import _default_text_stdout, range_type, PY2, isatty, \
+from ._compat import _default_text_stdout, range_type, isatty, \
      open_stream, strip_ansi, term_len, get_best_encoding, WIN, int_types, \
      CYGWIN
 from .utils import echo


### PR DESCRIPTION
Here is the fix to two minor issues:

* `io` module is already imported at https://github.com/pallets/click/blob/master/click/_compat.py#L2 and do not need to be re-imported
* `PY2` is not used in the `_termui_impl.py` module and can be safely removed

The tests were run locally and have passed on 2.7 and 3.6.

These issues (among a few others) were flagged up by LGTM.com: https://lgtm.com/projects/g/pallets/click/alerts/?mode=list. Some of the other `pallets` repositories such as `flask` have been analyzed there as well: https://lgtm.com/projects/g/pallets/flask/.

If you like, you can use LGTM for automatically reviewing code in pull requests. Here's an example of how Google's AMPHTML use that to flag up security vulnerabilities in their code base: [ampproject/amphtml#13060](https://github.com/ampproject/amphtml/pull/13060)

There is also a shield badge you could put into the `readme` file, 
![image](https://user-images.githubusercontent.com/50622389/58274055-ec4d6f00-7d89-11e9-9217-6430480d4439.png) 
which would show excellent quality of Python code in the `click` project.

(full disclosure: I'm a `click` user, and also part of the team that runs [LGTM.com](https://lgtm.com/))