### PR TITLE
Fix #1460: hide prompt input if hide_input is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
 -   ``version_option`` uses ``importlib.metadata`` (or the
     ``importlib_metadata`` backport) instead of ``pkg_resources``.
     :issue:`1582`
+-   If validation fails for a prompt with ``hide_input=True``, the value
+    is not shown in the error message. :issue:`1460`
 
 
 Version 7.1.2

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -153,7 +153,10 @@ def prompt(
         try:
             result = value_proc(value)
         except UsageError as e:
-            echo(f"Error: {e.message}", err=err)  # noqa: B306
+            if hide_input:
+                echo("Error: the value you entered was invalid", err=err)
+            else:
+                echo(f"Error: {e.message}", err=err)  # noqa: B306
             continue
         if not confirmation_prompt:
             return result


### PR DESCRIPTION
This PR aims to fix #1460 (prompt input would be displayed in the error message even if `hide_input` was enabled).

These scripts now work just fine and display `Error: the value you entered was invalid` if the input isn't what Click expects. Script 1:
```
cesaredecal$ python  -c 'import click; click.prompt("prompt", type=int, hide_input=True)'
prompt: 
Error: the value you entered was invalid
```


Script 2 (that asks for a numeric pin):
```
import click


@click.command()
@click.password_option(type=int)
def cli(password):
    pass


cli()
```

```
cesaredecal$ python hello.py
Password: 
Error: the value you entered was invalid
```

All tests pass.