### PR TITLE
click.style: add support for 256/RGB colors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Unreleased
     to ``--name``. :pr:`1355`
 -   A context's ``show_default`` parameter defaults to the value from
     the parent context. :issue:`1565`
+-   ``click.style()`` can output 256 and RGB color codes. Most modern
+    terminals support these codes. :pr:`1429`
 
 
 Version 7.1.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,8 @@ def test_echo_custom_file():
         ({"bg": "magenta"}, "\x1b[45mx y\x1b[0m"),
         ({"bg": "cyan"}, "\x1b[46mx y\x1b[0m"),
         ({"bg": "white"}, "\x1b[47mx y\x1b[0m"),
+        ({"bg": 91}, "\x1b[48;5;91mx y\x1b[0m"),
+        ({"bg": (135, 0, 175)}, "\x1b[48;2;135;0;175mx y\x1b[0m"),
         ({"blink": True}, "\x1b[5mx y\x1b[0m"),
         ({"underline": True}, "\x1b[4mx y\x1b[0m"),
         ({"bold": True}, "\x1b[1mx y\x1b[0m"),


### PR DESCRIPTION
This adds support for true-color text (using the \033[38;2;RRR;GGG;BBB escape sequence) and 256-color palette (using the \033[38;5;NNN escape sequence). It's backwards compatible with the current string-based colors, but adds a type-checking helper to handle integers or tuples/lists of 3 integers.