### PR TITLE
confirmation prompt text can now be customized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,7 @@ Unreleased
     ``default=None``. :issue:`1381`
 -   Option prompts validate the value with the option's callback in
     addition to its type. :issue:`457`
+-   ``confirmation_prompt`` can be set to a custom string. :issue:`723`
 -   Allow styled output in Jupyter on Windows. :issue:`1271`
 
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2146,8 +2146,9 @@ class Option(Parameter):
     :param prompt: if set to `True` or a non empty string then the user will be
                    prompted for input.  If set to `True` the prompt will be the
                    option name capitalized.
-    :param confirmation_prompt: if set then the value will need to be confirmed
-                                if it was prompted for.
+    :param confirmation_prompt: Prompt a second time to confirm the
+        value if it was prompted for. Can be set to a string instead of
+        ``True`` to customize the message.
     :param prompt_required: If set to ``False``, the user will be
         prompted for input only when the option was specified as a flag
         without a value.
@@ -2203,6 +2204,7 @@ class Option(Parameter):
             prompt_text = None
         else:
             prompt_text = prompt
+
         self.prompt = prompt_text
         self.confirmation_prompt = confirmation_prompt
         self.prompt_required = prompt_required

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -85,21 +85,14 @@ def prompt(
     If the user aborts the input by sending a interrupt signal, this
     function will catch it and raise a :exc:`Abort` exception.
 
-    .. versionadded:: 7.0
-       Added the show_choices parameter.
-
-    .. versionadded:: 6.0
-       Added unicode support for cmd.exe on Windows.
-
-    .. versionadded:: 4.0
-       Added the `err` parameter.
-
     :param text: the text to show for the prompt.
     :param default: the default value to use if no input happens.  If this
                     is not given it will prompt until it's aborted.
     :param hide_input: if this is set to true then the input value will
                        be hidden.
-    :param confirmation_prompt: asks for confirmation for the value.
+    :param confirmation_prompt: Prompt a second time to confirm the
+        value. Can be set to a string instead of ``True`` to customize
+        the message.
     :param type: the type to use to check the value against.
     :param value_proc: if this parameter is provided it's a function that
                        is invoked instead of the type conversion to
@@ -112,6 +105,19 @@ def prompt(
                          For example if type is a Choice of either day or week,
                          show_choices is true and text is "Group by" then the
                          prompt will be "Group by (day, week): ".
+
+    .. versionadded:: 8.0
+        ``confirmation_prompt`` can be a custom string.
+
+    .. versionadded:: 7.0
+        Added the ``show_choices`` parameter.
+
+    .. versionadded:: 6.0
+        Added unicode support for cmd.exe on Windows.
+
+    .. versionadded:: 4.0
+        Added the `err` parameter.
+
     """
     result = None
 
@@ -137,6 +143,12 @@ def prompt(
         text, prompt_suffix, show_default, default, show_choices, type
     )
 
+    if confirmation_prompt:
+        if confirmation_prompt is True:
+            confirmation_prompt = "Repeat for confirmation"
+
+        confirmation_prompt = _build_prompt(confirmation_prompt, prompt_suffix)
+
     while 1:
         while 1:
             value = prompt_func(prompt)
@@ -156,7 +168,7 @@ def prompt(
         if not confirmation_prompt:
             return result
         while 1:
-            value2 = prompt_func("Repeat for confirmation: ")
+            value2 = prompt_func(confirmation_prompt)
             if value2:
                 break
         if value == value2:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -446,3 +446,27 @@ def test_prompt_required_false(runner, args, expect):
     result = runner.invoke(cli, args=args, input="prompt", standalone_mode=False)
     assert result.exception is None
     assert result.return_value == expect
+
+
+@pytest.mark.parametrize(
+    ("prompt", "input", "expect"),
+    [
+        (True, "password\npassword", "password"),
+        ("Confirm Password", "password\npassword\n", "password"),
+        (False, None, None),
+    ],
+)
+def test_confirmation_prompt(runner, prompt, input, expect):
+    @click.command()
+    @click.option(
+        "--password", prompt=prompt, hide_input=True, confirmation_prompt=prompt
+    )
+    def cli(password):
+        return password
+
+    result = runner.invoke(cli, input=input, standalone_mode=False)
+    assert result.exception is None
+    assert result.return_value == expect
+
+    if prompt == "Confirm Password":
+        assert "Confirm Password: " in result.output


### PR DESCRIPTION
The user can now customize the confirmation prompt text. If `confirmation_prompt` is set to `True`, the default prompt text will be used. If a non-empty string is provided then that will be used.

- fixes #723 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
