### PR TITLE
raise ValueError for duplicate flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     is not shown in the error message. :issue:`1460`
 -   An ``IntRange`` option shows the accepted range in its help text.
     :issue:`1525`
+-   An option defined with duplicate flag names (``"--foo/--foo"``)
+    raises a ``ValueError``. :issue:`1465`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1840,6 +1840,11 @@ class Option(Parameter):
                     second = second.lstrip()
                     if second:
                         secondary_opts.append(second.lstrip())
+                    if first == second:
+                        raise ValueError(
+                            f"Boolean option {decl!r} cannot use the"
+                            " same flag for true/false."
+                        )
                 else:
                     possible_names.append(split_opt(decl))
                     opts.append(decl)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -565,3 +565,8 @@ def test_option_names(runner, option_args, expected):
         if form.startswith("-"):
             result = runner.invoke(cmd, [form])
             assert result.output == "True\n"
+
+
+def test_flag_duplicate_names(runner):
+    with pytest.raises(ValueError, match="cannot use the same flag for true/false"):
+        click.Option(["--foo/--foo"], default=False)


### PR DESCRIPTION
Specifying the same flag name twice will raise a `RuntimeError`.

```python
@click.option( "--foo/--foo", default=False)
```

fixes #1465 