### PR TITLE
Add support for generating a Dash/Zeal docset

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,14 +7,31 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Jinja
 SOURCEDIR     = .
 BUILDDIR      = _build
+DASHDIR       = ${BUILDDIR}/dashdoc
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+dashdoc: html
+	python doc2dash-userguide.py \
+		--name="Click" \
+		--destination="$(DASHDIR)" \
+		--index-page="index.html" \
+		--icon="$(SOURCEDIR)/_static/click-logo.png" \
+		--online-redirect-url="http://click.palletsprojects.com/" \
+		--force \
+		--verbose \
+		"$(BUILDDIR)/html"
+
+	tar --exclude=".DS_Store" -C "$(DASHDIR)" -czf "${DASHDIR}/Click.tgz" Click.docset
+
+clean:
+	rm -r "$(BUILDDIR)"
+
+.PHONY: help Makefile dashdoc clean

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,9 @@ release, version = get_version("Click", version_length=1)
 # General --------------------------------------------------------------
 
 master_doc = "index"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "pallets_sphinx_themes"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.autosectionlabel", "pallets_sphinx_themes"]
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
+autosectionlabel_prefix_document = True
 
 # HTML -----------------------------------------------------------------
 

--- a/docs/doc2dash-userguide.py
+++ b/docs/doc2dash-userguide.py
@@ -1,0 +1,104 @@
+# Based on: https://gist.github.com/jnothman/3f164a9f8f766009d29a95ab473ff972
+# Also see https://github.com/hynek/doc2dash/issues/57
+
+import logging
+
+import doc2dash.parsers
+from doc2dash.parsers.intersphinx import (
+    InterSphinxParser,
+    inv_entry_to_path,
+    ParserEntry,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+class Skip(Exception):
+    pass
+
+
+class ClickParser(InterSphinxParser):
+    def __init__(self, *args, **kwargs):
+        super(ClickParser, self).__init__(*args, **kwargs)
+        self.guides = set()
+
+    def convert_type(self, inv_type):
+        if inv_type == "std:doc":  # sphinx type
+            return "Guide"  # Dash type
+        elif inv_type == "std:label":  # sphinx type
+            return "Section"  # Dash type
+        else:
+            return super(ClickParser, self).convert_type(inv_type)
+
+    def create_entry(self, dash_type, key, inv_entry):
+        try:
+            if dash_type == "Guide":
+                path_str = inv_entry_to_path(inv_entry)
+                name = inv_entry[3]
+
+                self.guides.add(key)
+
+                if key == "api":
+                    # Dash does API
+                    raise Skip()
+
+                return ParserEntry(name=name, type=dash_type, path=path_str)
+            elif dash_type == "Section":
+                path_str = inv_entry_to_path(inv_entry)
+                name = inv_entry[3]
+
+                if key in self.guides:
+                    # already a Guide
+                    raise Skip("is a guide")
+
+                key_parts = key.split(":")
+
+                if key_parts[0] == "changelog":
+                    # don't need versions in here, only list the Changelog Guide.
+                    raise Skip()
+
+                if key_parts[0] in {"index", "api"}:
+                    # repeated elsewhere
+                    raise Skip()
+
+                if key_parts[0] == "search":
+                    # Dash does search
+                    raise Skip()
+
+                if len(key_parts) == 2 and (key_parts[0] == key_parts[1]):
+                    # headings for guides
+                    raise Skip()
+
+                if inv_entry[2] in {
+                        "advanced.html#aliases",
+                        "arguments.html#file-args",
+                        "options.html#choice-opts",
+                        "options.html#option-prompting",
+                        "options.html#ranges",
+                        "options.html#tuple-type",
+                        "complex.html#complex-guide",
+                        "documentation.html#doc-meta-variables",
+                        "python3.html#python3-limitations",
+                        "python3.html#python3-surrogates",
+                        "upgrading.html#upgrade-to-2-0",
+                        "upgrading.html#upgrade-to-3-2",
+                        }:
+                    # FIXME: missing named anchors which end up with repeated entries.
+                    raise Skip()
+
+                return ParserEntry(name=name, type=dash_type, path=path_str)
+
+        except Skip:
+            log.debug("Skipping %s '%s'", dash_type, key)
+            return None
+
+        return super(ClickParser, self).create_entry(dash_type, key, inv_entry)
+
+
+doc2dash.parsers.DOCTYPES = [ClickParser]
+
+if __name__ == "__main__":
+    import doc2dash.__main__
+
+    doc2dash.__main__.main()


### PR DESCRIPTION
Uses [doc2dash](https://pypi.org/project/doc2dash/) to build a [Dash](https://kapeli.com/dash)/[Zeal](https://zealdocs.org/) docset for Click.

![2019-07-26 at 12 14 pm](https://user-images.githubusercontent.com/59874/61948158-fc0e4d00-af9e-11e9-902c-8bdc3e030101.png)

Plan is to use this to contribute to https://github.com/Kapeli/Dash-User-Contributions so anyone can install it easily, but makes sense (IMO) for it to live with Click.

Build via:
```console
$ pip install sphinx doc2dash
$ cd docs
$ make dashdoc
```
Which produces `docs/_build/dashdoc/Click.docset/` (for local use) & `docs/_build/dashdoc/Click.tgz` (for distributing).

### Notes:

* enables [`autosectionlabel`](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html) in Sphinx so guide subheadings are indexed.
* has some manual exclusions of things that are repeated, irrelevant, etc.