### PR TITLE
Add a docstring to Command.get_usage to clarify how to retrieve usage

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -828,6 +828,10 @@ class Command(BaseCommand):
         self.deprecated = deprecated
 
     def get_usage(self, ctx):
+        """Formats the usage line into a string and returns it.
+
+        Calls :meth:`format_usage` internally.
+        """
         formatter = ctx.make_formatter()
         self.format_usage(ctx, formatter)
         return formatter.getvalue().rstrip('\n')
@@ -840,7 +844,10 @@ class Command(BaseCommand):
         return rv
 
     def format_usage(self, ctx, formatter):
-        """Writes the usage line into the formatter."""
+        """Writes the usage line into the formatter.
+
+        This is a low-level method called by :meth:`get_usage`.
+        """
         pieces = self.collect_usage_pieces(ctx)
         formatter.write_usage(ctx.command_path, ' '.join(pieces))
 
@@ -884,8 +891,9 @@ class Command(BaseCommand):
         return parser
 
     def get_help(self, ctx):
-        """Formats the help into a string and returns it.  This creates a
-        formatter and will call into the following formatting methods:
+        """Formats the help into a string and returns it.
+
+        Calls :meth:`format_help` internally.
         """
         formatter = ctx.make_formatter()
         self.format_help(ctx, formatter)
@@ -898,7 +906,9 @@ class Command(BaseCommand):
     def format_help(self, ctx, formatter):
         """Writes the help into the formatter if it exists.
 
-        This calls into the following methods:
+        This is a low-level method called by :meth:`get_help`.
+
+        This calls the following methods:
 
         -   :meth:`format_usage`
         -   :meth:`format_help_text`


### PR DESCRIPTION
Add a docstring to `Command.get_usage` to clarify how to retrieve usage text, and correct the doc for `Command.get_help`.  Addresses concerns raised in issue #974

This should make `Command.get_usage()` show up the API docs and provide the more straightforward and discoverable way for users to get the usage string instead of trying to make use of the semi-internal methods like `format_usage`.