### PR TITLE
skip code tests when only docs change

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,10 +4,18 @@ on:
     branches:
       - master
       - '*.x'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
   pull_request:
     branches:
       - master
       - '*.x'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
 jobs:
   tests:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Skip running the code tests when only docs pages are changed.

This *should* work, but I can't test it in this PR, since it changes the workflow file, which is not a docs file. But there's an easy docs issue that I'll use to test this after merging.