### PR TITLE
File and path completion again

### DIFF
--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -24,7 +24,7 @@ COMPLETION_SCRIPT_BASH = '''
     return 0
 }
 
-%(complete_func)setup() {
+%(complete_func)s_setup() {
     local COMPLETION_OPTIONS=""
     local BASH_VERSION_ARR=(${BASH_VERSION//./ })
     # Only BASH version 4.4 and later have the nosort option.
@@ -35,7 +35,7 @@ COMPLETION_SCRIPT_BASH = '''
     complete $COMPLETION_OPTIONS -F %(complete_func)s %(script_names)s
 }
 
-%(complete_func)setup
+%(complete_func)s_setup
 '''
 
 COMPLETION_SCRIPT_ZSH = '''

--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -39,6 +39,11 @@ passed 3 keyword arguments:
 - ``incomplete`` - The partial word that is being completed, as a string.  May
   be an empty string ``''`` if no characters have been entered yet.
 
+The returned strings should have spaces appended to them in the case that
+they cannot be further completed, omitting the space allows the completion
+to be invoked multiple times, which can be useful for completing path-like
+strings by searching a database or filesystem.
+
 Here is an example of using a callback function to generate dynamic suggestions:
 
 .. click:example::
@@ -46,7 +51,7 @@ Here is an example of using a callback function to generate dynamic suggestions:
     import os
 
     def get_env_vars(ctx, args, incomplete):
-        return [k for k in os.environ.keys() if incomplete in k]
+        return [k + ' ' for k in os.environ.keys() if incomplete in k]
 
     @click.command()
     @click.argument("envvar", type=click.STRING, autocompletion=get_env_vars)
@@ -127,5 +132,3 @@ For zsh:
 And then you would put this into your .bashrc or .zshrc instead::
 
     . /path/to/foo-bar-complete.sh
-
-

--- a/examples/bashcompletion/bashcompletion.py
+++ b/examples/bashcompletion/bashcompletion.py
@@ -11,7 +11,7 @@ def get_env_vars(ctx, args, incomplete):
     # Completions returned as strings do not have a description displayed.
     for key in os.environ.keys():
         if incomplete in key:
-            yield key
+            yield key + ' '
 
 
 @cli.command(help='A command to print environment variables')
@@ -33,7 +33,11 @@ def list_users(ctx, args, incomplete):
              ('alice', 'baker'),
              ('jerry', 'candlestick maker')]
     # Ths will allow completion matches based on matches within the description string too!
-    return [user for user in users if incomplete in user[0] or incomplete in user[1]]
+    return [
+        user + ' '
+        for user in users
+        if incomplete in user[0] or incomplete in user[1]
+    ]
 
 
 @group.command(help='Choose a user')

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -535,6 +535,6 @@ def test_files_only():
             ("dira" + os.path.sep, None),
             ("dirb" + os.path.sep, None),
         ]
-        assert list(get_choices(cli, "lol", ["--path"], "dirb/")) == [
+        assert list(get_choices(cli, "lol", ["--path"], "dirb" + os.path.sep)) == [
             (os.path.join("dirb", "file.txt") + " ", None)
         ]

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -422,10 +422,12 @@ def tempdir(chdir=False):
     if chdir:
         os.chdir(temp)
 
-    yield temp
+    try:
+        yield temp
 
-    os.chdir(cwd)
-    shutil.rmtree(temp)
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(temp)
 
 
 def test_absolute_path():


### PR DESCRIPTION
This is almost entirely @gtristan's work from #782, but updated for changes that have been made to `click` in the meantime. fixes #780

In my experience, failing autocompletion on paths and filenames is by *far* the most annoying part about using otherwise lovely `click` CLIs.  Which is why I have been motivated to put this together!

As at #782, the approach is:

- Add `-o nospace` to the bash completion options, so that spaces are not automatically added to completions.  This is necessary so that nested paths can be completed without constantly having to delete the added space.
- Then completions are expected to add spaces themselves, so update all the code that does this for completions automatically generated by `click`
- Look for type-based completions, and implement this for choices, booleans and - especially! - files and paths

I expect that the possibly-controversial bit is that, as of today, any user-implemented autocompletions won't include spaces; and so the addition of `-o nospace` will cause their CLIs to behave slightly differently.

I suggest that we either:

- Just go with this; it's actually an improvement because now users have the ability to do more sophisticated completions (as we do for files and paths)
- Or, we could change the click code to make sure there's a space after anything that users give us.  That denies them the ability to do cool things, but maintains backwards-compatibility.

I'm happy to implement the second of these if that's what maintainers want - especially if it helps this longstanding fix finally to get over the line!