### PR TITLE
nargs=-1 works with envvar 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Unreleased
 -   The ``BOOL`` type accepts the values "on" and "off". :issue:`1629`
 -   A ``Group`` with ``invoke_without_command=True`` will always invoke
     its result callback. :issue:`1178`
+-   ``nargs == -1`` and ``nargs > 1`` is parsed and validated for
+    values from environment variables and defaults. :issue:`729`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1624,11 +1624,25 @@ class Parameter:
 
         if value is None and not ctx.resilient_parsing:
             value = self.get_default(ctx)
+
             if value is not None:
                 ctx.set_parameter_source(self.name, ParameterSource.DEFAULT)
 
         if self.required and self.value_is_missing(value):
             raise MissingParameter(ctx=ctx, param=self)
+
+        # For bounded nargs (!= -1), validate the number of values.
+        if (
+            not ctx.resilient_parsing
+            and self.nargs > 1
+            and self.nargs != len(value)
+            and isinstance(value, (tuple, list))
+        ):
+            were = "was" if len(value) == 1 else "were"
+            ctx.fail(
+                f"Argument {self.name!r} takes {self.nargs} values but"
+                f" {len(value)} {were} given."
+            )
 
         return value
 

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -183,6 +183,10 @@ class Argument:
                 raise BadArgumentUsage(
                     f"argument {self.dest} takes {self.nargs} values"
                 )
+
+        if self.nargs == -1 and self.obj.envvar is not None:
+            value = None
+
         state.opts[self.dest] = value
         state.order.append(self.obj)
 


### PR DESCRIPTION
This PR aims to fix two bugs:

1. Initially combining `nargs=-1` and `envvar` would yield an empty tuple where the expected behaviour of `nargs=-1` is to take on an unlimited number of arguments passed in `envvar`. @amy-lei and I added a fix so that now combining `nargs=-1` with `envvar` should output all the expected values from envvar rather than an empty tuple.

2. We also added error catching for nargs > len(envvar) where we would raise: `Got unexpected extra arguments` and when nargs < len(envvar) we would raise: `argument [argname] takes [nargs] values`.

The changelog is also updated with our new changes. Let us know what you think @davidism!

fixes #729