### PR TITLE
Assure choices are strings

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -142,7 +142,10 @@ class Choice(ParamType):
     name = 'choice'
 
     def __init__(self, choices, case_sensitive=True):
-        self.choices = choices
+        # assures we have a list of strings or integers to avoid join failure
+        self.choices = [
+            str(s) if not isinstance(s, (int, str)) else s
+            for s in choices]
         self.case_sensitive = case_sensitive
 
     def get_metavar(self, param):


### PR DESCRIPTION
Fixes problem where the iterator may return different objects, making
choice fail when trying to use string specific methods.

Example:
```
    return '[%s]' % '|'.join(self.choices)
TypeError: sequence item 0: expected str instance, XXX found
```
Fixes: #591