### PR TITLE
ClickException goes to stderr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: click
 
+Version 7.1.1
+-------------
+
+Unreleased
+
+-   Fix ``ClickException`` output going to stdout instead of stderr.
+    :issue:`1495`
+
+
 Version 7.1
 -----------
 

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -39,7 +39,7 @@ class ClickException(Exception):
     def show(self, file=None):
         if file is None:
             file = get_text_stderr()
-        echo("Error: {}".format(self.format_message(), file=file))
+        echo("Error: {}".format(self.format_message()), file=file)
 
 
 class UsageError(ClickException):


### PR DESCRIPTION
Misplaced paren caused `file` kwarg to get ignored by `format` rather than passed to `echo`.

fixes #1495 