### PR TITLE
Make ParameterSource a proper Python 3 Enum subclass.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,7 @@ Unreleased
 -   Extra context settings (``obj=...``, etc.) are passed on to the
     completion system. :issue:`942`
 -   Include ``--help`` option in completion. :pr:`1504`
+-   ``ParameterSource`` is an ``enum.Enum`` subclass. :issue:`1530`
 
 
 Version 7.1.2

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -386,8 +386,10 @@ Detecting the Source of a Parameter
 
 In some situations it's helpful to understand whether or not an option
 or parameter came from the command line, the environment, the default
-value, or the default_map. The :meth:`Context.get_parameter_source`
-method can be used to find this out.
+value, or :attr:`Context.default_map`. The
+:meth:`Context.get_parameter_source` method can be used to find this
+out. It will return a member of the :class:`~click.core.ParameterSource`
+enum.
 
 .. click:example::
 
@@ -396,7 +398,7 @@ method can be used to find this out.
     @click.pass_context
     def cli(ctx, port):
         source = ctx.get_parameter_source("port")
-        click.echo(f"Port came from {source}")
+        click.echo(f"Port came from {source.name}")
 
 .. click:run::
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -108,6 +108,11 @@ Context
 
 .. autofunction:: get_current_context
 
+.. autoclass:: click.core.ParameterSource
+    :members:
+    :member-order: bysource
+
+
 Types
 -----
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -45,7 +45,7 @@ ALLOWED_IMPORTS = {
     "errno",
     "fcntl",
     "datetime",
-    "pipes",
+    "enum",
 }
 
 if WIN:


### PR DESCRIPTION
This implements the change proposed in  #1530.

I tried to make as few changes as possible, that's why I went and implemented a custom `__eq__()` to support the current use case inside the library (mostly inside tests)

Any comments and feedback are welcome :)

fixes #1530