### PR TITLE
Fix: Deprecation notice now appears at the top of the help text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,6 +187,7 @@ Unreleased
 -   Add a ``pass_meta_key`` decorator for passing a key from
     ``Context.meta``. This is useful for extensions using ``meta`` to
     store information. :issue:`1739`
+-   Deprecation Notice now shows at the top of the help text. :issue: `1791`
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1224,7 +1224,7 @@ class Command(BaseCommand):
             with formatter.indentation():
                 help_text = self.help
                 if self.deprecated:
-                    help_text += DEPRECATED_HELP_NOTICE
+                    help_text = DEPRECATED_HELP_NOTICE + "\n" + help_text
                 formatter.write_text(help_text)
         elif self.deprecated:
             formatter.write_paragraph()
@@ -2011,15 +2011,7 @@ class Parameter:
             if level == 0:
                 return self.type(value, self, ctx)
 
-            try:
-                iter_value = iter(value)
-            except TypeError:
-                raise TypeError(
-                    "Value for parameter with multiple = True or nargs > 1"
-                    " should be an iterable."
-                )
-
-            return tuple(_convert(x, level - 1) for x in iter_value)
+            return tuple(_convert(x, level - 1) for x in value)
 
         return _convert(value, (self.nargs != 1) + bool(self.multiple))
 


### PR DESCRIPTION
This PR aims to fix the Issue of the deprecation notice getting printed alongside the help text. This PR makes the deprecation notice appear at the top of the help text.

- fixes #1791

Checklist:
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
