### PR TITLE
Correct ZSH completion definitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 8.0
 
 Unreleased
 
+-   Fix autoloading for ZSH completion and add error handling. (`#1348`_ )
 -   Adds a repr to Command, showing the command name for friendlier debugging. (`#1267`_, `#1295`_)
 -   Add support for distinguishing the source of a command line parameter. (`#1264`_, `#1329`_)
 -   Add an optional parameter to ``ProgressBar.update`` to set the
@@ -16,6 +17,7 @@ Unreleased
 .. _#1264: https://github.com/pallets/click/issues/1264
 .. _#1329: https://github.com/pallets/click/pull/1329
 .. _#1226: https://github.com/pallets/click/issues/1226
+.. _#1348: https://github.com/pallets/click/pull/1348
 .. _#1332: https://github.com/pallets/click/pull/1332
 
 

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -39,10 +39,14 @@ COMPLETION_SCRIPT_BASH = '''
 '''
 
 COMPLETION_SCRIPT_ZSH = '''
+#compdef %(script_names)s
+
 %(complete_func)s() {
     local -a completions
     local -a completions_with_descriptions
     local -a response
+    (( ! $+commands[%(script_names)s] )) && return 1
+
     response=("${(@f)$( env COMP_WORDS=\"${words[*]}\" \\
                         COMP_CWORD=$((CURRENT-1)) \\
                         %(autocomplete_var)s=\"complete_zsh\" \\

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -25,6 +25,14 @@ def test_bash_func_name():
     assert '_COMPLETE_VAR=complete $1' in script
 
 
+def test_zsh_func_name():
+    from click._bashcomplete import get_completion_script
+    script = get_completion_script('foo-bar', '_COMPLETE_VAR', 'zsh').strip()
+    assert script.startswith('#compdef foo-bar')
+    assert 'compdef _foo_bar_completion foo-bar;' in script
+    assert '(( ! $+commands[foo-bar] )) && return 1' in script
+
+
 @pytest.mark.xfail(WIN, reason="Jupyter not tested/supported on Windows")
 def test_is_jupyter_kernel_output():
     class JupyterKernelFakeStream(object):


### PR DESCRIPTION
Supplying fix from https://github.com/cekit/cekit/pull/562.
This makes it auto-loadable (and adds some error handling)  - see http://zsh.sourceforge.net/Doc/Release/Completion-System.html