### PR TITLE
Allow custom temp directories with CLIRunner.isolated_filesystem

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,6 +161,9 @@ Unreleased
     ``default`` is ``None``. :issue:`1732`
 -   ``click.get_terminal_size()`` is deprecated and will be removed in
     8.1. Use :func:`shutil.get_terminal_size` instead. :issue:`1736`
+-   Control the location of the temporary directory created by
+    ``CLIRunner.isolated_filesystem`` by passing ``temp_dir``. A custom
+    directory will not be removed automatically. :issue:`395`
 
 
 Version 7.1.2

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -112,6 +112,19 @@ current working directory to a new, empty folder.
          assert result.exit_code == 0
          assert result.output == 'Hello World!\n'
 
+Pass ``temp_dir`` to control where the temporary directory is created.
+The directory will not be removed by Click in this case. This is useful
+to integrate with a framework like Pytest that manages temporary files.
+
+.. code-block:: python
+
+    def test_keep_dir(tmp_path):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+            ...
+
+
 Input Streams
 -------------
 

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -380,18 +380,30 @@ class CliRunner:
         )
 
     @contextlib.contextmanager
-    def isolated_filesystem(self):
-        """A context manager that creates a temporary folder and changes
-        the current working directory to it for isolated filesystem tests.
+    def isolated_filesystem(self, temp_dir=None):
+        """A context manager that creates a temporary directory and
+        changes the current working directory to it. This isolates tests
+        that affect the contents of the CWD to prevent them from
+        interfering with each other.
+
+        :param temp_dir: Create the temporary directory under this
+            directory. If given, the created directory is not removed
+            when exiting.
+
+        .. versionchanged:: 8.0
+            Added the ``temp_dir`` parameter.
         """
         cwd = os.getcwd()
-        t = tempfile.mkdtemp()
+        t = tempfile.mkdtemp(dir=temp_dir)
         os.chdir(t)
+
         try:
             yield t
         finally:
             os.chdir(cwd)
-            try:
-                shutil.rmtree(t)
-            except OSError:  # noqa: B014
-                pass
+
+            if temp_dir is None:
+                try:
+                    shutil.rmtree(t)
+                except OSError:  # noqa: B014
+                    pass

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -319,3 +319,18 @@ def test_file_stdin_attrs(runner):
 
     result = runner.invoke(cli, ["-"])
     assert result.output == "<stdin>\nr"
+
+
+def test_isolated_runner(runner):
+    with runner.isolated_filesystem() as d:
+        assert os.path.exists(d)
+
+    assert not os.path.exists(d)
+
+
+def test_isolated_runner_custom_tempdir(runner, tmp_path):
+    with runner.isolated_filesystem(temp_dir=tmp_path) as d:
+        assert os.path.exists(d)
+
+    assert os.path.exists(d)
+    os.rmdir(d)


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.
Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->
CLIRunner.isolated_filesystem accepts a custom argument tempdir. If user specifies custom tempdir, we do not delete it afterwards assuming user will clean up afterwards.


- Fixes #395

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.
If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
