### PR TITLE
docs: Clarify Python 3.7 behavior in documentation

### DIFF
--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -159,6 +159,11 @@ Python 3 bug tracker:
     <http://bugs.python.org/issue21398>`_ (this is relevant to Click
     because the pager support is provided by the stdlib pydoc module)
 
+Note (Python 3.7 onwards): Even though your locale may not be properly
+configured, Python 3.7 Click will not raise the above exception because Python
+3.7 programs are better at choosing default locales.  This doesn't change the
+general issue that your locale may be misconfigured.
+
 Unicode Literals
 ----------------
 


### PR DESCRIPTION
This commit clarifies the Python 3.7 behavior in the "Python 3
surrogate handling" documentation, as it differs from the general
behavior described in the section meant for Python 3.x