### PR TITLE
Fixed a copy-paste typo in autocomplete

### DIFF
--- a/docs/bashcomplete.rst
+++ b/docs/bashcomplete.rst
@@ -147,7 +147,7 @@ For Fish:
 
 .. code-block:: text
 
-    _FOO_BAR_COMPLETE=source_zsh foo-bar > foo-bar-complete.sh
+    _FOO_BAR_COMPLETE=source_fish foo-bar > foo-bar-complete.fish
 
 In ``.bashrc`` or ``.zshrc``, source the script instead of the ``eval``
 command:


### PR DESCRIPTION
One line had `source_zsh` instead of `source_fish`.
Not sure if these apply to typo fixes.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
