### PR TITLE
Fix #1460: hide prompt input if hide_input is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,11 +12,6 @@ Unreleased
     parameter. :issue:`1264`, :pr:`1329`
 -   Add an optional parameter to ``ProgressBar.update`` to set the
     ``current_item``. :issue:`1226`, :pr:`1332`
-
-
-Version 7.2
------------
-
 -   Include ``--help`` option in completion. :pr:`1504`
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: click
 
+Version 7.2
+-----------
+
+-   Include ``--help`` option in completion. :pr:`1504`
+
+
 Version 7.1.2
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Released 2020-03-09
 -   Make the warning about old 2-arg parameter callbacks a deprecation
     warning, to be removed in 8.0. This has been a warning since Click
     2.0. :pr:`1492`
+-   Adjust error messages to standardize the types of quotes used so
+    they match error messages from Python.
 
 
 Version 7.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,66 +1,212 @@
-==========================
 How to contribute to Click
 ==========================
 
-Thanks for considering contributing to Click.
+Thank you for considering contributing to Click!
+
 
 Support questions
-=================
+-----------------
 
-Please, don't use the issue tracker for this. Check whether the
-``#pocoo`` IRC channel on Freenode can help with your issue. If your problem
-is not strictly Click-specific, ``#python`` on Freenode is generally more
-active.  Also try searching or asking on `Stack Overflow`_ with the
-``python-click`` tag.
+Please, don't use the issue tracker for this. The issue tracker is a
+tool to address bugs and feature requests in Click itself. Use one of
+the following resources for questions about using Click or issues with
+your own code:
 
-.. _Stack Overflow: https://stackoverflow.com/questions/tagged/python-click?sort=votes
+-   The ``#get-help`` channel on our Discord chat:
+    https://discord.gg/t6rrQZH
+-   The mailing list flask@python.org for long term discussion or larger
+    issues.
+-   Ask on `Stack Overflow`_. Search with Google first using:
+    ``site:stackoverflow.com python click {search term, exception message, etc.}``
+
+.. _Stack Overflow: https://stackoverflow.com/questions/tagged/python-click?sort=linked
+
 
 Reporting issues
-================
+----------------
 
-- Under which versions of Python does this happen? This is even more important
-  if your issue is encoding related.
+Include the following information in your post:
 
-- Under which versions of Click does this happen? Check if this issue is fixed
-  in the repository.
+-   Describe what you expected to happen.
+-   If possible, include a `minimal reproducible example`_ to help us
+    identify the issue. This also helps check that the issue is not with
+    your own code.
+-   Describe what actually happened. Include the full traceback if there
+    was an exception.
+-   List your Python and Click. If possible, check if this issue is
+    already fixed in the latest releases or the latest code in the
+    repository.
+
+.. _minimal reproducible example: https://stackoverflow.com/help/minimal-reproducible-example
+
 
 Submitting patches
-==================
+------------------
 
-- Include tests if your patch is supposed to solve a bug, and explain clearly
-  under which circumstances the bug happens. Make sure the test fails without
-  your patch.
+If there is not an open issue for what you want to submit, prefer
+opening one for discussion before working on a PR. You can work on any
+issue that doesn't have an open PR linked to it or a maintainer assigned
+to it. These show up in the sidebar. No need to ask if you can work on
+an issue that interests you.
 
-- Try to follow `PEP8 <http://legacy.python.org/dev/peps/pep-0008/>`_, but you
-  may ignore the line-length-limit if following it would make the code uglier.
+Include the following in your patch:
 
-- For features: Consider whether your feature would be a better fit for an
-  `external package <https://click.palletsprojects.com/en/7.x/contrib/>`_
+-   Use `Black`_ to format your code. This and other tools will run
+    automatically if you install `pre-commit`_ using the instructions
+    below.
+-   Include tests if your patch adds or changes code. Make sure the test
+    fails without your patch.
+-   Update any relevant docs pages and docstrings. Docs pages and
+    docstrings should be wrapped at 72 characters.
+-   Add an entry in ``CHANGES.rst``. Use the same style as other
+    entries. Also include ``.. versionchanged::`` inline changelogs in
+    relevant docstrings.
 
-- For docs and bug fixes: Submit against the latest maintenance branch instead of master!
+.. _Black: https://black.readthedocs.io
+.. _pre-commit: https://pre-commit.com
 
-- Non docs or text related changes need an entry in ``CHANGES.rst``,
-  and ``.. versionadded`` or ``.. versionchanged`` markers in the docs.
 
-Running the testsuite
----------------------
+First time setup
+~~~~~~~~~~~~~~~~
 
-You probably want to set up a `virtualenv
-<https://virtualenv.readthedocs.io/en/latest/index.html>`_.
+-   Download and install the `latest version of git`_.
+-   Configure git with your `username`_ and `email`_.
 
