### PR TITLE
7.x fix completion for sub-command names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: click
 
+Version 7.2
+-----------
+
+-   Include ``--help`` option in completion. :pr:`1504`
+
+
 Version 7.1.2
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,17 @@
 .. currentmodule:: click
 
+Version 7.1.2
+-------------
+
+Released 2020-04-27
+
+-   Revert applying shell quoting to commands for ``echo_with_pager``
+    and ``edit``. This was intended to allows spaces in commands, but
+    caused issues if the string was actually a command and arguments, or
+    on Windows. Instead, the string must be quoted manually as it should
+    appear on the command line. :issue:`1514`
+
+
 Version 7.1.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ Released 2020-03-09
 -   Make the warning about old 2-arg parameter callbacks a deprecation
     warning, to be removed in 8.0. This has been a warning since Click
     2.0. :pr:`1492`
+-   Adjust error messages to standardize the types of quotes used so
+    they match error messages from Python.
 
 
 Version 7.0

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -76,4 +76,4 @@ from .utils import open_file
 # literals.
 disable_unicode_literals_warning = False
 
-__version__ = "7.1.1"
+__version__ = "7.1.2"

--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -297,7 +297,7 @@ def get_choices(cli, prog_name, args, incomplete):
     completions = []
     if not has_double_dash and start_of_option(incomplete):
         # completions for partial options
-        for param in ctx.command.params:
+        for param in ctx.command.get_params(ctx):
             if isinstance(param, Option) and not param.hidden:
                 param_opts = [
                     param_opt
@@ -309,11 +309,11 @@ def get_choices(cli, prog_name, args, incomplete):
                 )
         return completions
     # completion for option values from user supplied values
-    for param in ctx.command.params:
+    for param in ctx.command.get_params(ctx):
         if is_incomplete_option(all_args, param):
             return get_user_autocompletions(ctx, all_args, incomplete, param)
     # completion for argument values from user supplied values
-    for param in ctx.command.params:
+    for param in ctx.command.get_params(ctx):
         if is_incomplete_argument(ctx.params, param):
             return get_user_autocompletions(ctx, all_args, incomplete, param)
 

