### PR TITLE
Fix behavior when setting options_metavar parameter as empty 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,7 +144,7 @@ Unreleased
     ``is_flag=False``, and the value can instead be prompted for or
     passed in as a default value.
     :issue:`549, 736, 764, 921, 1015, 1618`
-
+-   Fix formatting when ``Command.options_metavar`` is empty. :pr:`1551`
 
 Version 7.1.2
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1139,7 +1139,7 @@ class Command(BaseCommand):
         """Returns all the pieces that go into the usage line and returns
         it as a list of strings.
         """
-        rv = [self.options_metavar]
+        rv = [self.options_metavar] if self.options_metavar else []
         for param in self.get_params(ctx):
             rv.extend(param.get_usage_pieces(ctx))
         return rv

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -350,3 +350,9 @@ def test_formatting_usage_no_option_padding(runner):
         "  --bar TEXT  This help message will be padded if it wraps.",
         "  --help      Show this message and exit.",
     ]
+
+
+def test_formatting_with_options_metavar_empty(runner):
+    cli = click.Command("cli", options_metavar="", params=[click.Argument(["var"])])
+    result = runner.invoke(cli, ["--help"])
+    assert "Usage: cli VAR\n" in result.output


### PR DESCRIPTION
Hi,

I have encountered an issue when using a Command object without any options.
As I wanted to prevent the '[OPTION]' from appearing in the Usage line, I tried to set the options_metavar parameter to None but got an exception.

I also tried to set it as an empty string rather than None, there's no exception then but the behavior isn't perfect neither as it prints a double space in the Usage row (the double space is between the filename and the argument)

Here's a code snippet to reproduce the issue with None

```python
@click.command("foo", options_metavar=None)
@click.argument("bar")
def cli():
    pass
```

### Expected Behavior
Running the above, I expected to see
```bash
$ python foobar.py --help
Usage: foobar.py BAR

Options:
  --help  Show this message and exit.
```

### Actual Behavior
An error is raised as the formatter was expecting a string instead of a None.

```pytb
Traceback (most recent call last):
  File "foobar.py", line 8, in <module>
    cli()
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 781, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 700, in make_context
    self.parse_args(ctx, args)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 1048, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 1630, in handle_parse_result
    value = invoke_param_callback(self.callback, ctx, self, value)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 123, in invoke_param_callback
    return callback(ctx, param, value)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 950, in show_help
    echo(ctx.get_help(), color=ctx.color)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 570, in get_help
    return self.command.get_help(self)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 975, in get_help
    self.format_help(ctx, formatter)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 1001, in format_help
    self.format_usage(ctx, formatter)
  File "/home/romain/projects/apps/myprss/.venv/lib/python3.7/site-packages/click/core.py", line 923, in format_usage
    formatter.write_usage(ctx.command_path, " ".join(pieces))
TypeError: sequence item 0: expected str instance, NoneType found
```

### Environment

* Python version: 3.7.4
* Click version: 7.1.2
