### PR TITLE
Added Date ParamType

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ Unreleased
     information about the object's structure that could be useful for a
     tool generating user-facing documentation. To get the structure of
     an entire CLI, use ``Context(cli).to_info_dict()``. :issue:`461`
+-   Add ``Date`` type for converting input in given date  formats.
+    :pr:``
 
 
 Version 7.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,7 +91,7 @@ Unreleased
     tool generating user-facing documentation. To get the structure of
     an entire CLI, use ``Context(cli).to_info_dict()``. :issue:`461`
 -   Add ``Date`` type for converting input in given date  formats.
-    :pr:``
+    :pr:`1656`
 
 
 Version 7.1.2

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -74,6 +74,9 @@ different behavior and some are supported out of the box:
 .. autoclass:: DateTime
    :noindex:
 
+.. autoclass:: Date
+   :noindex:
+
 Custom parameter types can be implemented by subclassing
 :class:`click.ParamType`.  For simple cases, passing a Python function that
 fails with a `ValueError` is also supported, though discouraged.

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -52,6 +52,7 @@ from .termui import style
 from .termui import unstyle
 from .types import BOOL
 from .types import Choice
+from .types import Date
 from .types import DateTime
 from .types import File
 from .types import FLOAT

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -305,6 +305,60 @@ class DateTime(ParamType):
         return "DateTime"
 
 
+class Date(ParamType):
+    """The Date type converts date strings into `datetime.date` objects.
+
+    The format strings which are checked are configurable, but default to some
+    common (non-timezone aware) ISO 8601 formats.
+
+    When specifying *Date* formats, you should only pass a list or a tuple.
+    Other iterables, like generators, may lead to surprising results.
+
+    The format strings are processed using ``datetime.strptime``, and this
+    consequently defines the format strings which are allowed.
+
+    Parsing is tried using each format, in order, and the first format which
+    parses successfully is used.
+
+    :param formats: A list or tuple of date format strings, in the order in
+                    which they should be tried. Defaults to
+                    ``'%Y-%m-%d'``.
+    """
+    name = 'date'
+
+    def __init__(self, formats=None):
+        self.formats = formats or [
+            '%Y-%m-%d',
+        ]
+
+    def to_info_dict(self):
+        info_dict = super().to_info_dict()
+        info_dict["formats"] = self.formats
+        return info_dict
+
+    def get_metavar(self, param):
+        return f"[{'|'.join(self.formats)}]"
+
+    def _try_to_convert_date(self, value, format):
+        try:
+            return datetime.strptime(value, format).date()
+        except ValueError:
+            return None
+
+    def convert(self, value, param, ctx):
+        for format in self.formats:
+            date = self._try_to_convert_date(value, format)
+            if date:
+                return date
+
+        self.fail(
+            f"invalid date format: {value}. (choose from {', '.join(self.formats)})"
+        )
+
+    def __repr__(self):
+        return 'Date'
+
+
 class _NumberParamTypeBase(ParamType):
     _number_class = None
 

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -324,11 +324,12 @@ class Date(ParamType):
                     which they should be tried. Defaults to
                     ``'%Y-%m-%d'``.
     """
-    name = 'date'
+
+    name = "date"
 
     def __init__(self, formats=None):
         self.formats = formats or [
-            '%Y-%m-%d',
+            "%Y-%m-%d",
         ]
 
     def to_info_dict(self):
@@ -356,7 +357,7 @@ class Date(ParamType):
         )
 
     def __repr__(self):
-        return 'Date'
+        return "Date"
 
 
 class _NumberParamTypeBase(ParamType):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -436,6 +436,41 @@ def test_datetime_option_custom(runner):
     assert result.output == "2010-06-05T00:00:00\n"
 
 
+def test_date_option_default(runner):
+    @click.command()
+    @click.option("--start_date", type=click.Date())
+    def cli(start_date):
+        click.echo(start_date.strftime("%Y-%m-%d"))
+
+    result = runner.invoke(cli, ["--start_date=2015-09-29"])
+    assert not result.exception
+    assert result.output == "2015-09-29\n"
+
+    result = runner.invoke(cli, ["--start_date=2015-09"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '--start_date':"
+        " invalid date format: 2015-09."
+        " (choose from %Y-%m-%d)"
+    ) in result.output
+
+    result = runner.invoke(cli, ["--help"])
+    assert (
+        "--start_date [%Y-%m-%d]" in result.output
+    )
+
+
+def test_date_option_custom(runner):
+    @click.command()
+    @click.option("--start_date", type=click.Date(formats=["%A %B %d, %Y"]))
+    def cli(start_date):
+        click.echo(start_date.strftime("%Y-%m-%d"))
+
+    result = runner.invoke(cli, ["--start_date=Wednesday June 05, 2010"])
+    assert not result.exception
+    assert result.output == "2010-06-05\n"
+
+
 def test_required_option(runner):
     @click.command()
     @click.option("--foo", required=True)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -455,9 +455,7 @@ def test_date_option_default(runner):
     ) in result.output
 
     result = runner.invoke(cli, ["--help"])
-    assert (
-        "--start_date [%Y-%m-%d]" in result.output
-    )
+    assert "--start_date [%Y-%m-%d]" in result.output
 
 
 def test_date_option_custom(runner):


### PR DESCRIPTION
Fixes #1655 by adding a date parameter type

Related links:
#44
#423 
#603
#1093 
#1099 
https://github.com/click-contrib/click-datetime

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
