### PR TITLE
Deprecation notice now appears at the top of the help text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,9 @@ Unreleased
     store information. :issue:`1739`
 -   ``Path`` ``resolve_path`` resolves symlinks on Windows Python < 3.8.
     :issue:`1813`
+-   Command deprecation notice appears at the start of the help text, as
+    well as in the short help. The notice is not in all caps.
+    :issue:`1791`
 
 
 Version 7.1.2

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -297,14 +297,14 @@ def test_deprecated_in_help_messages(runner):
         pass
 
     result = runner.invoke(cmd_with_help, ["--help"])
-    assert "(DEPRECATED)" in result.output
+    assert "(Deprecated)" in result.output
 
     @click.command(deprecated=True)
     def cmd_without_help():
         pass
 
     result = runner.invoke(cmd_without_help, ["--help"])
-    assert "(DEPRECATED)" in result.output
+    assert "(Deprecated)" in result.output
 
 
 def test_deprecated_in_invocation(runner):


### PR DESCRIPTION
This PR makes the deprecation notice appear at the beginning of the help text.

- fixes #1791

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
