### PR TITLE
Use `col_max` for `format_commands`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,6 +203,10 @@ Unreleased
     does not raise a ``UnicodeEncodeError``. :issue:`848`
 -   Fix an issue where ``readline`` would clear the entire ``prompt()``
     line instead of only the input when pressing backspace. :issue:`665`
+-   Added the ``col_max`` parameter to ``Context`` which gets passed
+    along to ``HelpFormatter.write_dl``. This allows you to customize
+    the width of the first column showing the command names
+    in the usage.
 
 
 Version 7.1.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -229,6 +229,7 @@ class Context:
     .. versionchanged:: 8.0
         The ``show_default`` parameter defaults to the value from the
         parent context.
+        Added the ``col_max`` parameter.
 
     .. versionchanged:: 7.1
        Added the ``show_default`` parameter.
@@ -330,7 +331,9 @@ class Context:
                 col_max = parent.col_max
             else:
                 col_max = 30
-        # The with maximum with of the command name column in usage.
+        #: The with maximum with of the command name column in usage.
+        #:
+        #: .. versionadded:: 8.0
         self.col_max = col_max
 
         if allow_extra_args is None:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -194,6 +194,7 @@ class Context:
                               format things wider than 80 characters by
                               default.  In addition to that, formatters might
                               add some safety mapping on the right.
+    :param col_max: the maximum with of the command name column in usage.
     :param resilient_parsing: if this flag is enabled then Click will
                               parse without any interactivity or callback
                               invocation.  Default values will also be
@@ -260,6 +261,7 @@ class Context:
         default_map=None,
         terminal_width=None,
         max_content_width=None,
+        col_max=None,
         resilient_parsing=False,
         allow_extra_args=None,
         allow_interspersed_args=None,
@@ -322,6 +324,11 @@ class Context:
         #: The maximum width of formatted content (None implies a sensible
         #: default which is 80 for most things).
         self.max_content_width = max_content_width
+
+        if col_max is None and parent is not None:
+            col_max = parent.col_max
+        # The with maximum with of the command name column in usage.
+        self.col_max = col_max
 
         if allow_extra_args is None:
             allow_extra_args = command.allow_extra_args
@@ -1472,7 +1479,9 @@ class MultiCommand(Command):
 
         # allow for 3 times the default spacing
         if len(commands):
-            limit = formatter.width - 6 - max(len(cmd[0]) for cmd in commands)
+            # default col_max is 30
+            limit = formatter.width - (ctx.col_max - 30) \
+                - 6 - max(len(cmd[0]) for cmd in commands)
 
             rows = []
             for subcommand, cmd in commands:
@@ -1481,7 +1490,7 @@ class MultiCommand(Command):
 
             if rows:
                 with formatter.section(_("Commands")):
-                    formatter.write_dl(rows)
+                    formatter.write_dl(rows, col_max=ctx.col_max)
 
     def parse_args(self, ctx, args):
         if not args and self.no_args_is_help and not ctx.resilient_parsing:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1483,8 +1483,12 @@ class MultiCommand(Command):
         # allow for 3 times the default spacing
         if len(commands):
             # default col_max is 30
-            limit = formatter.width - (ctx.col_max - 30) \
-                - 6 - max(len(cmd[0]) for cmd in commands)
+            limit = (
+                formatter.width
+                - (ctx.col_max - 30)
+                - 6
+                - max(len(cmd[0]) for cmd in commands)
+            )
 
             rows = []
             for subcommand, cmd in commands:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -325,8 +325,11 @@ class Context:
         #: default which is 80 for most things).
         self.max_content_width = max_content_width
 
-        if col_max is None and parent is not None:
-            col_max = parent.col_max
+        if col_max is None:
+            if parent is not None:
+                col_max = parent.col_max
+            else:
+                col_max = 30
         # The with maximum with of the command name column in usage.
         self.col_max = col_max
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -194,7 +194,7 @@ class HelpFormatter:
         )
         self.write("\n")
 
-    def write_dl(self, rows, col_max=30, col_spacing=2):
+    def write_dl(self, rows, col_max=None, col_spacing=2):
         """Writes a definition list into the buffer.  This is how options
         and commands are usually formatted.
 
@@ -203,6 +203,10 @@ class HelpFormatter:
         :param col_spacing: the number of spaces between the first and
                             second column.
         """
+
+        if col_max is None:
+            col_max = 30
+
         rows = list(rows)
         widths = measure_table(rows)
         if len(widths) != 2:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -335,3 +335,25 @@ def test_formatting_with_options_metavar_empty(runner):
     cli = click.Command("cli", options_metavar="", params=[click.Argument(["var"])])
     result = runner.invoke(cli, ["--help"])
     assert "Usage: cli VAR\n" in result.output
+
+
+def test_col_max_in_format_commands(runner):
+    @click.group(context_settings=dict(col_max=2))
+    def group():
+        pass
+
+    @group.group()
+    def command():
+        """docstring"""
+
+    result = runner.invoke(group, ["--help"])
+    assert result.output.splitlines() == [
+        "Usage: group [OPTIONS] COMMAND [ARGS]...",
+        "",
+        "Options:",
+        "  --help  Show this message and exit.",
+        "",
+        "Commands:",
+        "  command",
+        "      docstring",
+    ]


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1842

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
I don't think all parameters for `Context` are documented (such as `terminal_width`, and this is more niche than that).

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
