### PR TITLE
ZSH completions escape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Unreleased
     showing the name for friendlier debugging. :issue:`1267`
 -   Completion doesn't consider option names if a value starts with
     ``-`` after the ``--`` separator. :issue:`1247`
+-   ZSH Completion escapes special characters in values. :pr:`1418`
 
 
 Version 7.0

--- a/click/_bashcomplete.py
+++ b/click/_bashcomplete.py
@@ -61,11 +61,11 @@ COMPLETION_SCRIPT_ZSH = '''
     done
 
     if [ -n "$completions_with_descriptions" ]; then
-        _describe -V unsorted completions_with_descriptions -U -Q
+        _describe -V unsorted completions_with_descriptions -U
     fi
 
     if [ -n "$completions" ]; then
-        compadd -U -V unsorted -Q -a completions
+        compadd -U -V unsorted -a completions
     fi
     compstate[insert]="automenu"
 }


### PR DESCRIPTION
Completion in ZSH usually escapes spaces and other special characters in file names etc. I think this is the expected behavior.

As I see `-Q` has been introduced in https://github.com/stopthatcow/click/commit/13b84c5c4982f35988b812484cf9b76c8eba4ae6 which fixed sorting. However this options seems unnecessary and unrelated to sort order.

Also, I haven't found a straightforward way to test this. In case this breaks something else I'd figure out a way to override the default completion function.