### PR TITLE
Added FloatRange to API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -136,6 +136,8 @@ Types
 
 .. autoclass:: IntRange
 
+.. autoclass:: FloatRange
+
 .. autoclass:: Tuple
 
 .. autoclass:: ParamType


### PR DESCRIPTION
Adds FloatRange documentation to API docs by adding it to api.rst.

Fixes  #1718 
