### PR TITLE
Default value iterable checks are done in __init__()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,6 +187,11 @@ Unreleased
 -   Add a ``pass_meta_key`` decorator for passing a key from
     ``Context.meta``. This is useful for extensions using ``meta`` to
     store information. :issue:`1739`
+-   Param ``multiple`` is moved from ``Option`` to ``Parameter`` to support
+    default value iterable checks for ``multiple=True`` or ``nargs>1``. The
+    checks are moved from ``type_cast_value`` to ``Parameter.__init__()``.
+    ``BadParameter`` is raised instead of ``TypeError`` when the checks fail.
+    :issue:`1806`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1876,6 +1876,14 @@ class Parameter:
                     " should be an iterable."
                 )
 
+        if self.type.is_composite:
+            if self.nargs <= 1:
+                raise BadParameter(
+                    "Attempted to invoke composite type but nargs has"
+                    f" been set to {self.nargs}. This is not supported;"
+                    " nargs needs to be set to a fixed value > 1."
+                )
+
         if autocompletion is not None:
             import warnings
 
@@ -2005,13 +2013,6 @@ class Parameter:
             return () if self.multiple or self.nargs == -1 else None
 
         if self.type.is_composite:
-            if self.nargs <= 1:
-                raise TypeError(
-                    "Attempted to invoke composite type but nargs has"
-                    f" been set to {self.nargs}. This is not supported;"
-                    " nargs needs to be set to a fixed value > 1."
-                )
-
             if self.multiple:
                 return tuple(self.type(x, self, ctx) for x in value)
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1779,6 +1779,10 @@ class Parameter:
                   the arity of the tuple). If ``nargs=-1``, all remaining
                   parameters are collected.
     :param metavar: how the value is represented in the help page.
+    :param multiple: if this is set to `True` then the argument is accepted
+                     multiple times and recorded.  This is similar to ``nargs``
+                     in how it works but supports arbitrary number of
+                     arguments.
     :param expose_value: if this is `True` then the value is passed onwards
                          to the command callback and stored on the context,
                          otherwise it's skipped.
@@ -1792,6 +1796,11 @@ class Parameter:
         given. Takes ``ctx, param, incomplete`` and must return a list
         of :class:`~click.shell_completion.CompletionItem` or a list of
         strings.
+
+    .. versionchanged:: 8.0
+        Param ``multiple`` is added for checking value provided as default
+        for ``multiple=True`` or ``nargs>1`` is an iterable. Iterable checks
+        from ``type_cast_value`` are moved to ``__init__``.
 
     .. versionchanged:: 8.0
         ``process_value`` validates required parameters and bounded
@@ -1872,8 +1881,8 @@ class Parameter:
                 self.default = iter(self.default)
             except TypeError:
                 raise BadParameter(
-                    "Default for parameter with multiple = True or nargs > 1"
-                    " should be an iterable."
+                    f"Default for parameter '{self.name}' with multiple = True"
+                    " or nargs > 1 should be an iterable."
                 )
 
         if self.type.is_composite:
@@ -2171,10 +2180,6 @@ class Option(Parameter):
     :param flag_value: which value should be used for this flag if it's
                        enabled.  This is set to a boolean automatically if
                        the option string contains a slash to mark two options.
-    :param multiple: if this is set to `True` then the argument is accepted
-                     multiple times and recorded.  This is similar to ``nargs``
-                     in how it works but supports arbitrary number of
-                     arguments.
     :param count: this flag makes an option increment an integer.
     :param allow_from_autoenv: if this is enabled then the value of this
                                parameter will be pulled from an environment
@@ -2196,7 +2201,6 @@ class Option(Parameter):
         hide_input=False,
         is_flag=None,
         flag_value=None,
-        multiple=False,
         count=False,
         allow_from_autoenv=True,
         type=None,
@@ -2207,7 +2211,7 @@ class Option(Parameter):
         **attrs,
     ):
         default_is_missing = attrs.get("default", _missing) is _missing
-        super().__init__(param_decls, type=type, multiple=multiple, **attrs)
+        super().__init__(param_decls, type=type, **attrs)
 
         if prompt is True:
             prompt_text = self.name.replace("_", " ").capitalize()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -117,13 +117,15 @@ def test_multiple_required(runner):
     assert "Error: Missing option '-m' / '--message'." in result.output
 
 
