### PR TITLE
don't hide fast progress bars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,8 @@ Unreleased
 -   Multiline marker is removed from short help text. :issue:`1597`
 -   Restore progress bar behavior of echoing only the label if the file
     is not a TTY. :issue:`1138`
+-   Progress bar output is shown even if execution time is less than 0.5
+    seconds. :issue:`1648`
 
 
 Version 7.1.2

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -102,7 +102,6 @@ class ProgressBar:
         self.current_item = None
         self.is_hidden = not isatty(self.file)
         self._last_line = None
-        self.short_limit = 0.5
 
     def __enter__(self):
         self.entered = True
@@ -126,11 +125,8 @@ class ProgressBar:
         # twice works and does "what you want".
         return next(iter(self))
 
-    def is_fast(self):
-        return time.time() - self.start <= self.short_limit
-
     def render_finish(self):
-        if self.is_hidden or self.is_fast():
+        if self.is_hidden:
             return
         self.file.write(AFTER_BAR)
         self.file.flush()
@@ -263,7 +259,7 @@ class ProgressBar:
         line = "".join(buf)
         # Render the line only if it changed.
 
-        if line != self._last_line and not self.is_fast():
+        if line != self._last_line:
             self._last_line = line
             echo(line, file=self.file, color=self.color, nl=False)
             self.file.flush()

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -391,6 +391,9 @@ def progressbar(
         completed. This allows tuning for very fast iterators.
 
     .. versionchanged:: 8.0
+        Output is shown even if execution time is less than 0.5 seconds.
+
+    .. versionchanged:: 8.0
         Labels are echoed if the output is not a TTY. Reverts a change
         in 7.0 that removed all output.
 


### PR DESCRIPTION
Progress bar output is shown even if execution time is less than 0.5 seconds. The intention of #487 seemed to be to hide output if the final time was short, but ended up hiding initial updates for longer bars.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1648
- reverts #487 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
