### PR TITLE
removed multiline marker from short help text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,7 @@ Unreleased
 -   ``confirmation_prompt`` can be set to a custom string. :issue:`723`
 -   Allow styled output in Jupyter on Windows. :issue:`1271`
 -   ``style()`` supports the ``strikethrough`` style. :issue:`805`
+-   Multiline marker is removed from short help text. :issue:`1597`
 
 
 Version 7.1.2

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -57,6 +57,9 @@ def make_default_short_help(help, max_length=45):
     result = []
     done = False
 
+    if words[0] == "\b":
+        words = words[1:]
+
     for word in words:
         if word[-1:] == ".":
             done = True

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -296,6 +296,25 @@ def test_truncating_docstring(runner):
     ]
 
 
+def test_removing_multiline_marker(runner):
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()
+    def cmd1():
+        """\b
+        This is command with a multiline help text
+        which should not be rewrapped.
+        The output of the short help text should
+        not contain the multiline marker.
+        """
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert "\b" not in result.output
+
+
 def test_global_show_default(runner):
     @click.command(context_settings=dict(show_default=True))
     @click.option("-f", "in_file", default="out.txt", help="Output file name")


### PR DESCRIPTION
Changes made - 
- `\b` will be removed if present while making the default short help description
- If multiple `\b`'s are present on new lines, then those will be removed as well
- These changes do not affect the primary `help` text and `\b` prefixed help string will not be rewrapped as intended.

Example - 
Running the example mentioned in #1597 post removing `\b` gives the below output

```bash

$ cli_command -h > ./help.txt

# Content of ./help.txt : 
Usage: test_cli_help.py [OPTIONS] COMMAND [ARGS]...

  some help

 Options:
   --version   Show the version and exit.
   -h, --help  Show this message and exit.

 Commands:
   command1  command1 without arguments and options
   command2  command2 with arguments
   command3  command3 with multi line help arguments and options
   command4  command4 with arguments, options and sub_command and a very
                        long...
```

- fixes #1597 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
