### PR TITLE
Fix OSError when running on MinGW64 with MSYS2.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,12 +13,14 @@ Unreleased
 - Remove unused compat shim for ``bytes``. (`#1195`_)
 - Expand unit testing around termui, especially getchar (Windows). (`#1116`_)
 -   Fix output on Windows Python 2.7 built with MSVC 14. #1342
+- Fix OSError when running in MSYS2. (`#1338`_)
 
 .. _#1167: https://github.com/pallets/click/pull/1167
 .. _#1151: https://github.com/pallets/click/pull/1151
 .. _#1185: https://github.com/pallets/click/issues/1185
 .. _#1195: https://github.com/pallets/click/pull/1195
 .. _#1116: https://github.com/pallets/click/issues/1116
+.. _#1338: https://github.com/pallets/click/issues/1338
 
 Version 7.0
 -----------

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -2,12 +2,14 @@ import re
 import io
 import os
 import sys
+import sysconfig
 import codecs
 from weakref import WeakKeyDictionary
 
 
 PY2 = sys.version_info[0] == 2
 CYGWIN = sys.platform.startswith('cygwin')
+MSYS2 = sysconfig.get_platform().startswith('mingw')
 # Determine local App Engine environment, per Google's own suggestion
 APP_ENGINE = ('APPENGINE_RUNTIME' in os.environ and
               'Development/' in os.environ['SERVER_SOFTWARE'])
@@ -593,7 +595,7 @@ def should_strip_ansi(stream=None, color=None):
 # If we're on Windows, we provide transparent integration through
 # colorama.  This will make ANSI colors through the echo function
 # work automatically.
-if WIN:
+if WIN and not MSYS2:
     # Windows has a smaller terminal
     DEFAULT_COLUMNS = 79
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,7 +32,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading', 'colorama', 'errno', 'fcntl', 'datetime'
+    'threading', 'colorama', 'errno', 'fcntl', 'datetime', 'sysconfig'
 ])
 
 if WIN:


### PR DESCRIPTION
Fixes #1338.

In version 6.0, echo and prompt functions were modified to work with full unicode in the windows console by emulating an output stream. Since MSYS2 uses a bash console it was creating an OSError to apply these modifications when running in this environment.

This PR changes these modifications to only apply them if not running in a MSYS2 environment.