-The minimal requirement for running the testsuite is ``py.test``.  You can
-install it with::
+    .. code-block:: text
 
-    pip install pytest
+        $ git config --global user.name 'your name'
+        $ git config --global user.email 'your email'
 
-Then you can run the testsuite with::
+-   Make sure you have a `GitHub account`_.
+-   Fork Click to your GitHub account by clicking the `Fork`_ button.
+-   `Clone`_ the main repository locally.
 
-    py.test
+    .. code-block:: text
 
-For a more isolated test environment, you can also install ``tox`` instead of
-``pytest``. You can install it with::
+        $ git clone https://github.com/pallets/click
+        $ cd click
 
-    pip install tox
+-   Add your fork as a remote to push your work to. Replace
+    ``{username}`` with your username.
 
-The ``tox`` command will then run all tests against multiple combinations of
-Python versions and dependency versions.
+    .. code-block:: text
+
+        git remote add fork https://github.com/{username}/click
+
+-   Create a virtualenv.
+
+    .. code-block:: text
+
+        $ python3 -m venv env
+        $ . env/bin/activate
+
+    On Windows, activating is different.
+
+    .. code-block:: text
+
+        > env\Scripts\activate
+
+-   Install Click in editable mode with development dependencies.
+
+    .. code-block:: text
+
+        $ pip install -e . -r requirements/dev.txt
+
+-   Install the pre-commit hooks.
+
+    .. code-block:: text
+
+        $ pre-commit install
+
+.. _latest version of git: https://git-scm.com/downloads
+.. _username: https://help.github.com/en/articles/setting-your-username-in-git
+.. _email: https://help.github.com/en/articles/setting-your-commit-email-address-in-git
+.. _GitHub account: https://github.com/join
+.. _Fork: https://github.com/pallets/click/fork
+.. _Clone: https://help.github.com/en/articles/fork-a-repo#step-2-create-a-local-clone-of-your-fork
+
+
+Start coding
+~~~~~~~~~~~~
+
+-   Create a branch to identify the issue you would like to work on. If
+    you're submitting a bug or documentation fix, branch off of the
+    latest ".x" branch.
+
+    .. code-block:: text
+
+        $ git checkout -b your-branch-name origin/7.x
+
+    If you're submitting a feature addition or change, branch off of the
+    "master" branch.
+
+    .. code-block:: text
+
+        $ git checkout -b your-branch-name origin/master
+
+-   Using your favorite editor, make your changes,
+    `committing as you go`_.
+-   Include tests that cover any code changes you make. Make sure the
+    test fails without your patch. Run the tests as described below.
+-   Push your commits to your fork on GitHub and
+    `create a pull request`_. Link to the issue being addressed with
+    ``fixes #123`` in the pull request.
+
+    .. code-block:: text
+
+        $ git push --set-upstream fork your-branch-name
+
+.. _committing as you go: https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
+.. _create a pull request: https://help.github.com/en/articles/creating-a-pull-request
+
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+Run the basic test suite with pytest.
+
+.. code-block:: text
+
+    $ pytest
+
+This runs the tests for the current environment, which is usually
+sufficient. CI will run the full suite when you submit your pull
+request. You can run the full test suite with tox if you don't want to
+wait.
+
+.. code-block:: text
+
+    $ tox
+
+
+Running test coverage
+~~~~~~~~~~~~~~~~~~~~~
+
+Generating a report of lines that do not have test coverage can indicate
+where to start contributing. Run ``pytest`` using ``coverage`` and
+generate a report.
+
+.. code-block:: text
+
+    $ pip install coverage
+    $ coverage run -m pytest
+    $ coverage html
+
+Open ``htmlcov/index.html`` in your browser to explore the report.
+
+Read more about `coverage <https://coverage.readthedocs.io>`__.
+
+
+Building the docs
+~~~~~~~~~~~~~~~~~
+
+Build the docs in the ``docs`` directory using Sphinx.
+
+.. code-block:: text
+
+    $ cd docs
+    $ make html
+
+Open ``_build/html/index.html`` in your browser to view the docs.
+
+Read more about `Sphinx <https://www.sphinx-doc.org/en/stable/>`__.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ requests==2.23.0          # via sphinx
 six==1.15.0               # via packaging, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
 sphinx-issues==1.2.0      # via -r requirements/docs.in
-sphinx==3.1.0             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
+sphinx==3.1.1             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -22,7 +22,7 @@ requests==2.23.0          # via sphinx
 six==1.15.0               # via packaging
 snowballstemmer==2.0.0    # via sphinx
 sphinx-issues==1.2.0      # via -r requirements/docs.in
-sphinx==3.1.0             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
+sphinx==3.1.1             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -297,7 +297,7 @@ def get_choices(cli, prog_name, args, incomplete):
     completions = []
     if not has_double_dash and start_of_option(incomplete):
         # completions for partial options
