### PR TITLE
Short help with summary line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,8 @@ Unreleased
 -   Fix formatting when ``Command.options_metavar`` is empty. :pr:`1551`
 -   The default value passed to ``prompt`` will be cast to the correct
     type like an input value would be. :pr:`1517`
+-   Automatically generated short help messages will stop at the first
+    ending of a phrase or double linebreak. :issue:`1082`
 
 
 Version 7.1.2

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -49,6 +49,9 @@ def make_str(value):
 
 def make_default_short_help(help, max_length=45):
     """Return a condensed version of help string."""
+    line_ending = help.find("\n\n")
+    if line_ending != -1:
+        help = help[:line_ending]
     words = help.split()
     total_length = 0
     result = []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -528,3 +528,22 @@ def test_hidden_group(runner):
     assert result.exit_code == 0
     assert "subgroup" not in result.output
     assert "nope" not in result.output
+
+
+def test_summary_line(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()
+    def cmd():
+        """
+        Summary line without period
+
+        Here is a sentence. And here too.
+        """
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert "Summary line without period" in result.output
+    assert "Here is a sentence." not in result.output


### PR DESCRIPTION
Automatically generated short help messages will stop at the first double linebreak which indicates a summary line. Sometimes the summary line does not have a period, so short help messages end up malformed.

- Fixes #1082

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.