### PR TITLE
Fix a bunch of processing issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,9 @@ Unreleased
     not given. Parameters with ``nargs`` > 1 default to ``None``, and
     parameters with ``multiple=True`` or ``nargs=-1`` default to an
     empty tuple. :issue:`472`
+-   Handle empty env vars as though the option were not passed. This
+    extends the change introduced in 7.1 to be consistent in more cases.
+    :issue:`1285`
 
 
 Version 7.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,8 +111,22 @@ Unreleased
     completion system. :issue:`942`
 -   Include ``--help`` option in completion. :pr:`1504`
 -   ``ParameterSource`` is an ``enum.Enum`` subclass. :issue:`1530`
--   Boolean type strips surrounding space before converting.
+-   Boolean and UUID types strip surrounding space before converting.
     :issue:`1605`
+-   Adjusted error message from parameter type validation to be more
+    consistent. Quotes are used to distinguish the invalid value.
+    :issue:`1605`
+-   The default value for a parameter with ``nargs`` > 1 and
+    ``multiple=True`` must be a list of tuples. :issue:`1649`
+-   When getting the value for a parameter, the default is tried in the
+    same section as other sources to ensure consistent processing.
+    :issue:`1649`
+-   All parameter types accept a value that is already the correct type.
+    :issue:`1649`
+-   For shell completion, an argument is considered incomplete if its
+    value did not come from the command line args. :issue:`1649`
+-   Added ``ParameterSource.PROMPT`` to track parameter values that were
+    prompted for. :issue:`1649`
 
 
 Version 7.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,10 @@ Unreleased
     value did not come from the command line args. :issue:`1649`
 -   Added ``ParameterSource.PROMPT`` to track parameter values that were
     prompted for. :issue:`1649`
+-   Options with ``nargs`` > 1 no longer raise an error if a default is
+    not given. Parameters with ``nargs`` > 1 default to ``None``, and
+    parameters with ``multiple=True`` or ``nargs=-1`` default to an
+    empty tuple. :issue:`472`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2025,21 +2025,25 @@ class Parameter:
     def resolve_envvar_value(self, ctx):
         if self.envvar is None:
             return
+
         if isinstance(self.envvar, (tuple, list)):
             for envvar in self.envvar:
                 rv = os.environ.get(envvar)
-                if rv is not None:
+
+                if rv:
                     return rv
         else:
             rv = os.environ.get(self.envvar)
 
-            if rv != "":
+            if rv:
                 return rv
 
     def value_from_envvar(self, ctx):
         rv = self.resolve_envvar_value(ctx)
+
         if rv is not None and self.nargs != 1:
             rv = self.type.split_envvar_value(rv)
+
         return rv
 
     def handle_parse_result(self, ctx, opts, args):
@@ -2424,19 +2428,28 @@ class Option(Parameter):
 
         if rv is not None:
             return rv
+
         if self.allow_from_autoenv and ctx.auto_envvar_prefix is not None:
             envvar = f"{ctx.auto_envvar_prefix}_{self.name.upper()}"
-            return os.environ.get(envvar)
+            rv = os.environ.get(envvar)
+
+            if rv:
+                return rv
 
     def value_from_envvar(self, ctx):
         rv = self.resolve_envvar_value(ctx)
+
         if rv is None:
             return None
+
         value_depth = (self.nargs != 1) + bool(self.multiple)
+
         if value_depth > 0 and rv is not None:
             rv = self.type.split_envvar_value(rv)
+
             if self.multiple and self.nargs != 1:
                 rv = batch(rv, self.nargs)
+
         return rv
 
     def consume_value(self, ctx, opts):

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1988,8 +1988,12 @@ class Parameter:
         if (
             not ctx.resilient_parsing
             and self.nargs > 1
-            and self.nargs != len(value)
             and isinstance(value, (tuple, list))
+            and (
+                any(len(v) != self.nargs for v in value)
+                if self.multiple
+                else len(value) != self.nargs
+            )
         ):
             were = "was" if len(value) == 1 else "were"
             ctx.fail(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -147,7 +147,7 @@ def test_int_option(runner):
 
     result = runner.invoke(cli, ["--foo=bar"])
     assert result.exception
-    assert "Invalid value for '--foo': bar is not a valid integer" in result.output
+    assert "Invalid value for '--foo': 'bar' is not a valid integer." in result.output
 
 
 def test_uuid_option(runner):
@@ -169,7 +169,7 @@ def test_uuid_option(runner):
 
     result = runner.invoke(cli, ["--u=bar"])
     assert result.exception
-    assert "Invalid value for '--u': bar is not a valid UUID value" in result.output
+    assert "Invalid value for '--u': 'bar' is not a valid UUID." in result.output
 
 
 def test_float_option(runner):
@@ -189,7 +189,7 @@ def test_float_option(runner):
 
     result = runner.invoke(cli, ["--foo=bar"])
     assert result.exception
-    assert "Invalid value for '--foo': bar is not a valid float" in result.output
+    assert "Invalid value for '--foo': 'bar' is not a valid float." in result.output
 
 
 def test_boolean_option(runner):
@@ -303,10 +303,7 @@ def test_file_lazy_mode(runner):
         os.mkdir("example.txt")
         result_in = runner.invoke(input_non_lazy, ["--file=example.txt"])
         assert result_in.exit_code == 2
-        assert (
-            "Invalid value for '--file': Could not open file: example.txt"
-            in result_in.output
-        )
+        assert "Invalid value for '--file': 'example.txt'" in result_in.output
 
 
 def test_path_option(runner):
@@ -368,8 +365,8 @@ def test_choice_option(runner):
     result = runner.invoke(cli, ["--method=meh"])
     assert result.exit_code == 2
     assert (
-        "Invalid value for '--method': invalid choice: meh."
-        " (choose from foo, bar, baz)" in result.output
+        "Invalid value for '--method': 'meh' is not one of 'foo', 'bar', 'baz'."
+        in result.output
     )
 
     result = runner.invoke(cli, ["--help"])
@@ -389,8 +386,8 @@ def test_choice_argument(runner):
     result = runner.invoke(cli, ["meh"])
     assert result.exit_code == 2
     assert (
-        "Invalid value for '{foo|bar|baz}': invalid choice: meh. "
-        "(choose from foo, bar, baz)" in result.output
+        "Invalid value for '{foo|bar|baz}': 'meh' is not one of 'foo',"
+        " 'bar', 'baz'." in result.output
     )
 
     result = runner.invoke(cli, ["--help"])
@@ -414,9 +411,8 @@ def test_datetime_option_default(runner):
     result = runner.invoke(cli, ["--start_date=2015-09"])
     assert result.exit_code == 2
     assert (
-        "Invalid value for '--start_date':"
-        " invalid datetime format: 2015-09."
-        " (choose from %Y-%m-%d, %Y-%m-%dT%H:%M:%S, %Y-%m-%d %H:%M:%S)"
+        "Invalid value for '--start_date': '2015-09' does not match the formats"
+        " '%Y-%m-%d', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S'."
     ) in result.output
 
     result = runner.invoke(cli, ["--help"])

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -195,7 +195,7 @@ def test_formatting_usage_error_metavar_bad_arg(runner):
         "Usage: cmd [OPTIONS] metavar",
         "Try 'cmd --help' for help.",
         "",
-        "Error: Invalid value for 'metavar': 3.14 is not a valid integer",
+        "Error: Invalid value for 'metavar': '3.14' is not a valid integer.",
     ]
 
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -90,6 +90,21 @@ def test_argument_order():
     assert _get_words(cli, ["x", "b"], "d") == ["d"]
 
 
