### PR TITLE
add pass_meta_key decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -184,6 +184,9 @@ Unreleased
     return a path object instead of a string. :issue:`405`
 -   ``TypeError`` is raised when parameter with ``multiple=True`` or
     ``nargs > 1`` has non-iterable default. :issue:`1749`
+-   Add a ``pass_meta_key`` decorator for passing a key from
+    ``Context.meta``. This is useful for extensions using ``meta`` to
+    store information. :issue:`1739`
 
 
 Version 7.1.2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,9 @@ Decorators
 
 .. autofunction:: make_pass_decorator
 
+.. autofunction:: click.decorators.pass_meta_key
+
+
 Utilities
 ---------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     "sphinx_issues",
     "sphinx_tabs.tabs",
 ]
+autodoc_typehints = "description"
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 issues_github_path = "pallets/click"
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -12,7 +12,8 @@ from .utils import echo
 if t.TYPE_CHECKING:
     F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
-def pass_context(f):
+
+def pass_context(f: "F") -> "F":
     """Marks a callback as wanting to receive the current context
     object as first argument.
     """
@@ -20,10 +21,10 @@ def pass_context(f):
     def new_func(*args, **kwargs):
         return f(get_current_context(), *args, **kwargs)
 
-    return update_wrapper(new_func, f)
+    return update_wrapper(t.cast("F", new_func), f)
 
 
-def pass_obj(f):
+def pass_obj(f: "F") -> "F":
     """Similar to :func:`pass_context`, but only pass the object on the
     context onwards (:attr:`Context.obj`).  This is useful if that object
     represents the state of a nested system.
@@ -32,10 +33,12 @@ def pass_obj(f):
     def new_func(*args, **kwargs):
         return f(get_current_context().obj, *args, **kwargs)
 
-    return update_wrapper(new_func, f)
+    return update_wrapper(t.cast("F", new_func), f)
 
 
-def make_pass_decorator(object_type, ensure=False):
+def make_pass_decorator(
+    object_type: t.Type, ensure: bool = False
+) -> "t.Callable[[F], F]":
     """Given an object type this creates a decorator that will work
     similar to :func:`pass_obj` but instead of passing the object of the
     current context, it will find the innermost context of type
@@ -58,22 +61,25 @@ def make_pass_decorator(object_type, ensure=False):
                    remembered on the context if it's not there yet.
     """
 
-    def decorator(f):
+    def decorator(f: "F") -> "F":
         def new_func(*args, **kwargs):
             ctx = get_current_context()
+
             if ensure:
                 obj = ctx.ensure_object(object_type)
             else:
                 obj = ctx.find_object(object_type)
+
             if obj is None:
                 raise RuntimeError(
                     "Managed to invoke callback without a context"
                     f" object of type {object_type.__name__!r}"
                     " existing."
                 )
+
             return ctx.invoke(f, obj, *args, **kwargs)
 
-        return update_wrapper(new_func, f)
+        return update_wrapper(t.cast("F", new_func), f)
 
     return decorator
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,6 +4,7 @@ import pytest
 
 import click
 from click.core import ParameterSource
+from click.decorators import pass_meta_key
 
 
 def test_ensure_context_objects(runner):
@@ -149,6 +150,28 @@ def test_context_meta(runner):
         assert get_language() == "de_DE"
 
     runner.invoke(cli, [], catch_exceptions=False)
+
+
+def test_make_pass_meta_decorator(runner):
+    @click.group()
+    @click.pass_context
+    def cli(ctx):
+        ctx.meta["value"] = "good"
+
+    @cli.command()
+    @pass_meta_key("value")
+    def show(value):
+        return value
+
+    result = runner.invoke(cli, ["show"], standalone_mode=False)
+    assert result.return_value == "good"
+
+
+def test_make_pass_meta_decorator_doc():
+    pass_value = pass_meta_key("value")
+    assert "the 'value' key from :attr:`click.Context.meta`" in pass_value.__doc__
+    pass_value = pass_meta_key("value", doc_description="the test value")
+    assert "passes the test value" in pass_value.__doc__
 
 
 def test_context_pushing():


### PR DESCRIPTION
Extensions using `Context.meta` can use `pass_meta_key` to create decorators for passing their data to callbacks. The `doc_description` parameter can be used to add a specific description of the object, so that the decorator's docs can be included in the extension's docs.

```python
# in the extension
from click.decorators import pass_meta_key
pass_auth = pass_meta_key("click-auth.auth", doc_description="the :class:`ClickAuth` object")
```

```
# in the extension's docs
pass_auth.__doc__
Decorator that passes the :class:`ClickAuth` object as the first argument to the decorated function.
```

```python
# in the user code
@pass_auth
def list_prs(auth):
    ...
```

Also changed docs config so typing information is shown next to parameter descriptions instead of in the signature. https://pallets-click--1807.org.readthedocs.build/en/1807/api/#click.decorators.pass_meta_key

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1739

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
