### PR TITLE
Wrapped public messages with gettext for i18n support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,7 +197,7 @@ Unreleased
     :issue:`1791`
 -   When taking arguments from ``sys.argv`` on Windows, glob patterns,
     user dir, and env vars are expanded. :issue:`1096`
-
+-   Wrapped public messages with ``_(gettext)`` for i18n support. :issue:`303`
 
 Version 7.1.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,7 +197,9 @@ Unreleased
     :issue:`1791`
 -   When taking arguments from ``sys.argv`` on Windows, glob patterns,
     user dir, and env vars are expanded. :issue:`1096`
--   Wrapped public messages with ``_(gettext)`` for i18n support. :issue:`303`
+-   Marked messages shown by the CLI with ``gettext()`` to allow
+    applications to translate Click's built-in strings. :issue:`303`
+
 
 Version 7.1.2
 -------------

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -8,6 +8,7 @@ import math
 import os
 import sys
 import time
+from gettext import gettext as _
 
 from ._compat import _default_text_stdout
 from ._compat import CYGWIN
@@ -489,9 +490,13 @@ class Editor:
             c = subprocess.Popen(f'{editor} "{filename}"', env=environ, shell=True)
             exit_code = c.wait()
             if exit_code != 0:
-                raise ClickException(f"{editor}: Editing failed!")
+                raise ClickException(
+                    _("{editor}: Editing failed").format(editor=editor)
+                )
         except OSError as e:
-            raise ClickException(f"{editor}: Editing failed: {e}")
+            raise ClickException(
+                _("{editor}: Editing failed: {e}").format(editor=editor, e=e)
+            )
 
     def edit(self, text):
         import tempfile

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -6,6 +6,7 @@ import typing as t
 from contextlib import contextmanager
 from contextlib import ExitStack
 from functools import update_wrapper
+from gettext import gettext as _
 from itertools import repeat
 
 from ._unicodefun import _verify_python_env
@@ -995,7 +996,7 @@ class BaseCommand:
         except Abort:
             if not standalone_mode:
                 raise
-            echo("Aborted!", file=sys.stderr)
+            echo(_("Aborted!"), file=sys.stderr)
             sys.exit(1)
 
     def _main_shell_completion(self, ctx_args, prog_name, complete_var=None):
@@ -1170,7 +1171,7 @@ class Command(BaseCommand):
             is_eager=True,
             expose_value=False,
             callback=show_help,
-            help="Show this message and exit.",
+            help=_("Show this message and exit."),
         )
 
     def make_parser(self, ctx):
