### PR TITLE
Clarify where arguments should be documented and provide examples.

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -8,8 +8,8 @@ Arguments
 Arguments work similarly to :ref:`options <options>` but are positional.
 They also only support a subset of the features of options due to their
 syntactical nature. Click will also not attempt to document arguments for
-you and wants you to document them manually in order to avoid ugly help
-pages.
+you and wants you to :ref:`document them manually <documenting-arguments>`
+in order to avoid ugly help pages.
 
 Basic Arguments
 ---------------
@@ -25,6 +25,7 @@ Example:
     @click.command()
     @click.argument('filename')
     def touch(filename):
+        """Print FILENAME."""
         click.echo(filename)
 
 And what it looks like:
@@ -52,6 +53,7 @@ Example:
     @click.argument('src', nargs=-1)
     @click.argument('dst', nargs=1)
     def copy(src, dst):
+        """Move file SRC to DST."""
         for fn in src:
             click.echo('move %s to folder %s' % (fn, dst))
 
@@ -101,6 +103,7 @@ Example:
     @click.argument('input', type=click.File('rb'))
     @click.argument('output', type=click.File('wb'))
     def inout(input, output):
+        """Copy contents of INPUT to OUTPUT."""
         while True:
             chunk = input.read(1024)
             if not chunk:
@@ -136,9 +139,10 @@ Example:
 .. click:example::
 
     @click.command()
-    @click.argument('f', type=click.Path(exists=True))
-    def touch(f):
-        click.echo(click.format_filename(f))
+    @click.argument('filename', type=click.Path(exists=True))
+    def touch(filename):
+        """Print FILENAME if the file exists."""
+        click.echo(click.format_filename(filename))
 
 And what it does:
 
@@ -199,6 +203,7 @@ Example usage:
     @click.command()
     @click.argument('src', envvar='SRC', type=click.File('r'))
     def echo(src):
+        """Print value of SRC environment variable."""
         click.echo(src.read())
 
 And from the command line:
@@ -235,6 +240,7 @@ Example usage:
     @click.command()
     @click.argument('files', nargs=-1, type=click.Path())
     def touch(files):
+        """Print all FILES file names."""
         for filename in files:
             click.echo(filename)
 
@@ -252,6 +258,7 @@ True to avoid checking unknown options:
     @click.command(context_settings={"ignore_unknown_options": True})
     @click.argument('files', nargs=-1, type=click.Path())
     def touch(files):
+        """Print all FILES file names."""
         for filename in files:
             click.echo(filename)
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -32,10 +32,54 @@ And what it looks like:
 
     invoke(hello, args=['--help'])
 
-Arguments cannot be documented this way.  This is to follow the general
-convention of Unix tools of using arguments for only the most necessary
-things and to document them in the introduction text by referring to them
-by name.
+
+.. _documenting-arguments:
+
+Documenting Arguments
+~~~~~~~~~~~~~~~~~~~~~
+
+:func:`click.argument` does not take a ``help`` parameter. This is to
+follow the general convention of Unix tools of using arguments for only
+the most necessary things, and to document them in the command help text
+by referring to them by name.
+
+You might prefer to reference the argument in the description:
+
+.. click:example::
+
+    @click.command()
+    @click.argument('filename')
+    def touch(filename):
+        """Print FILENAME."""
+        click.echo(filename)
+
+And what it looks like:
+
+.. click:run::
+
+    invoke(touch, args=['--help'])
+
+Or you might prefer to explicitly provide a description of the argument:
+
+.. click:example::
+
+    @click.command()
+    @click.argument('filename')
+    def touch(filename):
+        """Print FILENAME.
+
+        FILENAME is the name of the file to check.
+        """
+        click.echo(filename)
+
+And what it looks like:
+
+.. click:run::
+
+    invoke(touch, args=['--help'])
+
+For more examples, see the examples in :doc:`/arguments`.
+
 
 Preventing Rewrapping
 ---------------------

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -23,8 +23,8 @@ available for options:
 *   act as flags (boolean or otherwise)
 *   option values can be pulled from environment variables, arguments can not
 *   options are fully documented in the help page, arguments are not
-    (this is intentional as arguments might be too specific to be
-    automatically documented)
+    (:ref:`this is intentional <documenting-arguments>` as arguments
+    might be too specific to be automatically documented)
 
 On the other hand arguments, unlike options, can accept an arbitrary number
 of arguments.  Options can strictly ever only accept a fixed number of


### PR DESCRIPTION
Per the documentation and several conversations in issues, arguments should be manually documented by the author. However, the *how* and *where* is vague, and some of the wording used can lead the reader to believe that there *is* a first-class mechanism for defining arguments, while there is in fact not.

This confusion appears to be a fairly common problem[1].

As @davidism points out in #1217, this is briefly described at a few points in the documentation, but these points are rather scattered and while there is one example provided[2], it was not clear to me until after reading #1217 that it is in fact showing a pattern of argument documentation.

In this change, I expand the help-text docs to explicitly show examples of argument documentation, as well as linking together the three parts of the docs that talk about this and adding docstrings to all examples on the arguments page, to further demonstrate the suggested pattern.

[1]
https://github.com/pallets/click/issues/375
https://github.com/pallets/click/issues/505
https://github.com/pallets/click/issues/587
https://stackoverflow.com/questions/31173308/why-does-my-use-of-click-argument-produce-got-an-unexpected-keyword-argument-h
https://github.com/pallets/click/pull/1051
https://github.com/pallets/click/issues/1080
https://github.com/pallets/click/issues/1217
[2] https://click.palletsprojects.com/en/7.x/documentation/#help-texts