### PR TITLE
Integrate alias feature into core

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1185,7 +1185,7 @@ class Command(BaseCommand):
                 formatter.write_text(DEPRECATED_HELP_NOTICE)
 
     def format_aliases(self, ctx, formatter):
-        """Writes the aliases to the formatter it any."""
+        """Writes the aliases to the formatter if any."""
         if self.alias:
             with formatter.section("Aliases"):
                 formatter.write_text(", ".join([self.name, self.alias]))

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -982,8 +982,6 @@ class Command(BaseCommand):
        Added repr showing the command name
     .. versionchanged:: 7.1
        Added the `no_args_is_help` parameter.
-    .. versionchanged:: 7.2
-       Added the `alias` parameter.
 
     :param name: the name of the command to use unless a group overrides it.
     :param context_settings: an optional dictionary with defaults that are

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1556,8 +1556,6 @@ class Group(MultiCommand):
 
         #: The registered subcommands by their exported names.
         self.commands = commands
-        # A dict of aliases for each command of the group
-        self.aliases = {cmd_name: c.alias for cmd_name, c in commands.items()}
 
     def add_command(self, cmd, name=None):
         """Registers another :class:`Command` with this group.  If the name
@@ -1568,8 +1566,6 @@ class Group(MultiCommand):
             raise TypeError("Command has no name.")
         _check_multicommand(self, name, cmd, register=True)
         self.commands[name] = cmd
-        if hasattr(cmd, "alias"):
-            self.aliases[name] = cmd.alias
 
     def command(self, *args, **kwargs):
         """A shortcut decorator for declaring and attaching a command to
@@ -1623,9 +1619,11 @@ class Group(MultiCommand):
         return decorator
 
     def get_command(self, ctx, cmd_name):
-        for cmd, alias in self.aliases.items():
-            if cmd_name == alias:
-                return self.commands.get(cmd)
+        for name in self.commands.keys():
+            cmd = self.commands.get(name)
+            if hasattr(cmd, "alias"):
+                if cmd.alias == cmd_name:
+                    return cmd
         return self.commands.get(cmd_name)
 
     def list_commands(self, ctx):

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1160,11 +1160,13 @@ class Command(BaseCommand):
 
         -   :meth:`format_usage`
         -   :meth:`format_help_text`
+        -   :meth:`format_aliases`
         -   :meth:`format_options`
         -   :meth:`format_epilog`
         """
         self.format_usage(ctx, formatter)
         self.format_help_text(ctx, formatter)
+        self.format_aliases(ctx, formatter)
         self.format_options(ctx, formatter)
         self.format_epilog(ctx, formatter)
 
@@ -1181,6 +1183,12 @@ class Command(BaseCommand):
             formatter.write_paragraph()
             with formatter.indentation():
                 formatter.write_text(DEPRECATED_HELP_NOTICE)
+
+    def format_aliases(self, ctx, formatter):
+        """Writes the aliases to the formatter it any."""
+        if self.alias:
+            with formatter.section("Aliases"):
+                formatter.write_text(", ".join([self.name, self.alias]))
 
     def format_options(self, ctx, formatter):
         """Writes all the options into the formatter if they exist."""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -334,3 +334,22 @@ def test_alias(runner):
     assert "Running list command" in result.output
     assert not result.exception
     assert result.exit_code == 0
+
+
+def test_aliases_in_help(runner):
+    cli = click.Group()
+
+    @cli.command(alias="ls")
+    def list():
+        click.echo("Running list command")
+
+    result = runner.invoke(cli, ["list", "--help"])
+    assert result.output.splitlines() == [
+        "Usage: root list [OPTIONS]",
+        "",
+        "Aliases:",
+        "  list, ls",
+        "",
+        "Options:",
+        "  --help  Show this message and exit.",
+    ]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -353,3 +353,64 @@ def test_aliases_in_help(runner):
         "Options:",
         "  --help  Show this message and exit.",
     ]
+
+
+def test_alias_multi_command(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @click.group(help="Manage lamas", alias="l")
+    def lama():
+        pass
+
+    @lama.command()
+    def list():
+        click.echo("Listing lamas")
+
+    cli.add_command(lama)
+
+    result = runner.invoke(cli, ["lama", "list"])
+
+    assert "Listing lamas" in result.output
+    assert not result.exception
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["l", "list"])
+
+    assert "Listing lamas" in result.output
+    assert not result.exception
+    assert result.exit_code == 0
+
+
+def test_alias_multi_command_help(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @click.group(help="Manage lamas", alias="l")
+    def lama():
+        pass
+
+    @lama.command()
+    def list():
+        click.echo("Listing lamas")
+
+    cli.add_command(lama)
+
+    result = runner.invoke(cli, ["l", "--help"])
+
+    assert result.output.splitlines() == [
+        "Usage: cli lama [OPTIONS] COMMAND [ARGS]...",
+        "",
+        "  Manage lamas",
+        "",
+        "Aliases:",
+        "  lama, l",
+        "",
+        "Options:",
+        "  --help  Show this message and exit.",
+        "",
+        "Commands:",
+        "  list",
+    ]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -314,3 +314,23 @@ def test_deprecated_in_invocation(runner):
 
     result = runner.invoke(deprecated_cmd)
     assert "DeprecationWarning:" in result.output
+
+
+def test_alias(runner):
+    cli = click.Group()
+
+    @cli.command(alias="ls")
+    def list():
+        click.echo("Running list command")
+
+    result = runner.invoke(cli, ["list"])
+
+    assert "Running list command" in result.output
+    assert not result.exception
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["ls"])
+
+    assert "Running list command" in result.output
+    assert not result.exception
+    assert result.exit_code == 0


### PR DESCRIPTION
Proposes a simple implementation for  supporting specifying aliases to commands.

- Fixes #1674

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
