### PR TITLE
Case insensitive shell completions for Choice(..., case_sensitive=False)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ Unreleased
     ending of a phrase or double linebreak. :issue:`1082`
 -   Skip progress bar render steps for efficiency with very fast
     iterators by setting ``update_min_steps``. :issue:`676`
+-   Respect ``case_sensitive=False`` when doing shell completion for
+    ``Choice`` :issue:`1692`
 
 
 Version 7.1.2

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -274,7 +274,14 @@ class Choice(ParamType):
         from click.shell_completion import CompletionItem
 
         str_choices = map(str, self.choices)
-        return [CompletionItem(c) for c in str_choices if c.startswith(incomplete)]
+
+        if self.case_sensitive:
+            matched = (c for c in str_choices if c.startswith(incomplete))
+        else:
+            incomplete = incomplete.lower()
+            matched = (c for c in str_choices if c.lower().startswith(incomplete))
+
+        return [CompletionItem(c) for c in matched]
 
 
 class DateTime(ParamType):

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -304,3 +304,13 @@ def test_context_settings(runner):
         env={"COMP_WORDS": "", "COMP_CWORD": "0", "_CLI_COMPLETE": "bash_complete"},
     )
     assert result.output == "plain,a\nplain,b\n"
+
+
+@pytest.mark.parametrize(("value", "expect"), [(False, ["Au", "al"]), (True, ["al"])])
+def test_choice_case_sensitive(value, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["-a"], type=Choice(["Au", "al", "Bc"], case_sensitive=value))],
+    )
+    completions = _get_words(cli, ["-a"], "a")
+    assert completions == expect


### PR DESCRIPTION
This PR adds the logic and a test for checking case insensitive completions for `Choice` instances which have the argument `case_sensitive=False`. 

What changed was having the `Choice` class' `shell_complete`-method take `self.case_sensitive` into account when matching on the provided instance choices by using temporary string transforms on the `incomplete` argument and `self.choices` into all lower case when `self.case_sensitive=False`.

- Fixes #1692 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed. (**NOTE**: No test results changed with this contribution, there was 1 failing test though)
