### PR TITLE
CliRunner.isolation() returns type compatible with CliRunner.invoke()

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -208,6 +208,7 @@ class CliRunner:
             bytes_output, encoding=self.charset, name="<stdout>", mode="w"
         )
 
+        bytes_error = None
         if self.mix_stderr:
             sys.stderr = sys.stdout
         else:
@@ -262,7 +263,7 @@ class CliRunner:
                         pass
                 else:
                     os.environ[key] = value
-            yield (bytes_output, not self.mix_stderr and bytes_error)
+            yield (bytes_output, bytes_error)
         finally:
             for key, value in old_env.items():
                 if value is None:


### PR DESCRIPTION
`CliRunner.isolation()` used to return a tuple of type (`BytesIO`, `False`). However, `CliRunner.invoke()` expected (`BytesIO`, `BytesIO`). 

Updated `CliRunner.isolation()` to return second item of tuple of type `BytesIO` or `None`. All tests are running fine. I don't think any additional changes to the docs or tests are required for this.

- fixes #1773 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
