### PR TITLE
Shell completion escape handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,8 @@ Unreleased
         The shell now comes first, such as ``{shell}_source`` rather
         than ``source_{shell}``, and is always required.
 
+-   Completion correctly parses command line strings with incomplete
+    quoting or escape sequences. :issue:`1708`
 -   Extra context settings (``obj=...``, etc.) are passed on to the
     completion system. :issue:`942`
 -   Include ``--help`` option in completion. :pr:`1504`

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,17 @@
+import pytest
+
+from click.parser import split_arg_string
+
+
+@pytest.mark.parametrize(
+    ("value", "expect"),
+    [
+        ("cli a b c", ["cli", "a", "b", "c"]),
+        ("cli 'my file", ["cli", "my file"]),
+        ("cli 'my file'", ["cli", "my file"]),
+        ("cli my\\", ["cli", "my"]),
+        ("cli my\\ file", ["cli", "my file"]),
+    ],
+)
+def test_split_arg_string(value, expect):
+    assert split_arg_string(value) == expect


### PR DESCRIPTION
This PR fixes #1708 by using Python's `shlex` module to parse and split argument strings for shell completion. Incomplete arguments where splitting with `shlex.split` fails with a `ValueError` are handled by inspecting the state of the parser after the failure. There are only two such failures: 

1. A missing closing quote for an incomplete argument. This is handled by appending the missing quote. Therefore, shell completion suggestions for an argument `'path to` will be generated with `incomplete = "path to"`.
2. An incomplete escape sequence. This is handled by removing the incomplete sequence. Therefore, shell completion suggestions for an argument `'path\` will be generated with `incomplete = "path"`. This mirrors the behaviour of zsh and possibly other shells.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.
If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
