### PR TITLE
CliRunner isolation stdin has name and mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Unreleased
     the parent context. :issue:`1565`
 -   ``click.style()`` can output 256 and RGB color codes. Most modern
     terminals support these codes. :pr:`1429`
+-   When using ``CliRunner.invoke()``, the replaced ``stdin`` file has
+    ``name`` and ``mode`` attributes. This lets ``File`` options with
+    the ``-`` value match non-testing behavior. :issue:`1064`
 
 
 Version 7.1.2

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -308,3 +308,14 @@ def test_command_standalone_mode_returns_value():
     assert result.output == "ok\n"
     assert result.return_value == "Hello, World!"
     assert result.exit_code == 0
+
+
+def test_file_stdin_attrs(runner):
+    @click.command()
+    @click.argument("f", type=click.File())
+    def cli(f):
+        click.echo(f.name)
+        click.echo(f.mode, nl=False)
+
+    result = runner.invoke(cli, ["-"])
+    assert result.output == "<stdin>\nr"


### PR DESCRIPTION
* create subclass of io.TextIOWrapper, NamedTextIOWrapper, for PY3
* use NamedTextIOWrapper instance for sys.stdin & sys.stdout inside
  of CliRunner's isolation contextmanager

fixes #1064 

A few more notes:
* `'name'` & `'mode'` are assigned to `self.__dict__` as kv-pairs, and not as actual attributes to the `self` object, because b/c the `io.TextIOWrapper` object is not writable
* then `__getattribute__` is used to get the above 2 pseudo-attributes from `self.__dict__`
* the bug behavior described #1064 also exists in PY2, but this PR does not attempt to address that (since Python 2 support will eventually be dropped)
* `NamedTextIOWrapper` is not applied to `sys.stderr`, since click does not readily make it available as a `click.File` parameter type