### PR TITLE
Suggest renaming option from `name` to `--name`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Unreleased
 -   Required arguments with the ``Choice`` type show the choices in
     curly braces to indicate that one is required (``{a|b|c}``).
     :issue:`1272`
+-   If only a name is passed to ``option()``, Click suggests renaming it
+    to ``--name``. :pr:`1355`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1977,8 +1977,8 @@ class Option(Parameter):
         if not opts and not secondary_opts:
             raise TypeError(
                 f"No options defined but a name was passed ({name})."
-                " Did you mean to declare an argument instead of an"
-                " option?"
+                " Did you mean to declare an argument instead? Did"
+                f" you mean to pass '--{name}'?"
             )
 
         return name, opts, secondary_opts

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,12 +23,13 @@ def test_prefixes(runner):
 
 
 def test_invalid_option(runner):
-    with pytest.raises(TypeError, match="name was passed"):
+    with pytest.raises(TypeError, match="name was passed") as exc_info:
+        click.Option(["foo"])
 
-        @click.command()
-        @click.option("foo")
-        def cli(foo):
-            pass
+    message = str(exc_info.value)
+    assert "name was passed (foo)" in message
+    assert "declare an argument" in message
+    assert "'--foo'" in message
 
 
 def test_invalid_nargs(runner):


### PR DESCRIPTION
Usually when I get this error message, it's because I wrote `@click.option('foo')` when I meant `@click.option('--foo')`. So this PR updates the error message to suggest the user fix that.