### PR TITLE
Added examples of default to boolean flags section

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -253,6 +253,7 @@ And on the command line:
 
     invoke(info, args=['--shout'])
     invoke(info, args=['--no-shout'])
+    invoke(info)
 
 If you really don't want an off-switch, you can just define one and
 manually inform Click that something is a flag:
@@ -274,6 +275,7 @@ And on the command line:
 .. click:run::
 
     invoke(info, args=['--shout'])
+    invoke(info)
 
 Note that if a slash is contained in your option already (for instance, if
 you use Windows-style parameters where ``/`` is the prefix character), you


### PR DESCRIPTION
I've found myself a few times double checking what the default option is when a boolean flag is use i.e. does `default=False` refer to the first flag or the second flag.  Thought adding an example of the calls without any flags to the docs would make this a bit clearer.

fixes  #1696