-@pytest.mark.parametrize(("multiple", "nargs"), [(True, None), (None, 2)])
-def test_multiple_bad_default(runner, multiple, nargs):
+@pytest.mark.parametrize(
+    ("name", "multiple", "nargs"), [("flags", True, None), ("message", None, 2)]
+)
+def test_multiple_bad_default(runner, name, multiple, nargs):
     with pytest.raises(
         click.BadParameter,
         match=(
-            "Default for parameter with multiple = True or nargs > 1 should be an"
-            " iterable."
+            f"Default for parameter '{name}' with multiple = True or nargs > 1"
+            " should be an iterable."
         ),
     ) as exc_info:
 
@@ -135,9 +137,9 @@ def test_multiple_bad_default(runner, multiple, nargs):
 
     message = str(exc_info.value)
     assert (
-        "Default for parameter with multiple = True or nargs > 1 should be an iterable."
-        in message
-    )
+        f"Default for parameter '{name}' with multiple = True or nargs > 1"
+        " should be an iterable."
+    ) in message
 
 
 def test_empty_envvar(runner):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -533,8 +533,8 @@ def test_option_help_preserve_paragraphs(runner):
         f"{i}\n"
         f"{i}If not given, the environment variable CONFIG_FILE is\n"
         f"{i}consulted and used if set. If neither are given, a default\n"
-        f"{i}configuration file is loaded." in result.output
-    )
+        f"{i}configuration file is loaded."
+    ) in result.output
 
 
 def test_argument_custom_class(runner):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -117,7 +117,8 @@ def test_multiple_required(runner):
     assert "Error: Missing option '-m' / '--message'." in result.output
 
 
-def test_multiple_bad_default(runner):
+@pytest.mark.parametrize(("multiple", "nargs"), [(True, None), (None, 2)])
+def test_multiple_bad_default(runner, multiple, nargs):
     with pytest.raises(
         click.BadParameter,
         match=(
@@ -127,7 +128,8 @@ def test_multiple_bad_default(runner):
     ) as exc_info:
 
         @click.command()
-        @click.option("--flags", multiple=True, default=False)
+        @click.option("--flags", multiple=multiple, default=False)
+        @click.argument("message", nargs=nargs, default=False)
         def cli(flags):
             pass
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -118,16 +118,23 @@ def test_multiple_required(runner):
 
 
 def test_multiple_bad_default(runner):
-    @click.command()
-    @click.option("--flags", multiple=True, default=False)
-    def cli(flags):
-        pass
+    with pytest.raises(
+        click.BadParameter,
+        match=(
+            "Default for parameter with multiple = True or nargs > 1 should be an"
+            " iterable."
+        ),
+    ) as exc_info:
 
-    result = runner.invoke(cli, [])
-    assert result.exception
+        @click.command()
+        @click.option("--flags", multiple=True, default=False)
+        def cli(flags):
+            pass
+
+    message = str(exc_info.value)
     assert (
-        "Value for parameter with multiple = True or nargs > 1 should be an iterable."
-        in result.exception.args
+        "Default for parameter with multiple = True or nargs > 1 should be an iterable."
+        in message
     )
 
 
@@ -526,8 +533,8 @@ def test_option_help_preserve_paragraphs(runner):
         f"{i}\n"
         f"{i}If not given, the environment variable CONFIG_FILE is\n"
         f"{i}consulted and used if set. If neither are given, a default\n"
-        f"{i}configuration file is loaded."
-    ) in result.output
+        f"{i}configuration file is loaded." in result.output
+    )
 
 
 def test_argument_custom_class(runner):


### PR DESCRIPTION
I have moved both checks to `Parameter.__init__()`. I've added a new parameter `multiple` in the `__init__` method of `Parameter`, which can be passed by both `Option` and `Argument` via `super.__init__()`, so that the checks can be performed there for both types of parameters. The check raises `BadParameter` with the name of the parameter that has the bad default. I've also updated the test.

fixes #1806 

Checklist:

- [x] Add tests that demonstrate the correct behaviour of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
