### PR TITLE
always install colorama on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 8.0
 Unreleased
 
 -   Drop support for Python 2 and 3.5.
+-   Colorama is always installed on Windows in order to provide style
+    and color support. :pr:`1784`
 -   Adds a repr to Command, showing the command name for friendlier
     debugging. :issue:`1267`, :pr:`1295`
 -   Add support for distinguishing the source of a command line

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -108,7 +108,7 @@ as in the GitHub repository together with readme files:
     <https://github.com/pallets/click/tree/master/examples/complex>`_
 *   ``validation``: `Custom parameter validation example
     <https://github.com/pallets/click/tree/master/examples/validation>`_
-*   ``colors``: `Colorama ANSI color support
+*   ``colors``: `Color support demo
     <https://github.com/pallets/click/tree/master/examples/colors>`_
 *   ``termui``: `Terminal UI functions demo
     <https://github.com/pallets/click/tree/master/examples/termui>`_
@@ -166,10 +166,10 @@ What this means is that the :func:`echo` function applies some error
 correction in case the terminal is misconfigured instead of dying with an
 :exc:`UnicodeError`.
 
-As an added benefit, starting with Click 2.0, the echo function also
-has good support for ANSI colors.  It will automatically strip ANSI codes
-if the output stream is a file and if colorama is supported, ANSI colors
-will also work on Windows. See :ref:`ansi-colors`.
+The echo function also supports color and other styles in output. It
+will automatically remove styles if the output stream is a file. On
+Windows, colorama is automatically installed and used. See
+:ref:`ansi-colors`.
 
 If you don't need this, you can also use the `print()` construct /
 function.

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -52,10 +52,8 @@ ANSI Colors
 
 .. versionadded:: 2.0
 
-The :func:`echo` function gained extra functionality to deal with ANSI
-colors and styles.  Note that on Windows, this functionality is only
-available if `colorama`_ is installed.  If it is installed, then ANSI
-codes are intelligently handled.
+The :func:`echo` function supports ANSI colors and styles. On Windows
+this uses `colorama`_.
 
 Primarily this means that:
 
@@ -66,12 +64,8 @@ Primarily this means that:
     that colors will work on Windows the same way they do on other
     operating systems.
 
-Note for `colorama` support: Click will automatically detect when `colorama`
-is available and use it.  Do *not* call ``colorama.init()``!
-
-To install `colorama`, run this command::
-
-    $ pip install colorama
+On Windows, Click uses colorama without calling ``colorama.init()``. You
+can still call that in your code, but it's not required for Click.
 
 For styling a string, the :func:`style` function can be used::
 

--- a/examples/colors/README
+++ b/examples/colors/README
@@ -3,7 +3,7 @@ $ colors_
   colors is a simple example that shows how you can
   colorize text.
 
-  For this to work on Windows, colorama is required.
+  Uses colorama on Windows.
 
 Usage:
 

--- a/examples/colors/colors.py
+++ b/examples/colors/colors.py
@@ -23,9 +23,8 @@ all_colors = (
 
 @click.command()
 def cli():
-    """This script prints some colors.  If colorama is installed this will
-    also work on Windows.  It will also automatically remove all ANSI
-    styles if data is piped into a file.
+    """This script prints some colors. It will also automatically remove
+    all ANSI styles if data is piped into a file.
 
     Give it a try!
     """

--- a/examples/colors/setup.py
+++ b/examples/colors/setup.py
@@ -5,11 +5,7 @@ setup(
     version="1.0",
     py_modules=["colors"],
     include_package_data=True,
-    install_requires=[
-        "click",
-        # Colorama is only required for Windows.
-        "colorama",
-    ],
+    install_requires=["click"],
     entry_points="""
         [console_scripts]
         colors=colors:cli

--- a/examples/termui/setup.py
+++ b/examples/termui/setup.py
@@ -5,11 +5,7 @@ setup(
     version="1.0",
     py_modules=["termui"],
     include_package_data=True,
-    install_requires=[
-        "click",
-        # Colorama is only required for Windows.
-        "colorama",
-    ],
+    install_requires=["click"],
     entry_points="""
         [console_scripts]
         termui=termui:cli

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,8 +20,6 @@ chardet==4.0.0
     # via requests
 click==7.1.2
     # via pip-tools
-colorama==0.4.4
-    # via -r requirements/tests.in
 distlib==0.3.1
     # via virtualenv
 docutils==0.16

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,3 +1,2 @@
 pytest
-colorama
 importlib_metadata

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,8 +6,6 @@
 #
 attrs==20.3.0
     # via pytest
-colorama==0.4.4
-    # via -r requirements/tests.in
 importlib-metadata==3.4.0
     # via -r requirements/tests.in
 iniconfig==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="click")
+setup(name="click", install_requires=["colorama; platform_system == 'Windows'"])

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -418,9 +418,6 @@ def clear():
     """
     if not isatty(sys.stdout):
         return
-    # If we're on Windows and we don't have colorama available, then we
-    # clear the screen by shelling out.  Otherwise we can use an escape
-    # sequence.
     if WIN:
         os.system("cls")
     else:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -41,7 +41,6 @@ ALLOWED_IMPORTS = {
     "itertools",
     "io",
     "threading",
-    "colorama",
     "errno",
     "fcntl",
     "datetime",
@@ -51,7 +50,7 @@ ALLOWED_IMPORTS = {
 }
 
 if WIN:
-    ALLOWED_IMPORTS.update(["ctypes", "ctypes.wintypes", "msvcrt", "time", "zlib"])
+    ALLOWED_IMPORTS.update(["ctypes", "ctypes.wintypes", "msvcrt", "time"])
 
 
 def test_light_imports():


### PR DESCRIPTION
Colorama is required to provide ANSI style/color support in the Windows console.  This adds it as a required dependency for Windows only.

I think in this very specific case it's ok to add this as a required dependency (on Windows). It's required to support a fairly fundamental feature, and it's way too complex to implement ourselves. It's also already fairly ubiquitous, it's installed 21 million times per month while Click is only 15 million. So it's likely that users are already pulling in this dependency or expect it to work.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1546 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
