### PR TITLE
Added IntRange min and max preview to --help output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Unreleased
     :issue:`1582`
 -   If validation fails for a prompt with ``hide_input=True``, the value
     is not shown in the error message. :issue:`1460`
+-   An ``IntRange`` option shows the accepted range in its help text.
+    :issue:`1525`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1936,6 +1936,10 @@ class Option(Parameter):
                 default_string = self.default
             extra.append(f"default: {default_string}")
 
+        if isinstance(self.type, IntRange):
+            if self.type.min is not None and self.type.max is not None:
+                extra.append(f"{self.type.min}-{self.type.max} inclusive")
+
         if self.required:
             extra.append("required")
         if extra:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -216,6 +216,16 @@ def test_dynamic_default_help_text(runner):
     assert "(current user)" in result.output
 
 
+def test_intrange_default_help_text(runner):
+    @click.command()
+    @click.option("--count", type=click.IntRange(1, 32), show_default=True, default=1)
+    def cmd(arg):
+        click.echo(arg)
+
+    result = runner.invoke(cmd, ["--help"])
+    assert "1-32 inclusive" in result.output
+
+
 def test_toupper_envvar_prefix(runner):
     @click.command()
     @click.option("--arg")


### PR DESCRIPTION
Issue https://github.com/pallets/click/issues/1525  requested to have the following output for using the `--help` flag on options of type IntRange:
```
Usage: test.py [OPTIONS]

  Simple program that greets NAME for a total of COUNT times.

Options:
  --count INTEGER RANGE  Number of greetings.  [default: 1-32 inclusive]
  --help                 Show this message and exit.
```

This can be used like as a regular click user would expect it to:
````python
import click

@click.command()
@click.option("--count",type=click.IntRange(1, 32), show_default=True, default=1, help="Number of greetings.")
def hello(count):
    """Simple program that greets for a total of COUNT times."""
    for _ in range(count):
        click.echo("Hello!")

if __name__ == '__main__':
    hello()
````