### PR TITLE
Better error message for bad parameter default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,6 +182,8 @@ Unreleased
     previous item. :issue:`1353`
 -   The ``Path`` param type can be passed ``path_type=pathlib.Path`` to
     return a path object instead of a string. :issue:`405`
+-   TypeError is raised when parameter with ``multiple=True`` or
+    ``nargs > 1`` has non-iterable default. :issue:`1749`
 
 
 Version 7.1.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,7 +182,7 @@ Unreleased
     previous item. :issue:`1353`
 -   The ``Path`` param type can be passed ``path_type=pathlib.Path`` to
     return a path object instead of a string. :issue:`405`
--   TypeError is raised when parameter with ``multiple=True`` or
+-   ``TypeError`` is raised when parameter with ``multiple=True`` or
     ``nargs > 1`` has non-iterable default. :issue:`1749`
 
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2015,7 +2015,7 @@ class Parameter:
                 iter_value = iter(value)
             except TypeError:
                 raise TypeError(
-                    "Default for parameter with multiple = True or nargs > 1"
+                    "Value for parameter with multiple = True or nargs > 1"
                     " should be an iterable."
                 )
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2011,7 +2011,15 @@ class Parameter:
             if level == 0:
                 return self.type(value, self, ctx)
 
-            return tuple(_convert(x, level - 1) for x in value)
+            try:
+                iter_value = iter(value)
+            except TypeError:
+                raise TypeError(
+                    "Default for parameter with multiple = True or nargs > 1"
+                    " should be an iterable."
+                )
+
+            return tuple(_convert(x, level - 1) for x in iter_value)
 
         return _convert(value, (self.nargs != 1) + bool(self.multiple))
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -117,6 +117,20 @@ def test_multiple_required(runner):
     assert "Error: Missing option '-m' / '--message'." in result.output
 
 
+def test_multiple_bad_default(runner):
+    @click.command()
+    @click.option("--flags", multiple=True, default=False)
+    def cli(flags):
+        pass
+
+    result = runner.invoke(cli, [])
+    assert result.exception
+    assert (
+        "Default for parameter with multiple = True or nargs > 1 should be an iterable."
+        in result.exception.args
+    )
+
+
 def test_empty_envvar(runner):
     @click.command()
     @click.option("--mypath", type=click.Path(exists=True), envvar="MYPATH")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -126,7 +126,7 @@ def test_multiple_bad_default(runner):
     result = runner.invoke(cli, [])
     assert result.exception
     assert (
-        "Default for parameter with multiple = True or nargs > 1 should be an iterable."
+        "Value for parameter with multiple = True or nargs > 1 should be an iterable."
         in result.exception.args
     )
 


### PR DESCRIPTION
Added a `try` block to check whether the default value provided to an option with `multiple=True` is a valid iterable. If the value is not a valid iterable, a `TypeError` with a better error message is raised.

- fixes #1749 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
