### PR TITLE
Adding support to the context to distinguish the source of a command line parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,12 @@ Version 8.0
 Unreleased
 
 -   Adds a repr to Command, showing the command name for friendlier debugging. (`#1267`_, `#1295`_)
-
+-   Add support for distinguishing the source of a command line parameter. (`#1264`_, `#1329`_)
+    
 .. _#1267: https://github.com/pallets/click/issues/1267
 .. _#1295: https://github.com/pallets/click/pull/1295
-
+.. _#1264: https://github.com/pallets/click/issues/1264
+.. _#1329: https://github.com/pallets/click/pull/1329
 
 Version 7.1
 -----------

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -14,7 +14,7 @@ composable.
 
 # Core classes
 from .core import Context, BaseCommand, Command, MultiCommand, Group, \
-     CommandCollection, Parameter, Option, Argument, ParameterSource
+     CommandCollection, Parameter, Option, Argument
 
 # Globals
 from .globals import get_current_context

--- a/click/__init__.py
+++ b/click/__init__.py
@@ -14,7 +14,7 @@ composable.
 
 # Core classes
 from .core import Context, BaseCommand, Command, MultiCommand, Group, \
-     CommandCollection, Parameter, Option, Argument
+     CommandCollection, Parameter, Option, Argument, ParameterSource
 
 # Globals
 from .globals import get_current_context

--- a/click/core.py
+++ b/click/core.py
@@ -369,7 +369,7 @@ class Context(object):
 
         self._close_callbacks = []
         self._depth = 0
-        self._parameter_sources = {}
+        self._sources_by_paramname = {}
         
     def __enter__(self):
         self._depth += 1
@@ -614,7 +614,7 @@ class Context(object):
                        should be a valid ParameterSource value
         """
         ParameterSource.validate(source)
-        self._parameter_sources[name] = source
+        self._sources_by_paramname[name] = source
 
     def get_parameter_source(self, name):
         """Get the source of a parameter.
@@ -630,7 +630,7 @@ class Context(object):
         :returns: the source
         :rtype: ParameterSource
         """
-        return self._parameter_sources[name]
+        return self._sources_by_paramname[name]
 
 
 class BaseCommand(object):

--- a/click/core.py
+++ b/click/core.py
@@ -130,7 +130,7 @@ def iter_params_for_processing(invocation_order, declaration_order):
     return sorted(declaration_order, key=sort_key)
 
 class ParameterSource(object):
-    """This is an enum that indicates the source of a command line option.
+    """This is an enum that indicates the source of a command line parameter.
 
     The enum has one of the following values: COMMANDLINE,
     ENVIRONMENT, DEFAULT, DEFAULT_MAP.  The DEFAULT indicates that the
@@ -143,7 +143,7 @@ class ParameterSource(object):
     DEFAULT = "DEFAULT"
     DEFAULT_MAP = "DEFAULT_MAP"
     
-    VALUES = [COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP]
+    VALUES = {COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP}
     
     @classmethod
     def validate(clz, value):
@@ -157,7 +157,7 @@ class ParameterSource(object):
         """
         if value not in clz.VALUES:
             raise ValueError("Invalid ParameterSource value: '{}'. Valid "
-                             "values are: {}".format(",".join(VALUES)))
+                             "values are: {}".format(value, ",".join(clz.VALUES)))
 
 
 class Context(object):
@@ -617,7 +617,7 @@ class Context(object):
         self._parameter_sources[name] = source
 
     def get_parameter_source(self, name):
-        """Get the `source` of a parameter.
+        """Get the source of a parameter.
 
         This indicates the location from which the value of the
         parameter was obtained.  This can be useful for determining
