### PR TITLE
Remove unused ``mix_stderr`` parameter from ``CliRunner.invoke``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Unreleased
 -   When using the test ``CliRunner`` with ``mix_stderr=False``, if
     ``result.stderr`` is empty it will not raise a ``ValueError``.
     :issue:`1193`
+-   Remove the unused ``mix_stderr`` parameter from
+    ``CliRunner.invoke``. :issue:`1435`
 
 
 Version 7.0

--- a/click/testing.py
+++ b/click/testing.py
@@ -278,7 +278,7 @@ class CliRunner(object):
             clickpkg.formatting.FORCED_WIDTH = old_forced_width
 
     def invoke(self, cli, args=None, input=None, env=None,
-               catch_exceptions=True, color=False, mix_stderr=False, **extra):
+               catch_exceptions=True, color=False, **extra):
         """Invokes a command in an isolated environment.  The arguments are
         forwarded directly to the command line script, the `extra` keyword
         arguments are passed to the :meth:`~clickpkg.Command.main` function of


### PR DESCRIPTION
Fixes #1435.