### PR TITLE
tolerate UnsupportedOperation in _winconsole._is_console()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Unreleased
     :issue:`1525`
 -   An option defined with duplicate flag names (``"--foo/--foo"``)
     raises a ``ValueError``. :issue:`1465`
+-   ``echo()`` will not fail when using pytest's ``capsys`` fixture on
+    Windows. :issue:`1590`
 
 
 Version 7.1.2

--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -284,7 +284,7 @@ def _is_console(f):
 
     try:
         fileno = f.fileno()
-    except OSError:
+    except (OSError, io.UnsupportedOperation):
         return False
 
     handle = msvcrt.get_osfhandle(fileno)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,6 +261,12 @@ def test_echo_writing_to_standard_error(capfd, monkeypatch):
     assert err == "Pause to stderr\n"
 
 
+def test_echo_with_capsys(capsys):
+    click.echo("Capture me.")
+    out, err = capsys.readouterr()
+    assert out == "Capture me.\n"
+
+
 def test_open_file(runner):
     @click.command()
     @click.argument("filename")


### PR DESCRIPTION
Details:

* On Windows, calling 'f.fileno()' in '_winconsole._is_console()' may raise
  UnsupportedOperation, for example when the pytest 'capsys' fixture is used
  which captures stdout for testing purposes.
  This change tolerates that exception and treats it as False.

* Added a testcase test_echo_with_capsys() where the output of click.echo()
   is captured using the pytest capsys fixture.

fixes #1590