### PR TITLE
add test for not showing default when no default is given

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -668,6 +668,14 @@ def test_show_default_string(runner):
     assert "[default: (unlimited)]" in message
 
 
+def test_do_not_show_no_default(runner):
+    """When show_default is True and no default is set do not show None."""
+    opt = click.Option(["--limit"], show_default=True)
+    ctx = click.Context(click.Command("cli"))
+    message = opt.get_help_record(ctx)[1]
+    assert "[default: None]" not in message
+
+
 @pytest.mark.parametrize(
     ("args", "expect"),
     [


### PR DESCRIPTION
Adds a test for a special case when using show_default, but no default is available resulting in [default: None].



- fixes #1732


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
