### PR TITLE
Revert "Use shlex.quote for quoting shell arguments"

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -174,8 +174,6 @@ if PY2:
     iteritems = lambda x: x.iteritems()
     range_type = xrange
 
-    from pipes import quote as shlex_quote
-
     def is_bytes(x):
         return isinstance(x, (buffer, bytearray))
 
@@ -283,8 +281,6 @@ else:
     range_type = range
     isidentifier = lambda x: x.isidentifier()
     iteritems = lambda x: iter(x.items())
-
-    from shlex import quote as shlex_quote
 
     def is_bytes(x):
         return isinstance(x, (bytes, memoryview, bytearray))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -49,7 +49,6 @@ ALLOWED_IMPORTS = {
     "fcntl",
     "datetime",
     "pipes",
-    "shlex",
 }
 
 if WIN:


### PR DESCRIPTION
This caused issues if the pager/editor command had options like `less -FRSX`, they would then get quoted as a single word rather than `less` then `-FRSX`.

`shlex.quote` doesn't seem to do the right thing on Windows cmd. Using `shlex.split` on the command first wouldn't help, as it would need to get re-joined and `subprocess.list2cmdline` is not an external API. Let's hold off until #1476 instead.

Reverts #1470
Closes #1514 