### PR TITLE
Support Debian's sensible-editor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Unreleased
     interpreter. :issue:`1139`
 -   Fix how default values for file-type options are shown during
     prompts. :issue:`914`
+-   Consider ``sensible-editor`` when determining the editor to use for
+    ``click.edit()``. :pr:`1469`
 
 
 Version 7.0

--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -427,7 +427,7 @@ class Editor(object):
                 return rv
         if WIN:
             return 'notepad'
-        for editor in 'vim', 'nano':
+        for editor in 'sensible-editor', 'vim', 'nano':
             if os.system('which %s >/dev/null 2>&1' % editor) == 0:
                 return editor
         return 'vi'


### PR DESCRIPTION
Debian and derivative distros include a program named `sensible-editor` that is similar in spirit to `Editor.get_editor()`, except it also allows the user to make an interactive choice when the relevant envvars are unset:

- It invokes `$VISUAL` or `$EDITOR` if they are defined
- Otherwise, the program specified in `~/.selected_editor` is run.  If this file does not exist and input is a tty, the user is shown a list of installed text editors and asked to choose one.  The choice is saved in `~/.selected_editor`, and then the given program is run.
- If the file does not exist and input is not a tty, or if the program saved in `~/.selected_editor` no longer exists, `sensible-editor` falls back to `nano`, then `nano-tiny`, then `vi`.

This patch adds `sensible-editor` to the list of editors considered by `Editor.get_editor()` so that determining an editor to use on Debian systems works similarly to other programs on Debian.