### PR TITLE
Use shlex.quote for quoting shell arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Unreleased
     distinguish it from the next option. :issue:`1075`
 -   Consider ``sensible-editor`` when determining the editor to use for
     ``click.edit()``. :pr:`1469`
+-   Arguments to system calls such as the executable path passed to
+    ``click.edit`` can contains spaces. :pr:`1470`
 
 
 Version 7.0

--- a/click/_compat.py
+++ b/click/_compat.py
@@ -162,6 +162,8 @@ if PY2:
     iteritems = lambda x: x.iteritems()
     range_type = xrange
 
+    from pipes import quote as shlex_quote
+
     def is_bytes(x):
         return isinstance(x, (buffer, bytearray))
 
@@ -267,6 +269,8 @@ else:
     range_type = range
     isidentifier = lambda x: x.isidentifier()
     iteritems = lambda x: iter(x.items())
+
+    from shlex import quote as shlex_quote
 
     def is_bytes(x):
         return isinstance(x, (bytes, memoryview, bytearray))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,7 +32,7 @@ click.echo(json.dumps(rv))
 ALLOWED_IMPORTS = set([
     'weakref', 'os', 'struct', 'collections', 'sys', 'contextlib',
     'functools', 'stat', 're', 'codecs', 'inspect', 'itertools', 'io',
-    'threading', 'colorama', 'errno', 'fcntl', 'datetime'
+    'threading', 'colorama', 'errno', 'fcntl', 'datetime', 'pipes', 'shlex'
 ])
 
 if WIN:


### PR DESCRIPTION
There are several points in the code in which filenames used as arguments in shell commands (executed with either `os.system()` or `subprocess.Popen(shell=True)`) are quoted by just enclosing them in double quotes.  This will fail whenever the filenames happen to already contain double quotes.  This patch fixes this behavior by quoting the filenames with `shlex.quote()` instead (`pipes.quote()` in Python 2).

fixes #1026 