### PR TITLE
Revert "Add python 3.9 to CI."

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,15 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
-          - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
-          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
+          - {name: Linux, python: '3.8', os: ubuntu-latest, tox: py38}
+          - {name: Windows, python: '3.8', os: windows-latest, tox: py38}
+          - {name: Mac, python: '3.8', os: macos-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Style, python: '3.9', os: ubuntu-latest, tox: style}
-          - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
+          - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
+          - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,38,37,36,py3}
+    py{38,37,36,py3}
     style
     docs
 skip_missing_interpreters = true


### PR DESCRIPTION
Reverts pallets/click#1685

GitHub doesn't have pre-made env with 3.9, so it has to install it, which makes Windows and Mac builds too slow.