### PR TITLE
7.x fix completion for sub-command names

### DIFF
--- a/src/click/_bashcomplete.py
+++ b/src/click/_bashcomplete.py
@@ -237,11 +237,11 @@ def get_visible_commands_starting_with(ctx, starts_with):
     :starts_with: string that visible commands must start with.
     :return: all visible (not hidden) commands that start with starts_with.
     """
-    for c in ctx.command.list_commands(ctx):
-        if c.startswith(starts_with):
-            command = ctx.command.get_command(ctx, c)
+    for name in ctx.command.list_commands(ctx):
+        if name.startswith(starts_with):
+            command = ctx.command.get_command(ctx, name)
             if not command.hidden:
-                yield command
+                yield name, command
 
 
 def add_subcommand_completions(ctx, incomplete, completions_out):
@@ -249,8 +249,8 @@ def add_subcommand_completions(ctx, incomplete, completions_out):
     if isinstance(ctx.command, MultiCommand):
         completions_out.extend(
             [
-                (c.name, c.get_short_help_str())
-                for c in get_visible_commands_starting_with(ctx, incomplete)
+                (name, command.get_short_help_str())
+                for name, command in get_visible_commands_starting_with(ctx, incomplete)
             ]
         )
 
@@ -260,12 +260,15 @@ def add_subcommand_completions(ctx, incomplete, completions_out):
         ctx = ctx.parent
         if isinstance(ctx.command, MultiCommand) and ctx.command.chain:
             remaining_commands = [
-                c
-                for c in get_visible_commands_starting_with(ctx, incomplete)
-                if c.name not in ctx.protected_args
+                (name, command)
+                for name, command in get_visible_commands_starting_with(ctx, incomplete)
+                if name not in ctx.protected_args
             ]
             completions_out.extend(
-                [(c.name, c.get_short_help_str()) for c in remaining_commands]
+                [
+                    (name, command.get_short_help_str())
+                    for name, command in remaining_commands
+                ]
             )
 
 

--- a/tests/test_bashcomplete.py
+++ b/tests/test_bashcomplete.py
@@ -518,3 +518,38 @@ def test_args_with_double_dash_complete(args, part, expect):
         pass
 
     assert choices_without_help(cli, args, part) == expect
+
+
+def test_subcommand_name():
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()  # use autodetected name
+    def asub():
+        pass
+
+    cli.add_command(asub, name="bsub")  # use manual name override
+
+    @click.command()  # autodetect name
+    def csub():
+        pass
+
+    cli.add_command(csub)  # use autodetected name
+    cli.add_command(csub, name="dsub")  # use manual name override
+
+    @cli.command(name="esub")  # manual name
+    def zsub():
+        pass
+
+    cli.add_command(zsub)  # use manual name
+    cli.add_command(zsub, name="fsub")  # use manual name override
+
+    assert choices_with_help(cli, [""], "") == [
+        ("asub", ""),
+        ("bsub", ""),
+        ("csub", ""),
+        ("dsub", ""),
+        ("esub", ""),
+        ("fsub", ""),
+    ]


### PR DESCRIPTION
shell completion for subcommands with custom names is broken.
here is a test and a fix.

this is the same as #1529 but for the 7.x maintenance branch. changes were cherry-picked from #1529.