### PR TITLE
Call parameter callbacks when invoking command with `Context.invoke`

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -603,6 +603,10 @@ class Context(object):
             for param in other_cmd.params:
                 if param.name not in kwargs and param.expose_value:
                     kwargs[param.name] = param.get_default(ctx)
+                    if param.callback is not None:
+                        kwargs[param.name] = param.callback(
+                            ctx, param, kwargs[param.name]
+                        )
 
         args = args[2:]
         with augment_usage_errors(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -20,6 +20,29 @@ def test_other_command_invoke(runner):
     assert result.output == "42\n"
 
 
+def test_invoke_command_with_callback(runner):
+    """Test that invoking a command will call any parameter callbacks."""
+
+    def arg_callback(ctx, param, value):
+        return 42
+
+    @click.command()
+    @click.pass_context
+    def cli(ctx):
+        return ctx.invoke(other_cmd)
+
+    @click.command()
+    @click.argument("arg", type=click.INT, required=False, callback=arg_callback)
+    def other_cmd(arg):
+        assert arg is not None
+
+    result = runner.invoke(other_cmd, [])
+    assert not result.exception
+
+    result = runner.invoke(cli, [])
+    assert not result.exception
+
+
 def test_other_command_forward(runner):
     cli = click.Group()
 


### PR DESCRIPTION
Fixes #950 

The `Context.invoke` method was not calling any callbacks that might
have been defined for the parameters of the command that is being
invoked.