### PR TITLE
include mandatory parent arguments in help synposis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Unreleased
     values from environment variables and defaults. :issue:`729`
 -   Detect the program name when executing a module or package with
     ``python -m name``. :issue:`1603`
+-   Include required parent arguments in help synopsis of subcommands.
+    :issue:`1475`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -508,7 +508,10 @@ class Context:
         if self.info_name is not None:
             rv = self.info_name
         if self.parent is not None:
-            rv = f"{self.parent.command_path} {rv}"
+            parent_command_path = [self.parent.command_path]
+            for param in self.parent.command.get_params(self):
+                parent_command_path.extend(param.get_usage_pieces(self))
+            rv = f"{' '.join(parent_command_path)} {rv}"
         return rv.lstrip()
 
     def find_root(self):


### PR DESCRIPTION
Help synopsis of subcommands now include parent's required arguments
example:
```
Usage: cmd ARG subcmd [OPTIONS]
```
fixes #1475 


