### PR TITLE
Explicit cast to HANDLE for Read/WriteConsoleW calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
 - Add support for colored output on UNIX Jupyter notebooks. (`#1185`_)
 - Remove unused compat shim for ``bytes``. (`#1195`_)
 - Expand unit testing around termui, especially getchar (Windows). (`#1116`_)
+-   Fix output on Windows Python 2.7 built with MSVC 14. #1342
 
 .. _#1167: https://github.com/pallets/click/pull/1167
 .. _#1151: https://github.com/pallets/click/pull/1151

--- a/click/_winconsole.py
+++ b/click/_winconsole.py
@@ -24,7 +24,7 @@ try:
     PyBuffer_Release = pythonapi.PyBuffer_Release
 except ImportError:
     pythonapi = None
-from ctypes.wintypes import LPWSTR, LPCWSTR
+from ctypes.wintypes import LPWSTR, LPCWSTR, HANDLE
 
 
 c_ssize_p = POINTER(c_ssize_t)
@@ -123,7 +123,7 @@ class _WindowsConsoleReader(_WindowsConsoleRawIOBase):
         code_units_to_be_read = bytes_to_be_read // 2
         code_units_read = c_ulong()
 
-        rv = ReadConsoleW(self.handle, buffer, code_units_to_be_read,
+        rv = ReadConsoleW(HANDLE(self.handle), buffer, code_units_to_be_read,
                           byref(code_units_read), None)
         if GetLastError() == ERROR_OPERATION_ABORTED:
             # wait for KeyboardInterrupt
@@ -156,7 +156,7 @@ class _WindowsConsoleWriter(_WindowsConsoleRawIOBase):
                                        MAX_BYTES_WRITTEN) // 2
         code_units_written = c_ulong()
 
-        WriteConsoleW(self.handle, buf, code_units_to_be_written,
+        WriteConsoleW(HANDLE(self.handle), buf, code_units_to_be_written,
                       byref(code_units_written), None)
         bytes_written = 2 * code_units_written.value
 


### PR DESCRIPTION
We have a custom build of Python 2.7 which is built against MSVC 14. We found that Click's windows console functionality was degraded after making the switch the MSVC 14, hitting that explicit `raise OSError`  in `_WindowsConsoleWriter.write()` with errno 6 (invalid file handle).

I run into the error using `click.echo()`, just for some cases, but it seems like you hit one of the bad cases and it ruins the rest of the cases. For example, here are the results I get for individual calls:

```
click.echo('')  # Fails
click.echo('f') # Succeeds
```

but run the two in sequence and they both fail:

```
import click
for s in ['', 'f']:
    try:
        click.echo(s)
        print "Pass", repr(s)
    except OSError:
        print "Fail", repr(s)
```

My output:

```
Fail ''
f
Fail 'f'
```

I may be a very remote corner case, since the MSVC 9 build of Python 2.7.16 and the MSVC 14 build of Python 3.6.8 both work fine.

Stack for reference:

```
Traceback (most recent call last):
  File "script.py", line 10, in <module>
    click.echo(s)
  File "utils.py", line 260, in echo
    file.write(message)
  File "_compat.py", line 628, in _safe_write
    return _write(s)
  File "ansitowin32.py", line 40, in write
    self.__convertor.write(text)
  File "ansitowin32.py", line 141, in write
    self.write_and_convert(text)
  File "ansitowin32.py", line 169, in write_and_convert
    self.write_plain_text(text, cursor, len(text))
  File "ansitowin32.py", line 175, in write_plain_text
    self.wrapped.flush()
  File "_winconsole.py", line 164, in write
    raise OSError(self._get_error_message(GetLastError()))
exceptions.OSError, Windows error 6
```