### PR TITLE
Fix name of bash completion script setup function

### DIFF
--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -26,7 +26,7 @@ COMPLETION_SCRIPT_BASH = """
     return 0
 }
 
-%(complete_func)setup() {
+%(complete_func)ssetup() {
     local COMPLETION_OPTIONS=""
     local BASH_VERSION_ARR=(${BASH_VERSION//./ })
     # Only BASH version 4.4 and later have the nosort option.
@@ -38,7 +38,7 @@ COMPLETION_SCRIPT_BASH = """
     complete $COMPLETION_OPTIONS -F %(complete_func)s %(script_names)s
 }
 
-%(complete_func)setup
+%(complete_func)ssetup
 """
 
 COMPLETION_SCRIPT_ZSH = """


### PR DESCRIPTION
Bash completion scripts are currently generated with a setup function whose name ends with "etup" instead of "setup". This is probably a typo where the Python % operator's conversion type s was confused with the first letter of "setup".