### PR TITLE
Fix issues with CliRunner's echo_stdin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,6 +208,8 @@ Unreleased
     :issue:`1568`
 -   The ``MultiCommand.resultcallback`` decorator is renamed to
     ``result_callback``. The old name is deprecated. :issue:`1160`
+-   Fix issues with ``CliRunner`` output when using ``echo_stdin=True``.
+    :issue:`1101`
 
 
 Version 7.1.2

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -52,29 +52,27 @@ def test_echo_stdin_prompts():
         click.echo(f"foo={foo}")
 
     runner = CliRunner(echo_stdin=True)
-    result = runner.invoke(test_python_input, input="wau wau\n")
+    result = runner.invoke(test_python_input, input="bar bar\n")
     assert not result.exception
-    assert result.output == "Foo: wau wau\nfoo=wau wau\n"
+    assert result.output == "Foo: bar bar\nfoo=bar bar\n"
 
     @click.command()
     @click.option("--foo", prompt=True)
     def test_prompt(foo):
         click.echo(f"foo={foo}")
 
-    runner = CliRunner(echo_stdin=True)
-    result = runner.invoke(test_prompt, input="wau wau\n")
+    result = runner.invoke(test_prompt, input="bar bar\n")
     assert not result.exception
-    assert result.output == "Foo: wau wau\nfoo=wau wau\n"
+    assert result.output == "Foo: bar bar\nfoo=bar bar\n"
 
     @click.command()
     @click.option("--foo", prompt=True, hide_input=True)
     def test_hidden_prompt(foo):
         click.echo(f"foo={foo}")
 
-    runner = CliRunner(echo_stdin=True)
-    result = runner.invoke(test_hidden_prompt, input="wau wau\n")
+    result = runner.invoke(test_hidden_prompt, input="bar bar\n")
     assert not result.exception
-    assert result.output == "Foo: \nfoo=wau wau\n"
+    assert result.output == "Foo: \nfoo=bar bar\n"
 
     @click.command()
     @click.option("--foo", prompt=True)
@@ -82,7 +80,6 @@ def test_echo_stdin_prompts():
     def test_multiple_prompts(foo, bar):
         click.echo(f"foo={foo}, bar={bar}")
 
-    runner = CliRunner(echo_stdin=True)
     result = runner.invoke(test_multiple_prompts, input="one\ntwo\n")
     assert not result.exception
     assert result.output == "Foo: one\nBar: two\nfoo=one, bar=two\n"


### PR DESCRIPTION
Fixes #1101 and some related issues with `CliRunner(echo_stdin=True)`.

As raised in #1101, with Python 2 any prompted input appears twice in the output recorded by `CliRunner` when using `echo_stdin=True`. It appears to work with Python 3 because `EchoingStdin` does not always echo. For example, using `input` instead of `click.prompt`:

```python
@click.command()
def test():
    foo = input("Foo: ")
    click.echo("foo={}".format(foo))

runner = CliRunner(echo_stdin=True)
result = runner.invoke(test, input="bar\n")
print(result.output)
```

**Expected output:**

    Foo: bar
    foo=bar

**Actual output:**

    Foo: foo=bar

**Environment:** Click 7.1.2, Python 3.7.7

Here the problem was that `TextIOWrapper` tries to call `read1` on the underlying input stream, which wasn't being overridden in `EchoingStdin`. After adding an echoing `read1`, both Python 2 and Python 3 double-echo with `click.prompt`.

I've modified `visible_input` not to echo when `echo_stdin=True`. To get consistent behaviour for hidden prompts (which should not echo even if `echo_stdin=True`) I also added a way to temporarily turn off echoing inside `hidden_input`. This is also used in `_getchar` if it gets passed `echo=False`.

Finally, there was one more subtle problem in Python 3. `TextIOWrapper` provides a buffered stream that reads a large chunk from the input before parsing out individual lines. When the underlying input stream is `EchoingStdin`, this causes all input (up to the chunk size) to be echoed at once. Here's another example:

```python
@click.command()
def test():
    click.prompt("a")
    click.prompt("b")

runner = CliRunner(echo_stdin=True)
result = runner.invoke(test, input="foo\nbar\n")
print(result.output)
```

**Expected output:**

    a: foo
    b: bar

**Actual output:**

    a: foo
    bar
    b: 

**Environment**: commit `21cde2f` (after the previously mentioned issues are fixed), Python 3.7.7

The only solution I found for this was to set the `_CHUNK_SIZE` attribute of `TextIOWrapper`, which is not documented (I found it [here](https://github.com/python/cpython/blob/7cb033c423b65def1632d6c3c747111543b342a2/Lib/_pyio.py#L1995)) and I guess that means it might not be compatible with all Python implementations. It would be great if someone knows a cleaner approach, otherwise I hope it's okay to contribute something like this.

---

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code. (n/a)
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs. (n/a)
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
