### PR TITLE
Minor typo fix in bash completion template

### DIFF
--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -26,7 +26,7 @@ COMPLETION_SCRIPT_BASH = """
     return 0
 }
 
-%(complete_func)setup() {
+%(complete_func)s_setup() {
     local COMPLETION_OPTIONS=""
     local BASH_VERSION_ARR=(${BASH_VERSION//./ })
     # Only BASH version 4.4 and later have the nosort option.
@@ -38,7 +38,7 @@ COMPLETION_SCRIPT_BASH = """
     complete $COMPLETION_OPTIONS -F %(complete_func)s %(script_names)s
 }
 
-%(complete_func)setup
+%(complete_func)s_setup
 """
 
 COMPLETION_SCRIPT_ZSH = """


### PR DESCRIPTION
Currently, the bash completion generated looks like:
```
_mycomm_completionetup;
```
^^ Missing the "s" in setup due to the Python template using the one "s" present.