### PR TITLE
Separates source from test code in test examples

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -20,48 +20,61 @@ The basic functionality for testing Click applications is the
 and captures the output as both bytes and binary data.
 
 The return value is a :class:`Result` object, which has the captured output
-data, exit code, and optional exception attached.
+data, exit code, and optional exception attached:
 
-Example::
+.. code-block:: python
+   :caption: hello.py
 
-    import click
-    from click.testing import CliRunner
+   import click
 
-    def test_hello_world():
-        @click.command()
-        @click.argument('name')
-        def hello(name):
-            click.echo('Hello %s!' % name)
+   @click.command()
+   @click.argument('name')
+   def hello(name):
+      click.echo('Hello %s!' % name)
 
-        runner = CliRunner()
-        result = runner.invoke(hello, ['Peter'])
-        assert result.exit_code == 0
-        assert result.output == 'Hello Peter!\n'
+.. code-block:: python
+   :caption: test_hello.py
 
-For subcommand testing, a subcommand name must be specified in the `args` parameter of :meth:`CliRunner.invoke` method.
+   from click.testing import CliRunner
+   from hello import hello
 
-Example::
+   def test_hello_world():
+     runner = CliRunner()
+     result = runner.invoke(hello, ['Peter'])
+     assert result.exit_code == 0
+     assert result.output == 'Hello Peter!\n'
 
-    import click
-    from click.testing import CliRunner
-    
-    def test_sync():
-        @click.group()
-        @click.option('--debug/--no-debug', default=False)
-        def cli(debug):
-            click.echo('Debug mode is %s' % ('on' if debug else 'off')) 
-    
-        @cli.command()
-        def sync():
-            click.echo('Syncing')
-    
-        runner = CliRunner()
-        result = runner.invoke(cli, ['--debug', 'sync'])
-        assert result.exit_code == 0
-        assert 'Debug mode is on' in result.output
-        assert 'Syncing' in result.output
+For subcommand testing, a subcommand name must be specified in the `args` parameter of :meth:`CliRunner.invoke` method:
 
-Additional keyword arguments passed to ``.invoke()`` will be used to construct the initial Context object. For example, if you want to run your tests against a fixed terminal width you can use the following::
+.. code-block:: python
+   :caption: sync.py
+
+   import click
+
+   @click.group()
+   @click.option('--debug/--no-debug', default=False)
+   def cli(debug):
+      click.echo('Debug mode is %s' % ('on' if debug else 'off'))
+
+   @cli.command()
+   def sync():
+      click.echo('Syncing')
+
+.. code-block:: python
+   :caption: test_sync.py
+
+   from click.testing import CliRunner
+   from sync import cli
+
+   def test_sync():
+     runner = CliRunner()
+     result = runner.invoke(cli, ['--debug', 'sync'])
+     assert result.exit_code == 0
+     assert 'Debug mode is on' in result.output
+     assert 'Syncing' in result.output
+
+Additional keyword arguments passed to ``.invoke()`` will be used to construct the initial Context object.
+For example, if you want to run your tests against a fixed terminal width you can use the following::
 
     runner = CliRunner()
     result = runner.invoke(cli, ['--debug', 'sync'], terminal_width=60)
@@ -71,47 +84,61 @@ File System Isolation
 
 For basic command line tools that want to operate with the file system, the
 :meth:`CliRunner.isolated_filesystem` method comes in useful which sets up
-an empty folder and changes the current working directory to.
+an empty folder and changes the current working directory to:
 
-Example::
+.. code-block:: python
+   :caption: cat.py
 
-    import click
-    from click.testing import CliRunner
+   import click
 
-    def test_cat():
-        @click.command()
-        @click.argument('f', type=click.File())
-        def cat(f):
-            click.echo(f.read())
+   @click.command()
+   @click.argument('f', type=click.File())
+   def cat(f):
+      click.echo(f.read())
 
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            with open('hello.txt', 'w') as f:
-                f.write('Hello World!')
+.. code-block:: python
+   :caption: test_cat.py
 
-            result = runner.invoke(cat, ['hello.txt'])
-            assert result.exit_code == 0
-            assert result.output == 'Hello World!\n'
+   from click.testing import CliRunner
+   from cat import cat
+
+   def test_cat():
+      runner = CliRunner()
+      with runner.isolated_filesystem():
+         with open('hello.txt', 'w') as f:
+             f.write('Hello World!')
+
+         result = runner.invoke(cat, ['hello.txt'])
+         assert result.exit_code == 0
+         assert result.output == 'Hello World!\n'
 
 Input Streams
 -------------
 
 The test wrapper can also be used to provide input data for the input
-stream (stdin).  This is very useful for testing prompts, for instance::
+stream (stdin).  This is very useful for testing prompts, for instance:
 
-    import click
-    from click.testing import CliRunner
+.. code-block:: python
+   :caption: prompt.py
 
-    def test_prompts():
-        @click.command()
-        @click.option('--foo', prompt=True)
-        def test(foo):
-            click.echo('foo=%s' % foo)
+   import click
 
-        runner = CliRunner()
-        result = runner.invoke(test, input='wau wau\n')
-        assert not result.exception
-        assert result.output == 'Foo: wau wau\nfoo=wau wau\n'
+   @click.command()
+   @click.option('--foo', prompt=True)
+   def prompt(foo):
+      click.echo('foo=%s' % foo)
+
+.. code-block:: python
+   :caption: test_prompt.py
+
+   from click.testing import CliRunner
+   from prompt import prompt
+
+   def test_prompts():
+      runner = CliRunner()
+      result = runner.invoke(prompt, input='wau wau\n')
+      assert not result.exception
+      assert result.output == 'Foo: wau wau\nfoo=wau wau\n'
 
 Note that prompts will be emulated so that they write the input data to
 the output stream as well.  If hidden input is expected then this


### PR DESCRIPTION
Addresses https://github.com/pallets/click/issues/1119

This is different from #1130, which still shows the source and test code right next to each other.

Example of this PR:
![image](https://user-images.githubusercontent.com/444778/58720081-d6960600-8396-11e9-8d7e-d6caab2b7814.png)
