### PR TITLE
fix: always use parameter UTF-8 fallback

### DIFF
--- a/click/types.py
+++ b/click/types.py
@@ -119,6 +119,8 @@ class StringParamType(ParamType):
                         value = value.decode(fs_enc)
                     except UnicodeError:
                         value = value.decode('utf-8', 'replace')
+                else:
+                    value = value.decode('utf-8', 'replace')
             return value
         return value
 


### PR DESCRIPTION
Even when the filesystem encoding and sys.argv encoding are the same we
should still fall back to trying UTF-8 for decoding command line
arguments.