### PR TITLE
Option callbacks are now invoked inside prompt and can be used to validate prompt inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,7 +167,9 @@ Unreleased
     ``CLIRunner.isolated_filesystem`` by passing ``temp_dir``. A custom
     directory will not be removed automatically. :issue:`395`
 -   ``click.confirm()`` will prompt until input is given if called with
-    ``default=None``. :issue:`#1381`
+    ``default=None``. :issue:`1381`
+-   Option prompts validate the value with the option's callback in
+    addition to its type. :issue:`457`
 
 
 Version 7.1.2

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -828,19 +828,21 @@ Callbacks for Validation
 .. versionchanged:: 2.0
 
 If you want to apply custom validation logic, you can do this in the
-parameter callbacks.  These callbacks can both modify values as well as
-raise errors if the validation does not work.
+parameter callbacks. These callbacks can both modify values as well as
+raise errors if the validation does not work. The callback runs after
+type conversion. It is called for all sources, including prompts.
 
 In Click 1.0, you can only raise the :exc:`UsageError` but starting with
 Click 2.0, you can also raise the :exc:`BadParameter` error, which has the
 added advantage that it will automatically format the error message to
 also contain the parameter name.
 
-Example:
-
 .. click:example::
 
     def validate_rolls(ctx, param, value):
+        if isinstance(value, tuple):
+            return value
+
         try:
             rolls, _, dice = value.partition("d")
             return int(dice), int(rolls)
@@ -848,18 +850,21 @@ Example:
             raise click.BadParameter("format must be 'NdM'")
 
     @click.command()
-    @click.option("--rolls", callback=validate_rolls, default="1d6")
+    @click.option(
+        "--rolls", type=click.UNPROCESSED, callback=validate_rolls,
+        default="1d6", prompt=True,
+    )
     def roll(rolls):
         sides, times = rolls
         click.echo(f"Rolling a {sides}-sided dice {times} time(s)")
-
-And what it looks like:
 
 .. click:run::
 
     invoke(roll, args=["--rolls=42"])
     println()
     invoke(roll, args=["--rolls=2d12"])
+    println()
+    invoke(roll, input=["42", "2d12"])
 
 
 .. _optional-value:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -228,7 +228,7 @@ def test_missing_argument_string_cast():
     ctx = click.Context(click.Command(""))
 
     with pytest.raises(click.MissingParameter) as excinfo:
-        click.Argument(["a"], required=True).full_process_value(ctx, None)
+        click.Argument(["a"], required=True).process_value(ctx, None)
 
     assert str(excinfo.value) == "missing parameter: a"
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -376,6 +376,22 @@ def test_custom_validation(runner):
     assert result.output == "42\n"
 
 
+def test_callback_validates_prompt(runner, monkeypatch):
+    def validate(ctx, param, value):
+        if value < 0:
+            raise click.BadParameter("should be positive")
+
+        return value
+
+    @click.command()
+    @click.option("-a", type=int, callback=validate, prompt=True)
+    def cli(a):
+        click.echo(a)
+
+    result = runner.invoke(cli, input="-12\n60\n")
+    assert result.output == "A: -12\nError: should be positive\nA: 60\n60\n"
+
+
 def test_winstyle_options(runner):
     @click.command()
     @click.option("/debug;/no-debug", help="Enables or disables debug mode.")
@@ -409,7 +425,7 @@ def test_missing_option_string_cast():
     ctx = click.Context(click.Command(""))
 
     with pytest.raises(click.MissingParameter) as excinfo:
-        click.Option(["-a"], required=True).full_process_value(ctx, None)
+        click.Option(["-a"], required=True).process_value(ctx, None)
 
     assert str(excinfo.value) == "missing parameter: a"
 


### PR DESCRIPTION
Callbacks used to be invoked for the prompt results, therefore couldn't be used as validators for validating prompt input. Following are the changes made - 

- Inlined `Parameter.process_value` into `Parameter.full_process_value`
- Renamed `full_process_value` to `process_value`
- Moved the `if self.callback` block from `handle_parse_result` to the bottom `process_value`

The current behaviour due to the above changes is as expected to be. The user will be prompted until he/she enters a value deemed valid by the validator callback.

However, this [test](https://github.com/pallets/click/blob/890e984174ffd16ac5510ec7fe21263f5ca7c65f/tests/test_termui.py#L423) is failing. From what I understand, `process_value` gets the value from the prompt when `value` is `None` and `self.prompt` is `True`. I think that `self.prompt_required` needs to be used somewhere but I'm not sure where exactly. 

I plan to update the docs, once all tests pass.

- Fixes #457 

Checklist:

- [x] Add tests that demonstrate the correct behaviour of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