@@ -630,7 +630,7 @@ class Context(object):
         :returns: the source
         :rtype: ParameterSource
         """
-        return self._parameter_sources.get(name)
+        return self._parameter_sources[name]
 
 
 class BaseCommand(object):

--- a/click/core.py
+++ b/click/core.py
@@ -130,13 +130,14 @@ def iter_params_for_processing(invocation_order, declaration_order):
     return sorted(declaration_order, key=sort_key)
 
 class ParameterSource(object):
+    """This is an enum that indicates the source of a command line option.
+
+    The enum has one of the following values: COMMANDLINE,
+    ENVIRONMENT, DEFAULT, DEFAULT_MAP.  The DEFAULT indicates that the
+    default value in the decorator was used.  This class should be
+    converted to an enum when Python 2 support is dropped.
     """
-    This is an enum that indicates the source of a command line option,
-    which is one of the following: COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP.
-    The DEFAULT indicates that the default value in the decorator was used.
-    This class should be converted to an enum when Python 2 support is
-    dropped.
-    """
+
     COMMANDLINE = "COMMANDLINE"
     ENVIRONMENT = "ENVIRONMENT"
     DEFAULT = "DEFAULT"
@@ -146,6 +147,14 @@ class ParameterSource(object):
     
     @classmethod
     def validate(clz, value):
+        """Validate that the specified value is a valid enum.
+
+        This method will raise a ValueError if the value is
+        not a valid enum.
+
+        :param clz: ParameterSource.class
+        :param value: the string value to verify
+        """
         if value not in clz.VALUES:
             raise ValueError("Invalid ParameterSource value: '{}'. Valid "
                              "values are: {}".format(",".join(VALUES)))
@@ -595,31 +604,34 @@ class Context(object):
         return self.invoke(cmd, **kwargs)
 
     def set_parameter_source(self, name, source):
-        """Sets the `source` of a parameter. This indicates the 
-        location from which the value of the parameter was obtained.
+        """Set the source of a parameter.
+
+        This indicates the location from which the value of the
+        parameter was obtained.
 
         :param name: the name of the command line parameter
-        :param source: the source of the the command line parameter,
-                       which should be a valid ParameterSource value
+        :param source: the source of the command line parameter, which
+                       should be a valid ParameterSource value
         """
         ParameterSource.validate(source)
         self._parameter_sources[name] = source
 
     def get_parameter_source(self, name):
-        """Get the `source` of a parameter. This indicates the 
-        location from which the value of the parameter was obtained.
-        This can be useful for determining when a user specified
-        an option on the command line that is the same as the default.
-        In that case, the source would be ParameterSource.COMMANDLINE,
-        even though the value of the parameter was equivalent to the
-        default.
+        """Get the `source` of a parameter.
+
+        This indicates the location from which the value of the
+        parameter was obtained.  This can be useful for determining
+        when a user specified an option on the command line that is
+        the same as the default.  In that case, the source would be
+        ParameterSource.COMMANDLINE, even though the value of the
+        parameter was equivalent to the default.
 
         :param name: the name of the command line parameter
         :returns: the source
         :rtype: ParameterSource
         """
         return self._parameter_sources.get(name)
-    
+
 
 class BaseCommand(object):
     """The base command implements the minimal API contract of commands.

--- a/click/core.py
+++ b/click/core.py
@@ -132,7 +132,7 @@ def iter_params_for_processing(invocation_order, declaration_order):
 class ParameterSource(object):
     """
     This is an enum that indicates the source of a command line option,
-    which is one of the following: COMMANDLINE, ENVIRONMENT, DEFAULT.
+    which is one of the following: COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP.
     The DEFAULT indicates that the default value in the decorator was used.
     This class should be converted to an enum when Python 2 support is
     dropped.
@@ -140,8 +140,9 @@ class ParameterSource(object):
     COMMANDLINE = "COMMANDLINE"
     ENVIRONMENT = "ENVIRONMENT"
     DEFAULT = "DEFAULT"
-
-    VALUES = [COMMANDLINE, ENVIRONMENT, DEFAULT]
+    DEFAULT_MAP = "DEFAULT_MAP"
+    
+    VALUES = [COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP]
     
     @classmethod
     def validate(clz, value):
@@ -1447,8 +1448,9 @@ class Parameter(object):
             source = ParameterSource.ENVIRONMENT
         if value is None:
             value = ctx.lookup_default(self.name)
-            source = ParameterSource.DEFAULT
-        ctx.set_parameter_source(self.name, source)
+            source = ParameterSource.DEFAULT_MAP
+        if value is not None:
+            ctx.set_parameter_source(self.name, source)
         return value
 
     def type_cast_value(self, ctx, value):
@@ -1495,6 +1497,8 @@ class Parameter(object):
 
         if value is None and not ctx.resilient_parsing:
             value = self.get_default(ctx)
