### PR TITLE
path type supports pathlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -180,6 +180,8 @@ Unreleased
     seconds. :issue:`1648`
 -   Progress bar ``item_show_func`` shows the current item, not the
     previous item. :issue:`1353`
+-   The ``Path`` param type can be passed ``path_type=pathlib.Path`` to
+    return a path object instead of a string. :issue:`405`
 
 
 Version 7.1.2

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 import click
@@ -76,5 +78,25 @@ def test_cast_multi_default(runner, nargs, multiple, default, expect):
 
     cli = click.Command("cli", params=[param], callback=lambda a: a)
     result = runner.invoke(cli, standalone_mode=False)
+    assert result.exception is None
+    assert result.return_value == expect
+
+
+@pytest.mark.parametrize(
+    ("cls", "expect"),
+    [
+        (None, "a/b/c.txt"),
+        (str, "a/b/c.txt"),
+        (bytes, b"a/b/c.txt"),
+        (pathlib.Path, pathlib.Path("a", "b", "c.txt")),
+    ],
+)
+def test_path_type(runner, cls, expect):
+    cli = click.Command(
+        "cli",
+        params=[click.Argument(["p"], type=click.Path(path_type=cls))],
+        callback=lambda p: p,
+    )
+    result = runner.invoke(cli, ["a/b/c.txt"], standalone_mode=False)
     assert result.exception is None
     assert result.return_value == expect


### PR DESCRIPTION
* `click.Path(path_type=pathlib.Path)` returns the value as a pathlib object. Technically any class is allowed, but this is only intended for pathlib.
* Use `os.fsdecode` and `fsencode` to convert `str` and `bytes`. Since Python 2 isn't supported more, the value from the command line will never be `bytes`.
* Remove the internal `path_type` attribute, which was confusingly named (the `path_type` parameter is stored as `type`), and was just `name.title()`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #405
- closes #1148
- closes #1234

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
