### PR TITLE
Overline and italic support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,7 +174,8 @@ Unreleased
     addition to its type. :issue:`457`
 -   ``confirmation_prompt`` can be set to a custom string. :issue:`723`
 -   Allow styled output in Jupyter on Windows. :issue:`1271`
--   ``style()`` supports the ``strikethrough`` style. :issue:`805`
+-   ``style()`` supports the ``strikethrough``, ``italic``, and
+    ``overline`` styles. :issue:`805, 1821`
 -   Multiline marker is removed from short help text. :issue:`1597`
 -   Restore progress bar behavior of echoing only the label if the file
     is not a TTY. :issue:`1138`

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -464,6 +464,8 @@ def style(
     bold=None,
     dim=None,
     underline=None,
+    overline=None,
+    italic=None,
     blink=None,
     reverse=None,
     strikethrough=None,
@@ -518,6 +520,8 @@ def style(
     :param dim: if provided this will enable or disable dim mode.  This is
                 badly supported.
     :param underline: if provided this will enable or disable underline.
+    :param overline: if provided this will enable or disable overline.
+    :param italic: if provided this will enable or disable italic.
     :param blink: if provided this will enable or disable blinking.
     :param reverse: if provided this will enable or disable inverse
                     rendering (foreground becomes background and the
@@ -535,7 +539,8 @@ def style(
        Added support for 256 and RGB color codes.
 
     .. versionchanged:: 8.0
-        Added the ``strikethrough`` parameter.
+        Added the ``strikethrough``, ``italic``, and ``overline``
+        parameters.
 
     .. versionchanged:: 7.0
         Added support for bright colors.
@@ -565,6 +570,10 @@ def style(
         bits.append(f"\033[{2 if dim else 22}m")
     if underline is not None:
         bits.append(f"\033[{4 if underline else 24}m")
+    if overline is not None:
+        bits.append(f"\033[{53 if underline else 55}m")
+    if italic is not None:
+        bits.append(f"\033[{5 if underline else 23}m")
     if blink is not None:
         bits.append(f"\033[{5 if blink else 25}m")
     if reverse is not None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,10 +64,15 @@ def test_echo_custom_file():
         ({"bg": "white"}, "\x1b[47mx y\x1b[0m"),
         ({"bg": 91}, "\x1b[48;5;91mx y\x1b[0m"),
         ({"bg": (135, 0, 175)}, "\x1b[48;2;135;0;175mx y\x1b[0m"),
-        ({"blink": True}, "\x1b[5mx y\x1b[0m"),
-        ({"underline": True}, "\x1b[4mx y\x1b[0m"),
         ({"bold": True}, "\x1b[1mx y\x1b[0m"),
         ({"dim": True}, "\x1b[2mx y\x1b[0m"),
+        ({"underline": True}, "\x1b[4mx y\x1b[0m"),
+        ({"overline": True}, "\x1b[55mx y\x1b[0m"),
+        ({"italic": True}, "\x1b[23mx y\x1b[0m"),
+        ({"blink": True}, "\x1b[5mx y\x1b[0m"),
+        ({"reverse": True}, "\x1b[7mx y\x1b[0m"),
+        ({"strikethrough": True}, "\x1b[9mx y\x1b[0m"),
+        ({"fg": "black", "reset": False}, "\x1b[30mx y"),
     ],
 )
 def test_styling(styles, ref):


### PR DESCRIPTION
This adds italics and overline support to `termui.style`

- fixes #1821

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
