### PR TITLE
Deprecate click.get_terminal_size() in favor of stdlib shutil.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,6 +159,8 @@ Unreleased
     :issue:`1752`
 -   If ``Option.show_default`` is a string, it is displayed even if
     ``default`` is ``None``. :issue:`1732`
+-   ``click.get_terminal_size()`` is deprecated and will be removed in
+    8.1. Use :func:`shutil.get_terminal_size` instead. :issue:`1736`
 
 
 Version 7.1.2

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -12,10 +12,8 @@ APP_ENGINE = "APPENGINE_RUNTIME" in os.environ and "Development/" in os.environ.
     "SERVER_SOFTWARE", ""
 )
 WIN = sys.platform.startswith("win") and not APP_ENGINE and not MSYS2
-DEFAULT_COLUMNS = 80
 auto_wrap_for_ansi = None
 colorama = None
-get_winterm_size = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
 
@@ -496,9 +494,6 @@ def should_strip_ansi(stream=None, color=None):
 # colorama.  This will make ANSI colors through the echo function
 # work automatically.
 if WIN:
-    # Windows has a smaller terminal
-    DEFAULT_COLUMNS = 79
-
     from ._winconsole import _get_windows_console_stream
 
     def _get_argv_encoding():
@@ -543,12 +538,6 @@ if WIN:
             except Exception:
                 pass
             return rv
-
-        def get_winterm_size():
-            win = colorama.win32.GetConsoleScreenBufferInfo(
-                colorama.win32.STDOUT
-            ).srWindow
-            return win.Right - win.Left, win.Bottom - win.Top
 
 
 else:

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -224,7 +224,7 @@ class ProgressBar:
         ).rstrip()
 
     def render_progress(self):
-        from .termui import get_terminal_size
+        import shutil
 
         if self.is_hidden:
             return
@@ -235,7 +235,7 @@ class ProgressBar:
             old_width = self.width
             self.width = 0
             clutter_length = term_len(self.format_progress_line())
-            new_width = max(0, get_terminal_size()[0] - clutter_length)
+            new_width = max(0, shutil.get_terminal_size().columns - clutter_length)
             if new_width < old_width:
                 buf.append(BEFORE_BAR)
                 buf.append(" " * self.max_width)

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 
 from ._compat import term_len
 from .parser import split_opt
-from .termui import get_terminal_size
 
 # Can force a width.  This is used by the test system
 FORCED_WIDTH = None
@@ -104,13 +103,15 @@ class HelpFormatter:
     """
 
     def __init__(self, indent_increment=2, width=None, max_width=None):
+        import shutil
+
         self.indent_increment = indent_increment
         if max_width is None:
             max_width = 80
         if width is None:
             width = FORCED_WIDTH
             if width is None:
-                width = max(min(get_terminal_size()[0], max_width) - 2, 50)
+                width = max(min(shutil.get_terminal_size().columns, max_width) - 2, 50)
         self.width = width
         self.current_indent = 0
         self.buffer = []

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -2,11 +2,8 @@ import inspect
 import io
 import itertools
 import os
-import struct
 import sys
 
-from ._compat import DEFAULT_COLUMNS
-from ._compat import get_winterm_size
 from ._compat import is_bytes
 from ._compat import isatty
 from ._compat import strip_ansi
@@ -215,44 +212,21 @@ def confirm(
 def get_terminal_size():
     """Returns the current size of the terminal as tuple in the form
     ``(width, height)`` in columns and rows.
+
+    .. deprecated:: 8.0
+        Will be removed in Click 8.1. Use
+        :func:`shutil.get_terminal_size` instead.
     """
     import shutil
+    import warnings
 
-    if hasattr(shutil, "get_terminal_size"):
-        return shutil.get_terminal_size()
-
-    # We provide a sensible default for get_winterm_size() when being invoked
-    # inside a subprocess. Without this, it would not provide a useful input.
-    if get_winterm_size is not None:
-        size = get_winterm_size()
-        if size == (0, 0):
-            return (79, 24)
-        else:
-            return size
-
-    def ioctl_gwinsz(fd):
-        try:
-            import fcntl
-            import termios
-
-            cr = struct.unpack("hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234"))
-        except Exception:
-            return
-        return cr
-
-    cr = ioctl_gwinsz(0) or ioctl_gwinsz(1) or ioctl_gwinsz(2)
-    if not cr:
-        try:
-            fd = os.open(os.ctermid(), os.O_RDONLY)
-            try:
-                cr = ioctl_gwinsz(fd)
-            finally:
-                os.close(fd)
-        except Exception:
-            pass
-    if not cr or not cr[0] or not cr[1]:
-        cr = (os.environ.get("LINES", 25), os.environ.get("COLUMNS", DEFAULT_COLUMNS))
-    return int(cr[1]), int(cr[0])
+    warnings.warn(
+        "'click.get_terminal_size()' is deprecated and will be removed"
+        " in Click 8.1. Use 'shutil.get_terminal_size()' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return shutil.get_terminal_size()
 
 
 def echo_via_pager(text_or_generator, color=None):


### PR DESCRIPTION
Since Python 3.3, the stdlib provides the function
shutil.get_terminal_size(). Now that the project has dropped Python 2
support, the compatibility shim is no longer necessary.

The stdlib version returns a named tuple. So rather than indexing "0",
can use the more self-documenting attribute "columns".

Docs available at:
https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size

Fixes #1736

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
