### PR TITLE
Issue 750

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -129,6 +129,9 @@ integers::
                 elif value[:1] == '0':
                     return int(value, 8)
                 return int(value, 10)
+        except TypeError:
+            self.fail('expected string for int() conversion, got %s of type %s'
+                      % (value, type(value).__name__), param, ctx)
             except ValueError:
                 self.fail('%s is not a valid integer' % value, param, ctx)
 


### PR DESCRIPTION
Updated the example code in the Custom Types example.  Given the choice to either force the value to string or return a TypeError in case of a bad type, opted for the latter so that future readers would not assume from the example that defaults have to be type string.

Error is now:
```
Error: Invalid value for "--val" / "-v": expected string for int() conversion, got 0 of type int
```
...rather than a stack trace.

closes #750