-        for param in ctx.command.params:
+        for param in ctx.command.get_params(ctx):
             if isinstance(param, Option) and not param.hidden:
                 param_opts = [
                     param_opt
@@ -309,11 +309,11 @@ def get_choices(cli, prog_name, args, incomplete):
                 )
         return completions
     # completion for option values from user supplied values
-    for param in ctx.command.params:
+    for param in ctx.command.get_params(ctx):
         if is_incomplete_option(all_args, param):
             return get_user_autocompletions(ctx, all_args, incomplete, param)
     # completion for argument values from user supplied values
-    for param in ctx.command.params:
+    for param in ctx.command.get_params(ctx):
         if is_incomplete_argument(ctx.params, param):
             return get_user_autocompletions(ctx, all_args, incomplete, param)
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -153,7 +153,10 @@ def prompt(
         try:
             result = value_proc(value)
         except UsageError as e:
-            echo(f"Error: {e.message}", err=err)  # noqa: B306
+            if hide_input:
+                echo("Error: the value you entered was invalid", err=err)
+            else:
+                echo(f"Error: {e.message}", err=err)  # noqa: B306
             continue
         if not confirmation_prompt:
             return result

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -20,7 +20,7 @@ def test_single_command():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--local-opt"]
+    assert choices_without_help(cli, [], "-") == ["--local-opt", "--help"]
     assert choices_without_help(cli, [], "") == []
 
 
@@ -30,7 +30,7 @@ def test_boolean_flag():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout"]
+    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout", "--help"]
 
 
 def test_multi_value_option():
@@ -44,7 +44,7 @@ def test_multi_value_option():
     def sub(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--pos"]
+    assert choices_without_help(cli, [], "-") == ["--pos", "--help"]
     assert choices_without_help(cli, ["--pos"], "") == []
     assert choices_without_help(cli, ["--pos", "1.0"], "") == []
     assert choices_without_help(cli, ["--pos", "1.0", "1.0"], "") == ["sub"]
@@ -56,7 +56,7 @@ def test_multi_option():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--message", "-m"]
+    assert choices_without_help(cli, [], "-") == ["--message", "-m", "--help"]
     assert choices_without_help(cli, ["-m"], "") == []
 
 
@@ -72,9 +72,9 @@ def test_small_chain():
         pass
 
     assert choices_without_help(cli, [], "") == ["sub"]
-    assert choices_without_help(cli, [], "-") == ["--global-opt"]
+    assert choices_without_help(cli, [], "-") == ["--global-opt", "--help"]
     assert choices_without_help(cli, ["sub"], "") == []
-    assert choices_without_help(cli, ["sub"], "-") == ["--local-opt"]
+    assert choices_without_help(cli, ["sub"], "-") == ["--local-opt", "--help"]
 
 
 def test_long_chain():
@@ -116,16 +116,17 @@ def test_long_chain():
     def csub(csub_opt, color):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--cli-opt"]
+    assert choices_without_help(cli, [], "-") == ["--cli-opt", "--help"]
     assert choices_without_help(cli, [], "") == ["asub"]
-    assert choices_without_help(cli, ["asub"], "-") == ["--asub-opt"]
+    assert choices_without_help(cli, ["asub"], "-") == ["--asub-opt", "--help"]
     assert choices_without_help(cli, ["asub"], "") == ["bsub"]
-    assert choices_without_help(cli, ["asub", "bsub"], "-") == ["--bsub-opt"]
+    assert choices_without_help(cli, ["asub", "bsub"], "-") == ["--bsub-opt", "--help"]
     assert choices_without_help(cli, ["asub", "bsub"], "") == ["csub"]
     assert choices_without_help(cli, ["asub", "bsub", "csub"], "-") == [
         "--csub-opt",
         "--csub",
         "--search-color",
+        "--help",
     ]
     assert (
         choices_without_help(cli, ["asub", "bsub", "csub", "--csub-opt"], "")
@@ -173,16 +174,22 @@ def test_chaining():
     def csub(csub_opt, arg):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--cli-opt"]
+    assert choices_without_help(cli, [], "-") == ["--cli-opt", "--help"]
     assert choices_without_help(cli, [], "") == ["cliarg1", "cliarg2"]
-    assert choices_without_help(cli, ["cliarg1", "asub"], "-") == ["--asub-opt"]
+    assert choices_without_help(cli, ["cliarg1", "asub"], "-") == [
+        "--asub-opt",
+        "--help",
+    ]
     assert choices_without_help(cli, ["cliarg1", "asub"], "") == ["bsub", "csub"]
     assert choices_without_help(cli, ["cliarg1", "bsub"], "") == ["arg1", "arg2"]
     assert choices_without_help(cli, ["cliarg1", "asub", "--asub-opt"], "") == []
     assert choices_without_help(
         cli, ["cliarg1", "asub", "--asub-opt", "5", "bsub"], "-"
-    ) == ["--bsub-opt"]
-    assert choices_without_help(cli, ["cliarg1", "asub", "bsub"], "-") == ["--bsub-opt"]
+    ) == ["--bsub-opt", "--help"]
+    assert choices_without_help(cli, ["cliarg1", "asub", "bsub"], "-") == [
+        "--bsub-opt",
+        "--help",
+    ]
     assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "") == [
         "carg1",
         "carg2",
@@ -191,7 +198,10 @@ def test_chaining():
         "carg1",
         "carg2",
     ]
-    assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "-") == ["--csub-opt"]
+    assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "-") == [
+        "--csub-opt",
+        "--help",
+    ]
     assert choices_with_help(cli, ["cliarg1", "asub"], "b") == [("bsub", "bsub help")]
 
 
