### PR TITLE
Fix error in new AppEngine environments

### DIFF
--- a/click/_compat.py
+++ b/click/_compat.py
@@ -11,7 +11,7 @@ CYGWIN = sys.platform.startswith('cygwin')
 MSYS2 = sys.platform.startswith('win') and ('GCC' in sys.version)
 # Determine local App Engine environment, per Google's own suggestion
 APP_ENGINE = ('APPENGINE_RUNTIME' in os.environ and
-              'Development/' in os.environ['SERVER_SOFTWARE'])
+              'Development/' in os.environ.get('SERVER_SOFTWARE', ''))
 WIN = sys.platform.startswith('win') and not APP_ENGINE and not MSYS2
 DEFAULT_COLUMNS = 80
 


### PR DESCRIPTION
This commit was already merged to master in #1462. This PR targets the 7.x branch. Original PR description follows.

----

Newer AppEngine environments don't define the SERVER_SOFTWARE env variable. Without this change, importing click dies with a KeyError.

See related pull request for urllib3: https://github.com/urllib3/urllib3/pull/1704