### PR TITLE
make_pass_decorator option to pass merged context

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -212,6 +212,38 @@ def test_close_before_pop(runner):
     assert called == [True]
 
 
+def test_make_pass_decorator_merged_context(runner):
+    """
+    Test to check that make_pass_decorator doesn't consume arguments based on
+    invocation order.
+    """
+
+    class Foo:
+        def __init__(self):
+            self.title = "default"
+            self.command = "overwritten"
+
+    pass_foo = click.make_pass_decorator(Foo, ensure=True, merge=True)
+
+    @click.group()
+    @pass_foo
+    def cli(foo):
+        pass
+
+    @cli.command()
+    @pass_foo
+    def test(ctx):
+        click.echo(isinstance(ctx, click.Context))
+        click.echo(ctx.title)
+        click.echo(ctx.command)
+        click.echo(ctx.command_path)
+
+    result = runner.invoke(cli, ["test"])
+    print(result)
+    assert not result.exception
+    assert result.output == "True\ndefault\noverwritten\ncli test\n"
+
+
 def test_make_pass_decorator_args(runner):
     """
     Test to check that make_pass_decorator doesn't consume arguments based on


### PR DESCRIPTION
Currently `make_pass_decorator` will pass a custom context object. If you need this and the normal context, you'd typically use both `@click.pass_context` and the decorator you make with `make_pass_decorator`. There are tests that do this. This can be cumbersome if you often want features in the normal context and custom features from your own, especially in a large cli with many commands.

This adds an option to have `make_pass_decorator` pass the normal context merged with the provided context object, preferring the custom in conflicts since that's the one the user wrote. This allows you to pass a single context object into the functions that has the built-in features and custom features, rather than two. This can simplify mental overhead in tracking which to use for what, and provides a single place to look for what you need.

This is opt-in - defaulted to preserve current behavior.