### PR TITLE
Show full subcommand names when using --help in aliasedgroup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@ Unreleased
     raises a ``ValueError``. :issue:`1465`
 -   ``echo()`` will not fail when using pytest's ``capsys`` fixture on
     Windows. :issue:`1590`
+-   Resolving commands returns the canonical command name instead of the
+    matched name. This makes behavior such as help text and
+    ``Context.invoked_subcommand`` consistent when using patterns like
+    ``AliasedGroup``. :issue:`1422`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1346,7 +1346,7 @@ class MultiCommand(Command):
                 self.parse_args(ctx, ctx.args)
             ctx.fail(f"No such command '{original_cmd_name}'.")
 
-        return cmd_name, cmd, args[1:]
+        return cmd.name, cmd, args[1:]
 
     def get_command(self, ctx, cmd_name):
         """Given a context and a command name, this returns a

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -258,6 +258,22 @@ def test_invoked_subcommand(runner):
     assert result.output == "no subcommand, use default\nin subcommand\n"
 
 
+def test_aliased_command_canonical_name(runner):
+    class AliasedGroup(click.Group):
+        def get_command(self, ctx, cmd_name):
+            return push
+
+    cli = AliasedGroup()
+
+    @cli.command()
+    def push():
+        click.echo("push command")
+
+    result = runner.invoke(cli, ["pu", "--help"])
+    assert not result.exception
+    assert result.output.startswith("Usage: root push [OPTIONS]")
+
+
 def test_unprocessed_options(runner):
     @click.command(context_settings=dict(ignore_unknown_options=True))
     @click.argument("args", nargs=-1, type=click.UNPROCESSED)


### PR DESCRIPTION
Fixes #1422 