### PR TITLE
Add repr for Command, Group, Option, Argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ Unreleased
 -   Arguments to system calls such as the executable path passed to
     ``click.edit`` can contains spaces. :pr:`1470`
 -   Add ZSH completion autoloading and error handling. :issue:`1348`
+-   Add a repr to ``Command``, showing the command name for friendlier
+    debugging. :issue:`1267`
+
 
 Version 7.0
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,8 +58,8 @@ Unreleased
 -   Arguments to system calls such as the executable path passed to
     ``click.edit`` can contains spaces. :pr:`1470`
 -   Add ZSH completion autoloading and error handling. :issue:`1348`
--   Add a repr to ``Command``, showing the command name for friendlier
-    debugging. :issue:`1267`
+-   Add a repr to ``Command``, ``Group``, ``Option``, and ``Argument``,
+    showing the name for friendlier debugging. :issue:`1267`
 
 
 Version 7.0

--- a/click/core.py
+++ b/click/core.py
@@ -832,6 +832,9 @@ class Command(BaseCommand):
         self.hidden = hidden
         self.deprecated = deprecated
 
+    def __repr__(self):
+        return '<%s %s>' % (self.__class__.__name__, self.name)
+
     def get_usage(self, ctx):
         """Formats the usage line into a string and returns it.
 

--- a/click/core.py
+++ b/click/core.py
@@ -622,6 +622,9 @@ class BaseCommand(object):
         #: an optional dictionary with defaults passed to the context.
         self.context_settings = context_settings
 
+    def __repr__(self):
+        return "<%s %s>" % (self.__class__.__name__, self.name)
+
     def get_usage(self, ctx):
         raise NotImplementedError('Base commands cannot get usage')
 
@@ -831,9 +834,6 @@ class Command(BaseCommand):
         self.no_args_is_help = no_args_is_help
         self.hidden = hidden
         self.deprecated = deprecated
-
-    def __repr__(self):
-        return '<%s %s>' % (self.__class__.__name__, self.name)
 
     def get_usage(self, ctx):
         """Formats the usage line into a string and returns it.
@@ -1395,6 +1395,9 @@ class Parameter(object):
         self.metavar = metavar
         self.envvar = envvar
         self.autocompletion = autocompletion
+
+    def __repr__(self):
+        return "<%s %s>" % (self.__class__.__name__, self.name)
 
     @property
     def human_readable_name(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -23,6 +23,24 @@ def test_basic_functionality(runner):
     assert result.exit_code == 0
 
 
+def test_repr():
+    @click.command()
+    def command():
+        pass
+
+    @click.group()
+    def group():
+        pass
+
+    @group.command()
+    def subcommand():
+        pass
+
+    assert repr(command) == '<Command command>'
+    assert repr(group) == '<Group group>'
+    assert repr(subcommand) == '<Command subcommand>'
+
+
 def test_return_values():
     @click.command()
     def cli():


### PR DESCRIPTION
Cherry pick #1295 to 7.x and move the repr to `BaseCommand` and `Parameter` so it applies to all core types.

Fixes #1267