### PR TITLE
option without value can prompt or use default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,13 @@ Unreleased
 -   ``Parameter.get_default()`` checks ``Context.default_map`` to
     handle overrides consistently in help text, ``invoke()``, and
     prompts. :issue:`1548`
+-   Add ``prompt_required`` param to ``Option``. When set to ``False``,
+    the user will only be prompted for an input if no value was passed.
+    :issue:`736`
+-   Providing the value to an option can be made optional through
+    ``is_flag=False``, and the value can instead be prompted for or
+    passed in as a default value.
+    :issue:`549, 736, 764, 921, 1015, 1618`
 
 
 Version 7.1.2

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -433,6 +433,10 @@ What it looks like:
 It is advised that prompt not be used in conjunction with the multiple
 flag set to True. Instead, prompt in the function interactively.
 
+By default, the user will be prompted for an input if one was not passed
+through the command line. To turn this behavior off, see
+:ref:`optional-value`.
+
 
 Password Prompts
 ----------------
@@ -845,3 +849,50 @@ And what it looks like:
     invoke(roll, args=['--rolls=42'])
     println()
     invoke(roll, args=['--rolls=2d12'])
+
+
+.. _optional-value:
+
+Optional Value
+--------------
+
+Providing the value to an option can be made optional, in which case
+providing only the option's flag without a value will either show a
+prompt or use its ``flag_value``.
+
+Setting ``is_flag=False, flag_value=value`` tells Click that the option
+can still be passed a value, but if only the flag is given the
+``flag_value`` is used.
+
+.. click:example::
+
+    @click.command()
+    @click.option("--name", is_flag=False, flag_value="Flag", default="Default")
+    def hello(name):
+        click.echo(f"Hello, {name}!")
+
+.. click:run::
+
+    invoke(hello, args=[])
+    invoke(hello, args=["--name", "Value"])
+    invoke(hello, args=["--name"])
+
+If the option has ``prompt`` enabled, then setting
+``prompt_required=False`` tells Click to only show the prompt if the
+option's flag is given, instead of if the option is not provided at all.
+
+.. click:example::
+
+    @click.command()
+    @click.option('--name', prompt=True, prompt_required=False, default="Default")
+    def hello(name):
+        click.echo(f"Hello {name}!")
+
+.. click:run::
+
+    invoke(hello)
+    invoke(hello, args=["--name", "Value"])
+    invoke(hello, args=["--name"], input="Prompt")
+
+If ``required=True``, then the option will still prompt if it is not
+given, but it will also prompt if only the flag is given.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -658,3 +658,34 @@ def test_show_default_boolean_flag_value(runner):
     ctx = click.Context(click.Command("test"))
     message = opt.get_help_record(ctx)[1]
     assert "[default: False]" in message
+
+
+@pytest.mark.parametrize(
+    ("args", "expect"),
+    [
+        (None, (None, None, ())),
+        (["--opt"], ("flag", None, ())),
+        (["--opt", "-a", 42], ("flag", "42", ())),
+        (["--opt", "test", "-a", 42], ("test", "42", ())),
+        (["--opt=test", "-a", 42], ("test", "42", ())),
+        (["-o"], ("flag", None, ())),
+        (["-o", "-a", 42], ("flag", "42", ())),
+        (["-o", "test", "-a", 42], ("test", "42", ())),
+        (["-otest", "-a", 42], ("test", "42", ())),
+        (["a", "b", "c"], (None, None, ("a", "b", "c"))),
+        (["--opt", "a", "b", "c"], ("a", None, ("b", "c"))),
+        (["--opt", "test"], ("test", None, ())),
+        (["-otest", "a", "b", "c"], ("test", None, ("a", "b", "c"))),
+        (["--opt=test", "a", "b", "c"], ("test", None, ("a", "b", "c"))),
+    ],
+)
+def test_option_with_optional_value(runner, args, expect):
+    @click.command()
+    @click.option("-o", "--opt", is_flag=False, flag_value="flag")
+    @click.option("-a")
+    @click.argument("b", nargs=-1)
+    def cli(opt, a, b):
+        return opt, a, b
+
+    result = runner.invoke(cli, args, standalone_mode=False, catch_exceptions=False)
+    assert result.return_value == expect


### PR DESCRIPTION
Resolves #549 
Resolves #736
Resolves #764 
Resolves #921 
Resolves #1015 

Add `prompt_required` attribute to `Option` so that when `prompt_required=False`, the user will only be prompted for an input if the option is specified without a value. The attribute defaults to `True` to maintain the current behavior of option prompts.

`is_flag=False` now means that providing the value to the option is optional. If the flag is provided without the value, it can be prompted for or use `flag_value`.