### PR TITLE
fix newline wrapping in option help

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Unreleased
     prompts. :issue:`914`
 -   Fix environment variable automatic generation for commands
     containing ``-``. :issue:`1253`
+-   Option help text replaces newlines with spaces when rewrapping, but
+    preserves paragraph breaks, fixing multiline formatting.
+    :issue:`834, 1066, 1397`
 
 
 Version 7.0

--- a/click/core.py
+++ b/click/core.py
@@ -945,8 +945,7 @@ class Command(BaseCommand):
         for param in self.get_params(ctx):
             rv = param.get_help_record(ctx)
             if rv is not None:
-                part_a, part_b = rv
-                opts.append((part_a, part_b.replace('\n', ' ')))
+                opts.append(rv)
 
         if opts:
             with formatter.section('Options'):

--- a/click/formatting.py
+++ b/click/formatting.py
@@ -198,12 +198,14 @@ class HelpFormatter(object):
                 self.write(' ' * (first_col + self.current_indent))
 
             text_width = max(self.width - first_col - 2, 10)
-            lines = iter(wrap_text(second, text_width).splitlines())
+            wrapped_text = wrap_text(second, text_width, preserve_paragraphs=True)
+            lines = wrapped_text.splitlines()
+
             if lines:
-                self.write(next(lines) + '\n')
-                for line in lines:
-                    self.write('%*s%s\n' % (
-                        first_col + self.current_indent, '', line))
+                self.write(lines[0] + '\n')
+
+                for line in lines[1:]:
+                    self.write('%*s%s\n' % (first_col + self.current_indent, '', line))
             else:
                 self.write('\n')
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -408,22 +408,30 @@ def test_case_insensitive_choice_returned_exactly(runner):
     assert result.output == 'Apple\n'
 
 
-def test_multiline_help(runner):
+def test_option_help_preserve_paragraphs(runner):
     @click.command()
-    @click.option('--foo', help="""
-        hello
+    @click.option(
+        "-C",
+        "--config",
+        type=click.Path(),
+        help="""Configuration file to use.
+        
+        If not given, the environment variable CONFIG_FILE is consulted
+        and used if set. If neither are given, a default configuration
+        file is loaded.""",
+    )
+    def cmd(config):
+        pass
 
-        i am
-
-        multiline
-    """)
-    def cmd(foo):
-        click.echo(foo)
-
-    result = runner.invoke(cmd, ['--help'])
+    result = runner.invoke(cmd, ['--help'], )
     assert result.exit_code == 0
-    out = result.output.splitlines()
-    assert '  --foo TEXT  hello  i am  multiline' in out
+    assert (
+        "  -C, --config PATH  Configuration file to use.\n"
+        "{i}\n"
+        "{i}If not given, the environment variable CONFIG_FILE is\n"
+        "{i}consulted and used if set. If neither are given, a default\n"
+        "{i}configuration file is loaded.".format(i=" " * 21)
+    ) in result.output
 
 def test_argument_custom_class(runner):
     class CustomArgument(click.Argument):


### PR DESCRIPTION
closes #834, closes #1025, closes #1066, closes #1307, closes #1397, closes #1406

When formatting option help text, pass `preserve_paragraphs=True` to `wrap_text`. This causes `\n\n` to be preserved, but `\n` within a paragraph is converted to space and re-wrapped.

```python
import click

@click.command()
@click.option(
	'-C', '--config', 'config_file',
	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
	help="""\
	Configuration file to use.
	
	If not given, the environment variable CONFIG_FILE is consulted and
	used if set. If neither are given, a default configuration file is
	loaded.""",
)
def example(config_file):
	pass

example()
```

```
$ python example.py --help
Usage: example.py [OPTIONS]

Options:
  -C, --config FILE  Configuration file to use.
                     
                     If not given, the environment variable CONFIG_FILE is
                     consulted and used if set. If neither are given, a default
                     configuration file is loaded.
  --help             Show this message and exit.
```

#1075 will add a newline after wrapped option help, making it more distinct from the text for the next option.