### PR TITLE
Allow styled output in Jupyter on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,7 @@ Unreleased
     ``default=None``. :issue:`1381`
 -   Option prompts validate the value with the option's callback in
     addition to its type. :issue:`457`
+-   Allow styled output in Jupyter on Windows. :issue:`1271`
 
 
 Version 7.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,5 +95,8 @@ warn_unreachable = True
 [mypy-click]
 no_implicit_reexport = False
 
+[mypy-colorama.*]
+ignore_missing_imports = True
+
 [mypy-importlib_metadata.*]
 ignore_missing_imports = True

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -471,11 +471,6 @@ def strip_ansi(value):
 
 
 def _is_jupyter_kernel_output(stream):
-    if WIN:
-        # TODO: Couldn't test on Windows, should't try to support until
-        # someone tests the details wrt colorama.
-        return
-
     while isinstance(stream, (_FixupStream, _NonClosingTextIOWrapper)):
         stream = stream._stream
 
@@ -521,7 +516,7 @@ if sys.platform.startswith("win") and WIN:
 
         strip = should_strip_ansi(stream, color)
         ansi_wrapper = colorama.AnsiToWin32(stream, strip=strip)
-        rv = ansi_wrapper.stream
+        rv = t.cast(t.TextIO, ansi_wrapper.stream)
         _write = rv.write
 
         def _safe_write(s):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,10 +1,6 @@
-import pytest
-
 from click._compat import should_strip_ansi
-from click._compat import WIN
 
 
-@pytest.mark.xfail(WIN, reason="Jupyter not tested/supported on Windows")
 def test_is_jupyter_kernel_output():
     class JupyterKernelFakeStream:
         pass


### PR DESCRIPTION
It appears that styles work in Jupyter Lab and Notebook, including on Windows, without further changes. Removed the check for Windows.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1271

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