--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -237,11 +237,11 @@ def get_visible_commands_starting_with(ctx, starts_with):
     :starts_with: string that visible commands must start with.
     :return: all visible (not hidden) commands that start with starts_with.
     """
-    for c in ctx.command.list_commands(ctx):
-        if c.startswith(starts_with):
-            command = ctx.command.get_command(ctx, c)
+    for name in ctx.command.list_commands(ctx):
+        if name.startswith(starts_with):
+            command = ctx.command.get_command(ctx, name)
             if not command.hidden:
-                yield command
+                yield name, command
 
 
 def add_subcommand_completions(ctx, incomplete, completions_out):
@@ -249,8 +249,8 @@ def add_subcommand_completions(ctx, incomplete, completions_out):
     if isinstance(ctx.command, MultiCommand):
         completions_out.extend(
             [
-                (c.name, c.get_short_help_str())
-                for c in get_visible_commands_starting_with(ctx, incomplete)
+                (name, command.get_short_help_str())
+                for name, command in get_visible_commands_starting_with(ctx, incomplete)
             ]
         )
 
@@ -260,12 +260,15 @@ def add_subcommand_completions(ctx, incomplete, completions_out):
         ctx = ctx.parent
         if isinstance(ctx.command, MultiCommand) and ctx.command.chain:
             remaining_commands = [
-                c
-                for c in get_visible_commands_starting_with(ctx, incomplete)
-                if c.name not in ctx.protected_args
+                (name, command)
+                for name, command in get_visible_commands_starting_with(ctx, incomplete)
+                if name not in ctx.protected_args
             ]
             completions_out.extend(
-                [(c.name, c.get_short_help_str()) for c in remaining_commands]
+                [
+                    (name, command.get_short_help_str())
+                    for name, command in remaining_commands
+                ]
             )
 
 

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -20,7 +20,7 @@ def test_single_command():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--local-opt"]
+    assert choices_without_help(cli, [], "-") == ["--local-opt", "--help"]
     assert choices_without_help(cli, [], "") == []
 
 
@@ -30,7 +30,7 @@ def test_boolean_flag():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout"]
+    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout", "--help"]
 
 
 def test_multi_value_option():
@@ -44,7 +44,7 @@ def test_multi_value_option():
     def sub(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--pos"]
+    assert choices_without_help(cli, [], "-") == ["--pos", "--help"]
     assert choices_without_help(cli, ["--pos"], "") == []
     assert choices_without_help(cli, ["--pos", "1.0"], "") == []
     assert choices_without_help(cli, ["--pos", "1.0", "1.0"], "") == ["sub"]
@@ -56,7 +56,7 @@ def test_multi_option():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--message", "-m"]
+    assert choices_without_help(cli, [], "-") == ["--message", "-m", "--help"]
     assert choices_without_help(cli, ["-m"], "") == []
 
 
@@ -72,9 +72,9 @@ def test_small_chain():
         pass
 
     assert choices_without_help(cli, [], "") == ["sub"]
-    assert choices_without_help(cli, [], "-") == ["--global-opt"]
+    assert choices_without_help(cli, [], "-") == ["--global-opt", "--help"]
     assert choices_without_help(cli, ["sub"], "") == []
-    assert choices_without_help(cli, ["sub"], "-") == ["--local-opt"]
+    assert choices_without_help(cli, ["sub"], "-") == ["--local-opt", "--help"]
 
 
 def test_long_chain():
@@ -116,16 +116,17 @@ def test_long_chain():
     def csub(csub_opt, color):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--cli-opt"]
+    assert choices_without_help(cli, [], "-") == ["--cli-opt", "--help"]
     assert choices_without_help(cli, [], "") == ["asub"]
-    assert choices_without_help(cli, ["asub"], "-") == ["--asub-opt"]
+    assert choices_without_help(cli, ["asub"], "-") == ["--asub-opt", "--help"]
     assert choices_without_help(cli, ["asub"], "") == ["bsub"]
-    assert choices_without_help(cli, ["asub", "bsub"], "-") == ["--bsub-opt"]
+    assert choices_without_help(cli, ["asub", "bsub"], "-") == ["--bsub-opt", "--help"]
     assert choices_without_help(cli, ["asub", "bsub"], "") == ["csub"]
     assert choices_without_help(cli, ["asub", "bsub", "csub"], "-") == [
         "--csub-opt",
         "--csub",
         "--search-color",
+        "--help",
     ]
     assert (
         choices_without_help(cli, ["asub", "bsub", "csub", "--csub-opt"], "")
@@ -173,16 +174,22 @@ def test_chaining():
     def csub(csub_opt, arg):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--cli-opt"]
+    assert choices_without_help(cli, [], "-") == ["--cli-opt", "--help"]
     assert choices_without_help(cli, [], "") == ["cliarg1", "cliarg2"]
-    assert choices_without_help(cli, ["cliarg1", "asub"], "-") == ["--asub-opt"]
+    assert choices_without_help(cli, ["cliarg1", "asub"], "-") == [
+        "--asub-opt",
+        "--help",
+    ]
     assert choices_without_help(cli, ["cliarg1", "asub"], "") == ["bsub", "csub"]
     assert choices_without_help(cli, ["cliarg1", "bsub"], "") == ["arg1", "arg2"]
     assert choices_without_help(cli, ["cliarg1", "asub", "--asub-opt"], "") == []
     assert choices_without_help(
         cli, ["cliarg1", "asub", "--asub-opt", "5", "bsub"], "-"
-    ) == ["--bsub-opt"]
-    assert choices_without_help(cli, ["cliarg1", "asub", "bsub"], "-") == ["--bsub-opt"]
+    ) == ["--bsub-opt", "--help"]
+    assert choices_without_help(cli, ["cliarg1", "asub", "bsub"], "-") == [
+        "--bsub-opt",
+        "--help",
+    ]
     assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "") == [
         "carg1",
         "carg2",
@@ -191,7 +198,10 @@ def test_chaining():
         "carg1",
         "carg2",
     ]
-    assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "-") == ["--csub-opt"]
+    assert choices_without_help(cli, ["cliarg1", "asub", "csub"], "-") == [
+        "--csub-opt",
+        "--help",
+    ]
     assert choices_with_help(cli, ["cliarg1", "asub"], "b") == [("bsub", "bsub help")]
 
 
@@ -222,6 +232,7 @@ def test_option_choice():
         ("--opt1", "opt1 help"),
         ("--opt2", None),
         ("--opt3", None),
+        ("--help", "Show this message and exit."),
     ]
     assert choices_without_help(cli, [], "--opt") == ["--opt1", "--opt2", "--opt3"]
     assert choices_without_help(cli, [], "--opt1=") == ["opt11", "opt12"]
@@ -234,14 +245,23 @@ def test_option_choice():
         "opt21",
         "opt22",
     ]
-    assert choices_without_help(cli, ["--opt2", "opt21"], "-") == ["--opt1", "--opt3"]
-    assert choices_without_help(cli, ["--opt1", "opt11"], "-") == ["--opt2", "--opt3"]
+    assert choices_without_help(cli, ["--opt2", "opt21"], "-") == [
+        "--opt1",
+        "--opt3",
+        "--help",
+    ]
+    assert choices_without_help(cli, ["--opt1", "opt11"], "-") == [
+        "--opt2",
+        "--opt3",
+        "--help",
+    ]
     assert choices_without_help(cli, ["--opt1"], "opt") == ["opt11", "opt12"]
     assert choices_without_help(cli, ["--opt3"], "opti") == ["option"]
 
     assert choices_without_help(cli, ["--opt1", "invalid_opt"], "-") == [
         "--opt2",
         "--opt3",
+        "--help",
     ]
 
 
@@ -268,7 +288,7 @@ def test_boolean_flag_choice():
     def cli(local_opt):
         pass
 
-    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout"]
+    assert choices_without_help(cli, [], "-") == ["--shout", "--no-shout", "--help"]
     assert choices_without_help(cli, ["--shout"], "") == ["arg1", "arg2"]
 
 
@@ -382,7 +402,7 @@ def test_long_chain_choice():
     ]
     assert choices_without_help(
         cli, ["sub", "--sub-opt", "subopt1", "subarg1", "bsub"], "-"
-    ) == ["--bsub-opt"]
+    ) == ["--bsub-opt", "--help"]
     assert choices_without_help(
         cli, ["sub", "--sub-opt", "subopt1", "subarg1", "bsub"], ""
     ) == ["bsubarg1", "bsubarg2"]
@@ -472,14 +492,14 @@ def test_hidden():
     assert choices_without_help(cli, [], "h") == []
     # If the user exactly types out the hidden command, complete its subcommands.
     assert choices_without_help(cli, ["hgroup"], "") == ["hgroupsub"]
-    assert choices_without_help(cli, ["hsub"], "--h") == ["--hname"]
+    assert choices_without_help(cli, ["hsub"], "--h") == ["--hname", "--help"]
 
 
 @pytest.mark.parametrize(
     ("args", "part", "expect"),
     [
-        ([], "-", ["--opt"]),
-        (["value"], "--", ["--opt"]),
+        ([], "-", ["--opt", "--help"]),
+        (["value"], "--", ["--opt", "--help"]),
         ([], "-o", []),
         (["--opt"], "-o", []),
         (["--"], "", ["name", "-o", "--opt", "--"]),

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -518,3 +518,38 @@ def test_args_with_double_dash_complete(args, part, expect):
         pass
 
     assert choices_without_help(cli, args, part) == expect
+
+
+def test_subcommand_name():
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()  # use autodetected name
+    def asub():
+        pass
+
+    cli.add_command(asub, name="bsub")  # use manual name override
+
+    @click.command()  # autodetect name
+    def csub():
+        pass
+
+    cli.add_command(csub)  # use autodetected name
+    cli.add_command(csub, name="dsub")  # use manual name override
+
+    @cli.command(name="esub")  # manual name
+    def zsub():
+        pass
+
+    cli.add_command(zsub)  # use manual name
+    cli.add_command(zsub, name="fsub")  # use manual name override
+
+    assert choices_with_help(cli, [""], "") == [
+        ("asub", ""),
+        ("bsub", ""),
+        ("csub", ""),
+        ("dsub", ""),
+        ("esub", ""),
+        ("fsub", ""),
+    ]


### PR DESCRIPTION
shell completion for subcommands with custom names is broken.
here is a test and a fix.

its imply #1529 cherry-picked to the 7.x maintenance branch