### PR TITLE
Added section to group

### DIFF
--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -12,9 +12,11 @@ from .core import Context
 from .core import Group
 from .core import MultiCommand
 from .core import Option
+from .core import Section
 from .core import Parameter
 from .decorators import argument
 from .decorators import command
+from .decorators import section
 from .decorators import confirmation_option
 from .decorators import group
 from .decorators import help_option

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -5,6 +5,7 @@ from functools import update_wrapper
 from .core import Argument
 from .core import Command
 from .core import Group
+from .core import Section
 from .core import Option
 from .globals import get_current_context
 from .utils import echo
@@ -140,6 +141,13 @@ def group(name=None, **attrs):
     attrs.setdefault("cls", Group)
     return command(name, **attrs)
 
+def section(name=None, **attrs):
+    """Creates a new :class:`Section` with a function as callback.  This
+    works otherwise the same as :func:`command` just that the `cls`
+    parameter is set to :class:`Group`.
+    """
+    attrs.setdefault("cls", Section)
+    return command(name, **attrs)
 
 def _param_memo(f, param):
     if isinstance(f, Command):


### PR DESCRIPTION
I've added the section concept to fill a hole I had using click on my tool. 
I needed two related things:
- the ability to group in the help command related to each other
```
Usage: section.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  btest1  Command btest1
  btest2  Command btest2
  btest3  Command btest3
  test    Command test

Management Commands:
  atest1  Command test1
  atest2  Command test2
  atest3  Command test3
```
- enable chaining for a subset of commands only (in the previous example 'Commands' can be chained but not 'Management Commands')

Here is a test I used to check everything is okay:
```
import click

@click.group()
def cli(**kwargs):
    print("cli", kwargs)


@cli.section("Commands", chain=True)
@click.pass_context
def commands(ctx, **kwargs):
    pass

@commands.command(name='btest1', help='Command btest1')
@click.argument('name')
@click.pass_context
def btest1(ctx, name, **kwargs):
    print("btest1", name)

@commands.command(name='btest2', help='Command btest2')
@click.option('-v', help='Activate verbose/debug mode', is_flag=True, multiple=True)
@click.pass_context
def btest2(ctx, v, **kwargs):
    print("btest2", v)

@commands.command(name='btest3', help='Command btest3')
@click.pass_context
def btest3(ctx, **kwargs):
    print("btest3")



@cli.command(help='Command test')
@click.pass_context
def test(ctx, **kwargs):
    print("test")

@cli.section("Management Commands")
@click.pass_context
def management(ctx, **kwargs):
    print("management")

@management.command(help='Command test1')
@click.pass_context
def atest1(ctx, **kwargs):
    print("atest1")

@management.command(help='Command test2')
@click.option('-v', help='Activate verbose/debug mode', is_flag=True, multiple=True)
@click.pass_context
def atest2(ctx, **kwargs):
    print("atest2")

@management.command(help='Command test3')
@click.pass_context
def atest3(ctx, **kwargs):
    print("atest3")


if __name__ == '__main__':
    cli()

```

If you're okay with the idea I can push forward to provide unit tests and do a full working job.
I made a very few modifications and it should not be difficult to be fully backward compatible with current click behaviour.
