### PR TITLE
With prompt, if no input is specified, the return value is not converted to the requested type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,6 +145,9 @@ Unreleased
     passed in as a default value.
     :issue:`549, 736, 764, 921, 1015, 1618`
 -   Fix formatting when ``Command.options_metavar`` is empty. :pr:`1551`
+-   The default value passed to ``prompt`` will be cast to the correct
+    type like an input value would be. :pr:`1517`
+
 
 Version 7.1.2
 -------------

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -16,7 +16,6 @@ from .exceptions import UsageError
 from .globals import resolve_color_default
 from .types import Choice
 from .types import convert_type
-from .types import Path
 from .utils import echo
 from .utils import LazyFile
 
@@ -146,11 +145,8 @@ def prompt(
             if value:
                 break
             elif default is not None:
-                if isinstance(value_proc, Path):
-                    # validate Path default value(exists, dir_okay etc.)
-                    value = default
-                    break
-                return default
+                value = default
+                break
         try:
             result = value_proc(value)
         except UsageError as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,6 +210,13 @@ def test_echo_color_flag(monkeypatch, capfd):
     assert out == f"{text}\n"
 
 
+def test_prompt_cast_default(capfd, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", StringIO("\n"))
+    value = click.prompt("value", default="100", type=int)
+    capfd.readouterr()
+    assert type(value) is int
+
+
 @pytest.mark.skipif(WIN, reason="Test too complex to make work windows.")
 def test_echo_writing_to_standard_error(capfd, monkeypatch):
     def emulate_input(text):


### PR DESCRIPTION
If the passed in default is a string but the type parameter is not a string then click should do its best to convert the default to the requested type.

This becomes an issue when using mypy with click.  MyPy will complain if you pass anything but a string for the default.  One option is to do a type ignore but that starts to pollute the code quickly if you have a lot of prompts that expect integer values.  Fixing this also will prevent some accidental bugs where you use different types with your `type` option and your `default`.  Click should do its best to honor the requested type.