### PR TITLE
Fix version detection when invoked with `python -m <package>`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: click
 
+Version 7.2
+-----------
+
+Unreleased
+
+-   Fix version detection when invoked via ``python -m <package>``.
+    :pr:`1531`
+
+
 Version 7.1.2
 -------------
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -265,6 +265,10 @@ def version_option(version=None, *param_decls, **attrs):
     if version is None:
         if hasattr(sys, "_getframe"):
             module = sys._getframe(1).f_globals.get("__name__")
+            if module == "__main__":
+                package = sys._getframe(1).f_globals.get("__package__")
+                if package:
+                    module = ".".join((package, module))
         else:
             module = ""
 


### PR DESCRIPTION
click.version_option attempts to determine the version using `pkg_resources` when no version is passed. This fails when the program was invoked with `python -m <package>`. 

<details>
<summary>Traceback</summary>

```python
  Traceback (most recent call last):
    File ".../3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File ".../3.7/lib/python3.7/runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File ".../foobar/__main__.py", line 11, in <module>
      main()
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 891, in __call__
      return self.main(*args, **kwargs)
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 843, in main
      with self.make_context(prog_name, args, **extra) as ctx:
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 762, in make_context
      self.parse_args(ctx, args)
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 1115, in parse_args
      value, args = param.handle_parse_result(ctx, opts, args)
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 1705, in handle_parse_result
      value = invoke_param_callback(self.callback, ctx, self, value)
    File ".../venv/lib/python3.7/site-packages/click/core.py", line 123, in invoke_param_callback
      return callback(ctx, param, value)
    File ".../venv/lib/python3.7/site-packages/click/decorators.py", line 295, in callback
      raise RuntimeError("Could not determine version")
  RuntimeError: Could not determine version
```
</details>

The reason version detection fails is that `__name__` in the calling module is `"__main__"`, while `entry_point.module_name` is `"<package>.__main__"`:

https://github.com/pallets/click/blob/19fdc8509a1b946c088512e0e5e388a8d012f0ce/src/click/decorators.py#L265-L269

https://github.com/pallets/click/blob/19fdc8509a1b946c088512e0e5e388a8d012f0ce/src/click/decorators.py#L288-L293

This PR fixes the issue by prefixing the module name with `__package__` from the calling module, if it was `"__main__"` to begin with.

---

**Minimal reproducible example**:

```
.
├── foobar
│   ├── __init__.py
│   └── __main__.py
├── setup.cfg
└── setup.py

1 directory, 4 files
```

```python
# setup.py
import setuptools
setuptools.setup()
```

```ini
# setup.cfg
[metadata]
name = foobar
version = 0.1.0

[options]
packages = find:
install_requires =
    click

[options.entry_points]
console_scripts =
    foobar = foobar.__main__:main
```

```python
# foobar/__init__.py (empty)
```

```python
# foobar/__main__.py
import click


@click.command()
@click.version_option()
def main() -> None:
    """foobar"""


if __name__ == "__main__":
    main(prog_name="foobar")
```