+            if value is not None:
+                ctx.set_parameter_source(self.name, ParameterSource.DEFAULT)
 
         if self.required and self.value_is_missing(value):
             raise MissingParameter(ctx=ctx, param=self)

--- a/click/core.py
+++ b/click/core.py
@@ -146,18 +146,17 @@ class ParameterSource(object):
     VALUES = {COMMANDLINE, ENVIRONMENT, DEFAULT, DEFAULT_MAP}
     
     @classmethod
-    def validate(clz, value):
+    def validate(cls, value):
         """Validate that the specified value is a valid enum.
 
         This method will raise a ValueError if the value is
         not a valid enum.
 
-        :param clz: ParameterSource.class
         :param value: the string value to verify
         """
-        if value not in clz.VALUES:
+        if value not in cls.VALUES:
             raise ValueError("Invalid ParameterSource value: '{}'. Valid "
-                             "values are: {}".format(value, ",".join(clz.VALUES)))
+                             "values are: {}".format(value, ",".join(cls.VALUES)))
 
 
 class Context(object):
@@ -369,7 +368,7 @@ class Context(object):
 
         self._close_callbacks = []
         self._depth = 0
-        self._sources_by_paramname = {}
+        self._source_by_paramname = {}
         
     def __enter__(self):
         self._depth += 1
@@ -614,7 +613,7 @@ class Context(object):
                        should be a valid ParameterSource value
         """
         ParameterSource.validate(source)
-        self._sources_by_paramname[name] = source
+        self._source_by_paramname[name] = source
 
     def get_parameter_source(self, name):
         """Get the source of a parameter.
