### PR TITLE
Add an optional current_item parameter to ProgressBar.update()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,16 @@ Unreleased
 
 -   Adds a repr to Command, showing the command name for friendlier debugging. (`#1267`_, `#1295`_)
 -   Add support for distinguishing the source of a command line parameter. (`#1264`_, `#1329`_)
+-   Add an optional parameter to ``ProgressBar.update`` to set the
+    ``current_item``. (`#1226`_, `#1332`_)
 
 .. _#1267: https://github.com/pallets/click/issues/1267
 .. _#1295: https://github.com/pallets/click/pull/1295
 .. _#1264: https://github.com/pallets/click/issues/1264
 .. _#1329: https://github.com/pallets/click/pull/1329
+.. _#1226: https://github.com/pallets/click/issues/1226
+.. _#1332: https://github.com/pallets/click/pull/1332
+
 
 Version 7.1
 -----------

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -260,8 +260,21 @@ class ProgressBar(object):
 
         self.eta_known = self.length_known
 
-    def update(self, n_steps):
+    def update(self, n_steps, current_item=None):
+        """Update the progress bar by advancing a specified number of
+        steps, and optionally set the ``current_item`` for this new
+        position.
+
+        :param n_steps: Number of steps to advance.
+        :param current_item: Optional item to set as ``current_item``
+            for the updated position.
+
+        .. versionadded:: 8.0
+            Added the ``current_item`` optional parameter.
+        """
         self.make_step(n_steps)
+        if current_item is not None:
+            self.current_item = current_item
         self.render_progress()
 
     def finish(self):

--- a/click/termui.py
+++ b/click/termui.py
@@ -302,6 +302,20 @@ def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 process_chunk(chunk)
                 bar.update(chunks.bytes)
 
+    The ``update()`` method also takes an optional value specifying the
+    ``current_item`` at the new position. This is useful when used
+    together with ``item_show_func`` to customize the output for each
+    manual step::
+
+        with click.progressbar(
+            length=total_size,
+            label='Unzipping archive',
+            item_show_func=lambda a: a.filename
+        ) as bar:
+            for archive in zip_file:
+                archive.extract()
+                bar.update(archive.size, archive)
+
     .. versionadded:: 2.0
 
     .. versionadded:: 4.0


### PR DESCRIPTION
Fix #1226   Add an optional `current_item` parameter to `ProgressBar.update()` to allow for `item_show_func` to continue to display when using `update()`.  A usage example for this was added to `ProgressBar` and some new tests.