### PR TITLE
Begin adding a loading bar utility

### DIFF
--- a/click/__init__.py
+++ b/click/__init__.py
@@ -35,7 +35,7 @@ from .utils import echo, get_binary_stream, get_text_stream, open_file, \
 # Terminal functions
 from .termui import prompt, confirm, get_terminal_size, echo_via_pager, \
      progressbar, clear, style, unstyle, secho, edit, launch, getchar, \
-     pause
+     pause, loadingbar
 
 # Exceptions
 from .exceptions import ClickException, UsageError, BadParameter, \

--- a/click/termui.py
+++ b/click/termui.py
@@ -258,6 +258,29 @@ def echo_via_pager(text_or_generator, color=None):
     return pager(itertools.chain(text_generator, "\n"), color)
 
 
+def loadingbar(msg='Loading', interval=.5, width=7, fill_char='.'):
+    """This function creates a context manager that when entered, begins
+    displaying an animated loading bar while some code runs.
+    The loading bar will be dismissed when 'with-block' for the context
+    manager exits.
+
+    Example usage::
+
+        with loadingbar():
+            some_indeterminite_length_task()
+
+        with loadingbar(msg='Downloading', width=9, interval=.25, fill_char='#'):
+            some_indeterminite_length_task()
+
+    :param msg: The text to display near the bar.
+    :param interval: The interval in seconds at which the animation will update.
+    :param width: The width in characters of the loading animation.
+    :param fill_char: The character to use in the loading bar.
+    """
+    from ._termui_impl import LoadingBar
+    return LoadingBar(msg=msg, interval=interval, width=width, fill_char=fill_char)
+
+
 def progressbar(iterable=None, length=None, label=None, show_eta=True,
                 show_percent=None, show_pos=False,
                 item_show_func=None, fill_char='#', empty_char='-',


### PR DESCRIPTION
This similar to `progressbar` in that it shows an animation while a task is being performed. However, this is intended to show more of cycling animation for a background task (think the beachball on macOS or the hourglass on Windows).

It is configurable with the character used in the bar, the length of the bar, how fast the animation moves, and what message to display alongside the bar.

For example,

```python
import click
import time

print "foo"
with click.loadingbar(msg='Doing work', fill_char='o', interval=0.1, width=8):
    print "baz"
    time.sleep(3)

print "bar"
```

Will produce a prompt like this:

```
foo
Doing work [ o      ]
bar
```

Where the `o` is moving on character in either direction every 0.1 seconds. The "foo" is printed before we create the loadingbar. "baz" inside the loading bar is suppressed so we don't mess up the loadingbar. And then we print "bar" after we exit the loadingbar "with-statement" block.