@@ -630,7 +629,7 @@ class Context(object):
         :returns: the source
         :rtype: ParameterSource
         """
-        return self._sources_by_paramname[name]
+        return self._source_by_paramname[name]
 
 
 class BaseCommand(object):

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -377,3 +377,30 @@ do.  However if you do use this for threading you need to be very careful
 as the vast majority of the context is not thread safe!  You are only
 allowed to read from the context, but not to perform any modifications on
 it.
+
+
+Detecting the Source of a Parameter
+-----------------------------------
+
+In some situations it's helpful to understand whether or not an option
+or parameter came from the command line, the environment, the default
+value, or the default_map. The :meth:`Context.get_parameter_source`
+method can be used to find this out.
+
+.. click:example::
+
+    @click.command()
+    @click.argument('port', nargs=1, default=8080, envvar="PORT")
+    @click.pass_context
+    def cli(ctx, port):
+        source = ctx.get_parameter_source("port")
+        click.echo("Port came from {}".format(source))
+
+.. click:run::
+
+    invoke(cli, prog_name='cli', args=['8080'])
+    println()
+    invoke(cli, prog_name='cli', args=[], env={"PORT": "8080"})
+    println()
+    invoke(cli, prog_name='cli', args=[])
+    println()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -314,4 +314,4 @@ def test_parameter_source_environment_variable_specified(runner):
 
 def test_validate_parameter_source():
     with pytest.raises(ValueError):
-        click.ParameterSource.validate("DEFAUL")
+        click.ParameterSource.validate("NOT_A_VALID_PARAMETER_SOURCE")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import click
-
+import pytest
 
 def test_ensure_context_objects(runner):
     class Foo(object):
@@ -300,6 +300,7 @@ def test_parameter_source_environment(runner):
         
     assert runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"TEST_OPTION": "1"}, auto_envvar_prefix="TEST").exit_code == 1
 
+
 def test_parameter_source_environment_variable_specified(runner):
     @click.command()
     @click.pass_context
@@ -309,3 +310,8 @@ def test_parameter_source_environment_variable_specified(runner):
         sys.exit(1)
         
     assert runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"NAME": "1"}).exit_code == 1
+
+
+def test_validate_parameter_source():
+    with pytest.raises(ValueError):
+        click.ParameterSource.validate("DEFAUL")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -263,9 +263,20 @@ def test_parameter_source_default():
     @click.option("-o", "--option", default=1)
     def cli(ctx, option):
         assert ctx.get_parameter_source("option") == click.ParameterSource.DEFAULT
+        ctx.exit(1)
 
-    cli.main([], "test_parameter_source_default", standalone_mode=False) == 0
+    assert cli.main([], "test_parameter_source_default", standalone_mode=False) == 1
 
+def test_parameter_source_default_map():
+    @click.command()
+    @click.pass_context
+    @click.option("-o", "--option", default=1)
+    def cli(ctx, option):
+        assert ctx.get_parameter_source("option") == click.ParameterSource.DEFAULT_MAP
+        ctx.exit(1)
+
+    assert cli.main([], "test_parameter_source_default", standalone_mode=False, default_map={ "option": 1}) == 1
+    
 
 def test_parameter_source_commandline():
     @click.command()
@@ -273,9 +284,10 @@ def test_parameter_source_commandline():
     @click.option("-o", "--option", default=1)
     def cli(ctx, option):
         assert ctx.get_parameter_source("option") == click.ParameterSource.COMMANDLINE
-
-    cli.main(["-o", "1"], "test_parameter_source_commandline", standalone_mode=False) == 0
-    cli.main(["--option", "1"], "test_parameter_source_default", standalone_mode=False) == 0
+        ctx.exit(1)
+        
+    assert cli.main(["-o", "1"], "test_parameter_source_commandline", standalone_mode=False) == 1
+    assert cli.main(["--option", "1"], "test_parameter_source_default", standalone_mode=False) == 1
 
 
 def test_parameter_source_environment(runner):
@@ -284,9 +296,9 @@ def test_parameter_source_environment(runner):
     @click.option("-o", "--option", default=1)
     def cli(ctx, option):
         assert ctx.get_parameter_source("option") == click.ParameterSource.ENVIRONMENT
-
-    runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"CLI_OPTION": "1"},
-             standalone_mode=False)
+        sys.exit(1)
+        
+    assert runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"TEST_OPTION": "1"}, auto_envvar_prefix="TEST").exit_code == 1
 
 def test_parameter_source_environment_variable_specified(runner):
     @click.command()
@@ -294,7 +306,6 @@ def test_parameter_source_environment_variable_specified(runner):
     @click.option("-o", "--option", default=1, envvar="NAME")
     def cli(ctx, option):
         assert ctx.get_parameter_source("option") == click.ParameterSource.ENVIRONMENT
-
-    runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"NAME": "1"},
-             standalone_mode=False)
-    
+        sys.exit(1)
+        
+    assert runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"NAME": "1"}).exit_code == 1

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -256,3 +256,45 @@ def test_exit_not_standalone():
         ctx.exit(0)
 
     assert cli.main([], 'test_exit_not_standalone', standalone_mode=False) == 0
+
+def test_parameter_source_default():
+    @click.command()
+    @click.pass_context
+    @click.option("-o", "--option", default=1)
+    def cli(ctx, option):
+        assert ctx.get_parameter_source("option") == click.ParameterSource.DEFAULT
+
+    cli.main([], "test_parameter_source_default", standalone_mode=False) == 0
+
+
+def test_parameter_source_commandline():
+    @click.command()
+    @click.pass_context
+    @click.option("-o", "--option", default=1)
+    def cli(ctx, option):
+        assert ctx.get_parameter_source("option") == click.ParameterSource.COMMANDLINE
+
+    cli.main(["-o", "1"], "test_parameter_source_commandline", standalone_mode=False) == 0
+    cli.main(["--option", "1"], "test_parameter_source_default", standalone_mode=False) == 0
+
+
+def test_parameter_source_environment(runner):
+    @click.command()
+    @click.pass_context
+    @click.option("-o", "--option", default=1)
+    def cli(ctx, option):
+        assert ctx.get_parameter_source("option") == click.ParameterSource.ENVIRONMENT
+
+    runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"CLI_OPTION": "1"},
+             standalone_mode=False)
+
+def test_parameter_source_environment_variable_specified(runner):
+    @click.command()
+    @click.pass_context
+    @click.option("-o", "--option", default=1, envvar="NAME")
+    def cli(ctx, option):
+        assert ctx.get_parameter_source("option") == click.ParameterSource.ENVIRONMENT
+
+    runner.invoke(cli, [], prog_name="test_parameter_source_environment", env={"NAME": "1"},
+             standalone_mode=False)
+    


### PR DESCRIPTION
Fixes #1264 