### PR TITLE
use Read the Docs to build docs for PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,6 @@ jobs:
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
           - {name: Typing, python: '3.9', os: ubuntu-latest, tox: typing}
-          - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,4 @@ python:
       path: .
 sphinx:
   builder: dirhtml
+  fail_on_warning: true


### PR DESCRIPTION
Read the Docs will build and host the docs for each PR. The builds can be accessed by clicking "details" in the GitHub checks status, and are removed after 90 days. Remove the GH CI env and make RTD fail on warnings like tox does.