+def test_argument_default():
+    cli = Command(
+        "cli",
+        add_help_option=False,
+        params=[
+            Argument(["a"], type=Choice(["a"]), default="a"),
+            Argument(["b"], type=Choice(["b"]), default="b"),
+        ],
+    )
+    assert _get_words(cli, [], "") == ["a"]
+    assert _get_words(cli, ["a"], "b") == ["b"]
+    # ignore type validation
+    assert _get_words(cli, ["x"], "b") == ["b"]
+
+
 def test_type_choice():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["a1", "a2", "b"]))])
     assert _get_words(cli, ["-c"], "") == ["a1", "a2", "b"]
@@ -119,9 +134,9 @@ def test_option_flag():
             Argument(["a"], type=Choice(["a1", "a2", "b"])),
         ],
     )
-    assert _get_words(cli, ["type"], "--") == ["--on", "--off"]
+    assert _get_words(cli, [], "--") == ["--on", "--off"]
     # flag option doesn't take value, use choice argument
-    assert _get_words(cli, ["x", "--on"], "a") == ["a1", "a2"]
+    assert _get_words(cli, ["--on"], "a") == ["a1", "a2"]
 
 
 def test_option_custom():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -54,3 +54,27 @@ def test_float_range_no_clamp_open():
 
     with pytest.raises(RuntimeError):
         sneaky.convert("1.5", None, None)
+
+
+@pytest.mark.parametrize(
+    ("nargs", "multiple", "default", "expect"),
+    [
+        (2, False, None, None),
+        (2, False, (None, None), (None, None)),
+        (None, True, None, ()),
+        (None, True, (None, None), (None, None)),
+        (2, True, None, ()),
+        (2, True, [(None, None)], ((None, None),)),
+        (-1, None, None, ()),
+    ],
+)
+def test_cast_multi_default(runner, nargs, multiple, default, expect):
+    if nargs == -1:
+        param = click.Argument(["a"], nargs=nargs, default=default)
+    else:
+        param = click.Option(["-a"], nargs=nargs, multiple=multiple, default=default)
+
+    cli = click.Command("cli", params=[param], callback=lambda a: a)
+    result = runner.invoke(cli, standalone_mode=False)
+    assert result.exception is None
+    assert result.return_value == expect


### PR DESCRIPTION
This fixes the various processing issues I noticed while investigating #1649.

* When `multiple=True` is set and `nargs` > 1, `default` must be a list of tuples. Setting such a default is detected correctly to produce a `type` of `Tuple`.
* `get_default` is now tried in `consume_value` with the other sources, rather than being tried in `full_process_value` after calling `process_value`. This makes the processing more consistent. `consume_value` must now return a `(value, ParameterSource)` tuple.
* `UUID` and `DateTime` types were adjusted so that their `convert` method allows a value that is already the correct type. This was already the case for other types.
* Prompting is done in `Option.consume_value` instead of `full_process_value` to match the other sources.
* Add `ParameterSource.PROMPT` to track that the value was prompted for. This is currently set even if the user confirms the default value.
* Use the parameter source to determine if an argument was provided on the command line for completion, rather than checking if the value is `None`. This fixes an issue an argument with a default value wouldn't be completed. Also use the parameter source to check if a `prompt` should happen.
* Return `None` if a default was not provided and `nargs` > 1. `multiple=True` or `nargs=-1` returns an empty tuple. The workaround described in #472 of setting `default=(None, None)` still works, but is no longer necessary.
* Empty env vars are treated as if they weren't provided, rather than as an empty string (#1285). This was only applied to one branch in the env var processing code, it has been extended to the other cases.

- Fixes #1649 
- Fixes #472, closes #767 
- Fixes #1285, extends #1304 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.