### PR TITLE
swap order of completion instruction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,9 @@ Unreleased
         all values, and must return a list of strings or a list of
         ``ShellComplete``. The old name and behavior is deprecated and
         will be removed in 8.1.
+    -   The env var values used to start completion have changed order.
+        The shell now comes first, such as ``{shell}_source`` rather
+        than ``source_{shell}``, and is always required.
 
 -   Extra context settings (``obj=...``, etc.) are passed on to the
     completion system. :issue:`942`

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -21,7 +21,7 @@ def shell_complete(cli, ctx_args, prog_name, complete_var, instruction):
         instruction and shell, in the form ``instruction_shell``.
     :return: Status code to exit with.
     """
-    instruction, _, shell = instruction.partition("_")
+    shell, _, instruction = instruction.partition("_")
     comp_cls = get_completion_class(shell)
 
     if comp_cls is None:
@@ -78,7 +78,7 @@ _SOURCE_BASH = """\
     local response
 
     response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD \
-%(complete_var)s=complete_bash $1)
+%(complete_var)s=bash_complete $1)
 
     for completion in $response; do
         IFS=',' read type value <<< "$completion"
@@ -114,7 +114,7 @@ _SOURCE_ZSH = """\
     (( ! $+commands[%(prog_name)s] )) && return 1
 
     response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) \
-%(complete_var)s=complete_zsh %(prog_name)s)}")
+%(complete_var)s=zsh_complete %(prog_name)s)}")
 
     for type key descr in ${response}; do
         if [[ "$type" == "plain" ]]; then
@@ -146,7 +146,7 @@ _SOURCE_FISH = """\
 function %(complete_func)s;
     set -l response;
 
-    for value in (env %(complete_var)s=complete_fish COMP_WORDS=(commandline -cp) \
+    for value in (env %(complete_var)s=fish_complete COMP_WORDS=(commandline -cp) \
 COMP_CWORD=(commandline -t) %(prog_name)s);
         set response $response $value;
     end;
@@ -184,8 +184,8 @@ class ShellComplete:
 
     name = None
     """Name to register the shell as with :func:`add_completion_class`.
-    This is used in completion instructions (``source_{name}`` and
-    ``complete_{name}``).
+    This is used in completion instructions (``{name}_source`` and
+    ``{name}_complete``).
     """
     source_template = None
     """Completion script template formatted by :meth:`source`. This must

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -254,8 +254,8 @@ def _patch_for_completion(monkeypatch):
 @pytest.mark.usefixtures("_patch_for_completion")
 def test_full_source(runner, shell):
     cli = Group("cli", commands=[Command("a"), Command("b")])
-    result = runner.invoke(cli, env={"_CLI_COMPLETE": f"source_{shell}"})
-    assert f"_CLI_COMPLETE=complete_{shell}" in result.output
+    result = runner.invoke(cli, env={"_CLI_COMPLETE": f"{shell}_source"})
+    assert f"_CLI_COMPLETE={shell}_complete" in result.output
 
 
 @pytest.mark.parametrize(
@@ -272,7 +272,7 @@ def test_full_source(runner, shell):
 @pytest.mark.usefixtures("_patch_for_completion")
 def test_full_complete(runner, shell, env, expect):
     cli = Group("cli", commands=[Command("a"), Command("b", help="bee")])
-    env["_CLI_COMPLETE"] = f"complete_{shell}"
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
     assert result.output == expect
 
@@ -286,6 +286,6 @@ def test_context_settings(runner):
     result = runner.invoke(
         cli,
         obj={"choices": ["a", "b"]},
-        env={"COMP_WORDS": "", "COMP_CWORD": "0", "_CLI_COMPLETE": "complete_bash"},
+        env={"COMP_WORDS": "", "COMP_CWORD": "0", "_CLI_COMPLETE": "bash_complete"},
     )
     assert result.output == "plain,a\nplain,b\n"


### PR DESCRIPTION
The order was previously `source_{shell}` and `complete_{shell}` because support for other shells was added later. In the new system the shell is always required, there is no longer the assumption of Bash if none is given. Since we've rewritten the system and all existing completion instructions and scripts are invalid anyway, take the opportunity to move the shell first. The order is now `{shell}_source` and `{shell}_complete`.

One potential argument for the old order is that it could be used for autodetection. If the shell was left off the end, detect the shell. However, autodetection isn't particularly useful since the scripts and activation instruction differ between shells anyway. If we do want that later, being explicit with `auto_source` is fine too.

related to #1484 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
