### PR TITLE
[doc] remove recommendation to use Python 2 instead of Python 3

### DIFF
--- a/docs/python3.rst
+++ b/docs/python3.rst
@@ -8,9 +8,6 @@ it suffers from the Unicode text model in Python 3.  All examples in the
 documentation were written so that they could run on both Python 2.x and
 Python 3.4 or higher.
 
-At the moment, it is strongly recommended to use Python 2 for Click
-utilities unless Python 3 is a hard requirement.
-
 .. _python3-limitations:
 
 Python 3 Limitations


### PR DESCRIPTION
As discussed in https://github.com/pallets/click/issues/924#issuecomment-516233650