### PR TITLE
Add friendlier error message when datetime value fails

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -235,7 +235,7 @@ class DateTime(ParamType):
 
         self.fail(
             'invalid datetime format: {}. (choose from {})\nTried:\n{}'.format(
-                value, ', '.join(self.formats), "\n".join(tries)))
+                value, ', '.join(self.formats), "\n".join(formatted)))
 
     def __repr__(self):
         return 'DateTime'

--- a/click/types.py
+++ b/click/types.py
@@ -217,20 +217,25 @@ class DateTime(ParamType):
 
     def _try_to_convert_date(self, value, format):
         try:
-            return datetime.strptime(value, format)
-        except ValueError:
-            return None
+            return datetime.strptime(value, format), None
+        except ValueError as err:
+            return None, err
 
     def convert(self, value, param, ctx):
+        errors = []
         # Exact match
         for format in self.formats:
-            dtime = self._try_to_convert_date(value, format)
-            if dtime:
+            dtime, err = self._try_to_convert_date(value, format)
+            if err:
+                errors.append((format, err))
+            else:
                 return dtime
 
+        formatted = ["%25s => %s" % (format, err) for (format, err) in errors]
+
         self.fail(
-            'invalid datetime format: {}. (choose from {})'.format(
-                value, ', '.join(self.formats)))
+            'invalid datetime format: {}. (choose from {})\nTried:\n{}'.format(
+                value, ', '.join(self.formats), "\n".join(tries)))
 
     def __repr__(self):
         return 'DateTime'


### PR DESCRIPTION
This PR adds a friendlier error message when datetime conversion fails.

I invoked my program using `2019-06-31` for the datetime option, but the error message wasn't clear because the format did match one of the default formats. The actual error was that the date was invalid (June has 30 days). Unfortunately, the datetime module in Python returns ValueError if the datetime is invalid or if the format doesn't match. And the code in click assumes that the format didn't match.

The solution is to, when there is a failure, explicitly list out all conversion attempts and the resulting error message.

Old message:
```
Error: Invalid value for "--start_date": invalid datetime format: 2019-06-31. (choose from %Y-%m-%d, %Y-%m-%dT%H:%M:%S, %Y-%m-%d %H:%M:%S)
```

New message:
```
Error: Invalid value for "--start_date": invalid datetime format: 2019-06-31. (choose from %Y-%m-%d, %Y-%m-%dT%H:%M:%S, %Y-%m-%d %H:%M:%S)
Tried:
                 %Y-%m-%d => day is out of range for month
        %Y-%m-%dT%H:%M:%S => time data '2019-06-31' does not match format '%Y-%m-%dT%H:%M:%S'
        %Y-%m-%d %H:%M:%S => time data '2019-06-31' does not match format '%Y-%m-%d %H:%M:%S'

```