@@ -222,6 +232,7 @@ def test_option_choice():
         ("--opt1", "opt1 help"),
         ("--opt2", None),
         ("--opt3", None),
+        ("--help", "Show this message and exit."),
     ]
     assert choices_without_help(cli, [], "--opt") == ["--opt1", "--opt2", "--opt3"]
     assert choices_without_help(cli, [], "--opt1=") == ["opt11", "opt12"]
@@ -234,14 +245,23 @@ def test_option_choice():
         "opt21",
         "opt22",
     ]
-    assert choices_without_help(cli, ["--opt2", "opt21"], "-") == ["--opt1", "--opt3"]
-    assert choices_without_help(cli, ["--opt1", "opt11"], "-") == ["--opt2", "--opt3"]
+    assert choices_without_help(cli, ["--opt2", "opt21"], "-") == [
+        "--opt1",
+        "--opt3",
+        "--help",
+    ]
+    assert choices_without_help(cli, ["--opt1", "opt11"], "-") == [
+        "--opt2",
+        "--opt3",
+        "--help",
+    ]
     assert choices_without_help(cli, ["--opt1"], "opt") == ["opt11", "opt12"]
     assert choices_without_help(cli, ["--opt3"], "opti") == ["option"]
 
     assert choices_without_help(cli, ["--opt1", "invalid_opt"], "-") == [
         "--opt2",
         "--opt3",
+        "--help",
     ]
 
 
@@ -268,7 +288,7 @@ def test_boolean_flag_choice():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout"]
+    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout", "--help"]
     assert choices_without_help(cli, ["--shout"], "") == ["arg1", "arg2"]
 
 
@@ -382,7 +402,7 @@ def test_long_chain_choice():
     ]
     assert choices_without_help(
         cli, ["sub", "--sub-opt", "subopt1", "subarg1", "bsub"], "-"
-    ) == ["--bsub-opt"]
+    ) == ["--bsub-opt", "--help"]
     assert choices_without_help(
         cli, ["sub", "--sub-opt", "subopt1", "subarg1", "bsub"], ""
     ) == ["bsubarg1", "bsubarg2"]
@@ -472,14 +492,14 @@ def test_hidden():
     assert choices_without_help(cli, [], "h") == []
     # If the user exactly types out the hidden command, complete its subcommands.
     assert choices_without_help(cli, ["hgroup"], "") == ["hgroupsub"]
-    assert choices_without_help(cli, ["hsub"], "--h") == ["--hname"]
+    assert choices_without_help(cli, ["hsub"], "--h") == ["--hname", "--help"]
 
 
 @pytest.mark.parametrize(
     ("args", "part", "expect"),
     [
-        ([], "-", ["--opt"]),
-        (["value"], "--", ["--opt"]),
+        ([], "-", ["--opt", "--help"]),
+        (["value"], "--", ["--opt", "--help"]),
         ([], "-o", []),
         (["--opt"], "-o", []),
         (["--"], "", ["name", "-o", "--opt", "--"]),


### PR DESCRIPTION
This PR aims to fix #1460 (prompt input would be displayed in the error message even if `hide_input` was enabled).

These scripts now work just fine and display `Error: the value you entered was invalid` if the input isn't what Click expects. Script 1:
```
cesaredecal$ python  -c 'import click; click.prompt("prompt", type=int, hide_input=True)'
prompt: 
Error: the value you entered was invalid
```


Script 2 (that asks for a numeric pin):
```
import click


@click.command()
@click.password_option(type=int)
def cli(password):
    pass


cli()
```

```
cesaredecal$ python hello.py
Password: 
Error: the value you entered was invalid
```

All tests with `tox` pass. As far as the implementation goes, it would have probably been a little cleaner to handle the checking inside the `UsageError` class (or similar), but we don't have visibility on `hide_input` there. Feedback very welcome as I'm pretty new with Python.