### PR TITLE
deprecate old param callback style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Unreleased
 -   Add completion support for Fish shell. :pr:`1423`
 -   Decoding bytes option values falls back to UTF-8 in more cases.
     :pr:`1468`
+-   Make the warning about old 2-arg parameter callbacks a deprecation
+    warning, to be removed in 8.0. This has been a warning since Click
+    2.0. :pr:`1492`
 
 
 Version 7.0

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -110,18 +110,16 @@ def invoke_param_callback(callback, ctx, param, value):
     args = getattr(code, "co_argcount", 3)
 
     if args < 3:
-        # This will become a warning in Click 3.0:
         from warnings import warn
 
         warn(
-            Warning(
-                "Invoked legacy parameter callback '{}'. The new"
-                " signature for such callbacks starting with Click 2.0"
-                " is (ctx, param, value).".format(callback)
-            ),
+            "Parameter callbacks take 3 args, (ctx, param, value). The"
+            " 2-arg style is deprecated and will be removed in 8.0.".format(callback),
+            DeprecationWarning,
             stacklevel=3,
         )
         return callback(ctx, value)
+
     return callback(ctx, param, value)
 
 
@@ -1440,8 +1438,7 @@ class Parameter(object):
                     without any arguments.
     :param callback: a callback that should be executed after the parameter
                      was matched.  This is called as ``fn(ctx, param,
-                     value)`` and needs to return the value.  Before Click
-                     2.0, the signature was ``(ctx, value)``.
+                     value)`` and needs to return the value.
     :param nargs: the number of arguments to match.  If not ``1`` the return
                   value is a tuple instead of single value.  The default for
                   nargs is ``1`` (except if the type is a tuple, then it's

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -14,7 +14,7 @@ def test_legacy_callbacks(runner):
     def cli(foo):
         click.echo(foo)
 
-    with pytest.warns(Warning, match="Invoked legacy parameter callback"):
+    with pytest.warns(DeprecationWarning, match="2-arg style"):
         result = runner.invoke(cli, ["--foo", "wat"])
         assert result.exit_code == 0
         assert "WAT" in result.output


### PR DESCRIPTION
This has been emitting a warning since 2.0. Turn it into a deprecation warning to be removed in 8.0.