### PR TITLE
Fix SyntaxWarning in test over literal comparison.

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -48,7 +48,7 @@ def test_return_values():
 
     with cli.make_context('foo', []) as ctx:
         rv = cli.invoke(ctx)
-        assert rv is 42
+        assert rv == 42
 
 
 def test_basic_group(runner):


### PR DESCRIPTION
The test generates a `SyntaxWarning` in Python 3.8 over using is to compare literals.

```
python -Wall tests/test_basic.py
tests/test_basic.py:51: SyntaxWarning: "is" with a literal. Did you mean "=="?
  assert rv is 42
```