### PR TITLE
Upgrade GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,15 +1,21 @@
-**This issue tracker is a tool to address bugs in Click itself.
+---
+name: Bug report
+about: Report a bug in Click (not other projects which depend on Click)
+---
+
+<!--
+This issue tracker is a tool to address bugs in Click itself.
 Please use the #pocoo IRC channel on freenode, the Discord server or
 Stack Overflow for general questions about using Flask or issues
-not related to Click.**
+not related to Click.
 
 If you'd like to report a bug in Click, fill out the template below. Provide
 any extra information that may be useful / related to your problem.
 Ideally, create an [MCVE](https://stackoverflow.com/help/mcve), which helps us
 understand the problem and helps check that it is not caused by something in
 your code.
+-->
 
----
 
 ### Expected Behavior
 

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: security@palletsprojects.com
+    about: Do not report security issues publicly. Email our security contact.
+  - name: Questions
+    url: https://stackoverflow.com/questions/tagged/python-click?tab=Frequent
+    about: Search for and ask questions about your code on Stack Overflow.
+  - name: Questions and discussions
+    url: https://discord.gg/pallets
+    about: Discuss questions about your code on our Discord chat.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest a new feature for Click
+---
+
+<!--
+Replace this comment with a description of what the feature should do.
+Include details such as links relevant specs or previous discussions.
+-->
+
+<!--
+Replace this comment with an example of the problem which this feature
+would resolve. Is this problem solvable without changes to Click,
+such as by subclassing or using an extension?
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+
+<!--
+Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.
+Replace this comment with a description of the change. Describe how it addresses the linked ticket.
+-->
+
+<!--
+Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
+-->
+
+- Fixes #<issue number>
+
+<!--
+Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.
+If only docs were changed, these aren't relevant and can be removed.
+-->
+
+Checklist:
+
+- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
+- [ ] Add or update relevant docs, in the docs folder and in code.
+- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
+- [ ] Add `.. versionchanged::` entries in any relevant code docs.
+- [ ] Run `pre-commit` hooks and fix any issues.
+- [ ] Run `pytest` and `tox`, no tests failed.


### PR DESCRIPTION
Was looking through issues and realized Click could use the new github issue templates. These are adapted from werkzeug.