### PR TITLE
pass extra context settings to completion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,6 @@ Unreleased
     parameter. :issue:`1264`, :pr:`1329`
 -   Add an optional parameter to ``ProgressBar.update`` to set the
     ``current_item``. :issue:`1226`, :pr:`1332`
--   Include ``--help`` option in completion. :pr:`1504`
 -   ``version_option`` uses ``importlib.metadata`` (or the
     ``importlib_metadata`` backport) instead of ``pkg_resources``.
     :issue:`1582`
@@ -104,6 +103,10 @@ Unreleased
         all values, and must return a list of strings or a list of
         ``ShellComplete``. The old name and behavior is deprecated and
         will be removed in 8.1.
+
+-   Extra context settings (``obj=...``, etc.) are passed on to the
+    completion system. :issue:`942`
+-   Include ``--help`` option in completion. :pr:`1504`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -950,7 +950,7 @@ class BaseCommand:
             prog_name = _detect_program_name()
 
         # Process shell completion requests and exit early.
-        self._main_shell_completion(prog_name, complete_var)
+        self._main_shell_completion(extra, prog_name, complete_var)
 
         try:
             try:
@@ -1000,7 +1000,7 @@ class BaseCommand:
             echo("Aborted!", file=sys.stderr)
             sys.exit(1)
 
-    def _main_shell_completion(self, prog_name, complete_var=None):
+    def _main_shell_completion(self, ctx_args, prog_name, complete_var=None):
         """Check if the shell is asking for tab completion, process
         that, then exit early. Called from :meth:`main` before the
         program is invoked.
@@ -1020,7 +1020,7 @@ class BaseCommand:
 
         from .shell_completion import shell_complete
 
-        rv = shell_complete(self, prog_name, complete_var, instruction)
+        rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
         _fast_exit(rv)
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
The completion system created a context that ignored any extra context settings passed in like `cli(obj={...}, color=False)`. These are now passed to the completion system, so they're reflected in the context that is built for completion.

fixes #942

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.