### PR TITLE
Fix: resolve_path logic is now cross-platform compatible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,6 +187,8 @@ Unreleased
 -   Add a ``pass_meta_key`` decorator for passing a key from
     ``Context.meta``. This is useful for extensions using ``meta`` to
     store information. :issue:`1739`
+-   ``Path`` ``resolve_path`` resolves symlinks on Windows Python < 3.8.
+    :issue:`1813`
 
 
 Version 7.1.2

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -734,6 +734,10 @@ class Path(ParamType):
 
         if not is_dash:
             if self.resolve_path:
+                # realpath on Windows Python < 3.8 doesn't resolve symlinks
+                if os.path.islink(rv):
+                    rv = os.readlink(rv)
+
                 rv = os.path.realpath(rv)
 
             try:


### PR DESCRIPTION
The resolve_path logic, as mentioned in the Issue, is now cross-platform compatible.

- fixes #1813 

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
