### PR TITLE
test runner opens stderr with backslashreplace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -199,6 +199,8 @@ Unreleased
     user dir, and env vars are expanded. :issue:`1096`
 -   Marked messages shown by the CLI with ``gettext()`` to allow
     applications to translate Click's built-in strings. :issue:`303`
+-   Writing invalid characters  to ``stderr`` when using the test runner
+    does not raise a ``UnicodeEncodeError``. :issue:`848`
 
 
 Version 7.1.2

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -178,13 +178,17 @@ class CliRunner:
 
         This is automatically done in the :meth:`invoke` method.
 
-        .. versionadded:: 4.0
-           The ``color`` parameter was added.
-
         :param input: the input stream to put into sys.stdin.
         :param env: the environment overrides as dictionary.
         :param color: whether the output should contain color codes. The
                       application can still override this explicitly.
+
+        .. versionchanged:: 8.0
+            ``stderr`` is opened with ``errors="backslashreplace"``
+            instead of the default ``"strict"``.
+
+        .. versionchanged:: 4.0
+            Added the ``color`` parameter.
         """
         input = make_input_stream(input, self.charset)
 
@@ -214,7 +218,11 @@ class CliRunner:
         else:
             bytes_error = io.BytesIO()
             sys.stderr = _NamedTextIOWrapper(
-                bytes_error, encoding=self.charset, name="<stderr>", mode="w"
+                bytes_error,
+                encoding=self.charset,
+                name="<stderr>",
+                mode="w",
+                errors="backslashreplace",
             )
 
         def visible_input(prompt=None):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -334,3 +334,15 @@ def test_isolated_runner_custom_tempdir(runner, tmp_path):
 
     assert os.path.exists(d)
     os.rmdir(d)
+
+
+def test_isolation_stderr_errors():
+    """Writing to stderr should escape invalid characters instead of
+    raising a UnicodeEncodeError.
+    """
+    runner = CliRunner(mix_stderr=False)
+
+    with runner.isolation() as (_, err):
+        click.echo("\udce2", err=True, nl=False)
+
+    assert err.getvalue() == b"\\udce2"


### PR DESCRIPTION
This matches how Python opens `sys.stderr`. Writing invalid characters to stderr no longer fails.

- fixes #848

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
