### PR TITLE
Fix OSError when running on MinGW64 with MSYS2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 -   Fix output on Windows Python 2.7 built with MSVC 14. :pr:`1342`
 -   Always return of of the passed choices for ``click.Choice``
     :issue:`1277`, :pr:`1318`
+-   Fix ``OSError`` when running in MSYS2. :issue:`1338`
 
 
 Version 7.0

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -8,10 +8,11 @@ from weakref import WeakKeyDictionary
 
 PY2 = sys.version_info[0] == 2
 CYGWIN = sys.platform.startswith('cygwin')
+MSYS2 = sys.platform.startswith('win') and ('GCC' in sys.version)
 # Determine local App Engine environment, per Google's own suggestion
 APP_ENGINE = ('APPENGINE_RUNTIME' in os.environ and
               'Development/' in os.environ['SERVER_SOFTWARE'])
-WIN = sys.platform.startswith('win') and not APP_ENGINE
+WIN = sys.platform.startswith('win') and not APP_ENGINE and not MSYS2
 DEFAULT_COLUMNS = 80
 
 


### PR DESCRIPTION
Fixes #1338.

In version 6.0, echo and prompt functions were modified to work with full unicode in the windows console by emulating an output stream. Since MSYS2 uses a bash console it was creating an OSError to apply these modifications when running in this environment.

This PR changes these modifications to only apply them if not running in a MSYS2 environment.