@@ -1280,7 +1281,9 @@ class Command(BaseCommand):
         if self.deprecated:
             echo(
                 style(
-                    f"DeprecationWarning: The command {self.name!r} is deprecated.",
+                    _(
+                        "DeprecationWarning: The command {self.name!r} is deprecated."
+                    ).format(self=self),
                     fg="red",
                 ),
                 err=True,

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -1,6 +1,7 @@
 import inspect
 import typing as t
 from functools import update_wrapper
+from gettext import gettext as _
 
 from .core import Argument
 from .core import Command
@@ -280,7 +281,7 @@ def version_option(
     *param_decls,
     package_name=None,
     prog_name=None,
-    message="%(prog)s, version %(version)s",
+    message=None,
     **kwargs,
 ):
     """Add a ``--version`` option which immediately prints the version
@@ -315,6 +316,9 @@ def version_option(
     .. versionchanged:: 8.0
         Use :mod:`importlib.metadata` instead of ``pkg_resources``.
     """
+    if message is None:
+        message = _("%(prog)s, version %(version)s")
+
     if version is None and package_name is None:
         frame = inspect.currentframe()
         f_globals = frame.f_back.f_globals if frame is not None else None
@@ -381,7 +385,7 @@ def version_option(
     kwargs.setdefault("is_flag", True)
     kwargs.setdefault("expose_value", False)
     kwargs.setdefault("is_eager", True)
-    kwargs.setdefault("help", "Show the version and exit.")
+    kwargs.setdefault("help", _("Show the version and exit."))
     kwargs["callback"] = callback
     return option(*param_decls, **kwargs)
 
@@ -412,6 +416,6 @@ def help_option(*param_decls, **kwargs):
     kwargs.setdefault("is_flag", True)
     kwargs.setdefault("expose_value", False)
     kwargs.setdefault("is_eager", True)
-    kwargs.setdefault("help", "Show this message and exit.")
+    kwargs.setdefault("help", _("Show this message and exit."))
     kwargs["callback"] = callback
     return option(*param_decls, **kwargs)

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -305,7 +305,8 @@ def version_option(
     :param prog_name: The name of the CLI to show in the message. If not
         provided, it will be detected from the command.
     :param message: The message to show. The values ``%(prog)s``,
-        ``%(package)s``, and ``%(version)s`` are available.
+        ``%(package)s``, and ``%(version)s`` are available. Defaults to
+        ``"%(prog)s, version %(version)s"``.
     :param kwargs: Extra arguments are passed to :func:`option`.
     :raise RuntimeError: ``version`` could not be detected.
 

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -1,3 +1,5 @@
+from gettext import gettext as _
+
 from ._compat import filename_to_ui
 from ._compat import get_text_stderr
 from .utils import echo
@@ -28,7 +30,7 @@ class ClickException(Exception):
     def show(self, file=None):
         if file is None:
             file = get_text_stderr()
-        echo(f"Error: {self.format_message()}", file=file)
+        echo(_("Error: {self.format_message()}").format(self=self), file=file)
 
 
 class UsageError(ClickException):
@@ -59,8 +61,16 @@ class UsageError(ClickException):
             )
         if self.ctx is not None:
             color = self.ctx.color
-            echo(f"{self.ctx.get_usage()}\n{hint}", file=file, color=color)
-        echo(f"Error: {self.format_message()}", file=file, color=color)
+            echo(
+                _("{usage}\n{hint}").format(usage=self.ctx.get_usage(), hint=hint),
+                file=file,
+                color=color,
+            )
+        echo(
+            _("Error: {message}").format(message=self.format_message()),
+            file=file,
+            color=color,
+        )
 
 
 class BadParameter(UsageError):
@@ -144,7 +154,7 @@ class MissingParameter(BadParameter):
     def __str__(self):
         if self.message is None:
             param_name = self.param.name if self.param else None
-            return f"missing parameter: {param_name}"
+            return _("missing parameter: {param_name}").format(param_name=param_name)
         else:
             return self.message
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -1,5 +1,6 @@
 import typing as t
 from contextlib import contextmanager
+from gettext import gettext as _
 
 from ._compat import term_len
 from .parser import split_opt
@@ -129,13 +130,17 @@ class HelpFormatter:
         """Decreases the indentation."""
         self.current_indent -= self.indent_increment
 
-    def write_usage(self, prog, args="", prefix="Usage: "):
+    def write_usage(self, prog, args="", prefix=None):
         """Writes a usage line into the buffer.
 
         :param prog: the program name.
         :param args: whitespace separated list of arguments.
-        :param prefix: the prefix for the first line.
+        :param prefix: The prefix for the first line. Defaults to
+            ``"Usage: "``.
         """
+        if prefix is None:
+            prefix = f"{_('Usage:')} "
+
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -22,6 +22,8 @@ Copyright 2002-2006 Python Software Foundation. All rights reserved.
 # Copyright 2001-2006 Gregory P. Ward
 # Copyright 2002-2006 Python Software Foundation
 from collections import deque
+from gettext import gettext as _
+from gettext import ngettext
 
 from .exceptions import BadArgumentUsage
 from .exceptions import BadOptionUsage
@@ -194,7 +196,9 @@ class Argument:
                 value = None
             elif holes != 0:
                 raise BadArgumentUsage(
-                    f"argument {self.dest} takes {self.nargs} values"
+                    _("Argument {name!r} takes {nargs} values.").format(
+                        name=self.dest, nargs=self.nargs
+                    )
                 )
 
         if self.nargs == -1 and self.obj.envvar is not None:
@@ -359,7 +363,9 @@ class OptionParser:
             value = self._get_value_from_state(opt, option, state)
 
         elif explicit_value is not None:
-            raise BadOptionUsage(opt, f"{opt} option does not take a value")
+            raise BadOptionUsage(
+                opt, _("Option {name!r} does not take a value.").format(name=opt)
+            )
 
         else:
             value = None
@@ -414,9 +420,13 @@ class OptionParser:
                 # Option allows omitting the value.
                 value = _flag_needs_value
             else:
-                n_str = "an argument" if nargs == 1 else f"{nargs} arguments"
                 raise BadOptionUsage(
-                    option_name, f"{option_name} option requires {n_str}."
+                    option_name,
+                    ngettext(
+                        "Option {name!r} requires an argument.",
+                        "Option {name!r} requires {nargs} arguments.",
+                        nargs,
+                    ).format(name=option_name, nargs=nargs),
                 )
         elif nargs == 1:
             next_rarg = state.rargs[0]

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -1,6 +1,7 @@
 import os
 import re
 import typing as t
+from gettext import gettext as _
 
 from .core import Argument
 from .core import MultiCommand
@@ -289,12 +290,14 @@ class BashComplete(ShellComplete):
 
             if major < "4" or major == "4" and minor < "4":
                 raise RuntimeError(
-                    "Shell completion is not supported for Bash"
-                    " versions older than 4.4."
+                    _(
+                        "Shell completion is not supported for Bash"
+                        " versions older than 4.4."
+                    )
                 )
         else:
             raise RuntimeError(
-                "Couldn't detect Bash version, shell completion is not supported."
+                _("Couldn't detect Bash version, shell completion is not supported.")
             )
 
     def source(self):

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -4,6 +4,7 @@ import itertools
 import os
 import sys
 import typing as t
+from gettext import gettext as _
 
 from ._compat import is_bytes
 from ._compat import isatty
@@ -145,7 +146,7 @@ def prompt(
 
     if confirmation_prompt:
         if confirmation_prompt is True:
-            confirmation_prompt = "Repeat for confirmation"
+            confirmation_prompt = _("Repeat for confirmation")
 
         confirmation_prompt = _build_prompt(confirmation_prompt, prompt_suffix)
 
@@ -161,9 +162,9 @@ def prompt(
             result = value_proc(value)
         except UsageError as e:
             if hide_input:
-                echo("Error: the value you entered was invalid", err=err)
+                echo(_("Error: the value you entered was invalid"), err=err)
             else:
-                echo(f"Error: {e.message}", err=err)  # noqa: B306
+                echo(_("Error: {e.message}").format(e=e), err=err)  # noqa: B306
             continue
         if not confirmation_prompt:
             return result
@@ -173,7 +174,7 @@ def prompt(
                 break
         if value == value2:
             return result
-        echo("Error: the two entered values do not match", err=err)
+        echo(_("Error: the two entered values do not match"), err=err)
 
 
 def confirm(
@@ -222,7 +223,7 @@ def confirm(
         elif default is not None and value == "":
             rv = default
         else:
-            echo("Error: invalid input", err=err)
+            echo(_("Error: invalid input"), err=err)
             continue
         break
     if abort and not rv:

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -162,7 +162,7 @@ def prompt(
             result = value_proc(value)
         except UsageError as e:
             if hide_input:
-                echo(_("Error: the value you entered was invalid"), err=err)
+                echo(_("Error: The value you entered was invalid."), err=err)
             else:
                 echo(_("Error: {e.message}").format(e=e), err=err)  # noqa: B306
             continue
@@ -174,7 +174,7 @@ def prompt(
                 break
         if value == value2:
             return result
-        echo(_("Error: the two entered values do not match"), err=err)
+        echo(_("Error: The two entered values do not match."), err=err)
 
 
 def confirm(
@@ -732,7 +732,7 @@ def raw_terminal():
     return f()
 
 
-def pause(info="Press any key to continue ...", err=False):
+def pause(info=None, err=False):
     """This command stops execution and waits for the user to press any
     key to continue.  This is similar to the Windows batch "pause"
     command.  If the program is not run through a terminal, this command
@@ -743,12 +743,17 @@ def pause(info="Press any key to continue ...", err=False):
     .. versionadded:: 4.0
        Added the `err` parameter.
 
-    :param info: the info string to print before pausing.
+    :param info: The message to print before pausing. Defaults to
+        ``"Press any key to continue..."``.
     :param err: if set to message goes to ``stderr`` instead of
                 ``stdout``, the same as with echo.
     """
     if not isatty(sys.stdin) or not isatty(sys.stdout):
         return
+
+    if info is None:
+        info = _("Press any key to continue...")
+
     try:
         if info:
             echo(info, nl=False, err=err)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -230,7 +230,7 @@ def test_missing_argument_string_cast():
     with pytest.raises(click.MissingParameter) as excinfo:
         click.Argument(["a"], required=True).process_value(ctx, None)
 
-    assert str(excinfo.value) == "missing parameter: a"
+    assert str(excinfo.value) == "Missing parameter: a"
 
 
 def test_implicit_non_required(runner):
@@ -301,7 +301,7 @@ def test_defaults_for_nargs(runner):
 
     result = runner.invoke(cmd, ["3"])
     assert result.exception is not None
-    assert "argument a takes 2 values" in result.output
+    assert "Argument 'a' takes 2 values." in result.output
 
 
 def test_multiple_param_decls_not_allowed(runner):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -120,7 +120,7 @@ def test_basic_option(runner):
 
     result = runner.invoke(cli, ["--foo"])
     assert result.exception
-    assert "--foo option requires an argument" in result.output
+    assert "Option '--foo' requires an argument." in result.output
 
     result = runner.invoke(cli, ["--foo="])
     assert not result.exception

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -47,6 +47,7 @@ ALLOWED_IMPORTS = {
     "enum",
     "typing",
     "types",
+    "gettext",
 }
 
 if WIN:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -83,7 +83,7 @@ def test_unknown_options(runner, unknown_flag):
 
     result = runner.invoke(cli, [unknown_flag])
     assert result.exception
-    assert f"no such option: {unknown_flag}" in result.output
+    assert f"No such option: {unknown_flag}" in result.output
 
 
 @pytest.mark.parametrize(
@@ -441,7 +441,7 @@ def test_missing_option_string_cast():
     with pytest.raises(click.MissingParameter) as excinfo:
         click.Option(["-a"], required=True).process_value(ctx, None)
 
-    assert str(excinfo.value) == "missing parameter: a"
+    assert str(excinfo.value) == "Missing parameter: a"
 
 
 def test_missing_choice(runner):

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -376,7 +376,7 @@ def test_fast_edit(runner):
     ("prompt_required", "required", "args", "expect"),
     [
         (True, False, None, "prompt"),
-        (True, False, ["-v"], "-v option requires an argument"),
+        (True, False, ["-v"], "Option '-v' requires an argument."),
         (False, True, None, "prompt"),
         (False, True, ["-v"], "prompt"),
     ],


### PR DESCRIPTION
Changes made - 

- Wrapped all exceptions
- Wrapped default help option text
- Wrapped default prompt text

I'm not sure if `__repr__` need to be wrapped.

- fixes #303 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
