### PR TITLE
revert adding space between option help

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,8 @@ Unreleased
     passed in as a default value.
     :issue:`549, 736, 764, 921, 1015, 1618`
 -   Fix formatting when ``Command.options_metavar`` is empty. :pr:`1551`
+-   Revert adding space between option help text that wraps.
+    :issue:`1831`
 -   The default value passed to ``prompt`` will be cast to the correct
     type like an input value would be. :pr:`1517`
 -   Automatically generated short help messages will stop at the first

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -225,10 +225,6 @@ class HelpFormatter:
 
                 for line in lines[1:]:
                     self.write(f"{'':>{first_col + self.current_indent}}{line}\n")
-
-                if len(lines) > 1:
-                    # separate long help from next option
-                    self.write("\n")
             else:
                 self.write("\n")
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -331,42 +331,6 @@ def test_global_show_default(runner):
     ]
 
 
-def test_formatting_usage_multiline_option_padding(runner):
-    @click.command("foo")
-    @click.option("--bar", help="This help message will be padded if it wraps.")
-    def cli():
-        pass
-
-    result = runner.invoke(cli, "--help", terminal_width=45)
-    assert not result.exception
-    assert result.output.splitlines() == [
-        "Usage: foo [OPTIONS]",
-        "",
-        "Options:",
-        "  --bar TEXT  This help message will be",
-        "              padded if it wraps.",
-        "",
-        "  --help      Show this message and exit.",
-    ]
-
-
-def test_formatting_usage_no_option_padding(runner):
-    @click.command("foo")
-    @click.option("--bar", help="This help message will be padded if it wraps.")
-    def cli():
-        pass
-
-    result = runner.invoke(cli, "--help", terminal_width=80)
-    assert not result.exception
-    assert result.output.splitlines() == [
-        "Usage: foo [OPTIONS]",
-        "",
-        "Options:",
-        "  --bar TEXT  This help message will be padded if it wraps.",
-        "  --help      Show this message and exit.",
-    ]
-
-
 def test_formatting_with_options_metavar_empty(runner):
     cli = click.Command("cli", options_metavar="", params=[click.Argument(["var"])])
     result = runner.invoke(cli, ["--help"])


### PR DESCRIPTION
People reported this was inconsistent. Effort should be devoted towards a more extensible formatting system instead.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1831 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
