### PR TITLE
use os.fsdecode to display paths

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -333,14 +333,6 @@ def get_text_stderr(encoding=None, errors=None):
     return _force_correct_text_writer(sys.stderr, encoding, errors, force_writable=True)
 
 
-def filename_to_ui(value):
-    if isinstance(value, bytes):
-        value = value.decode(get_filesystem_encoding(), "replace")
-    else:
-        value = value.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
-    return value
-
-
 def get_strerror(e, default=None):
     if hasattr(e, "strerror"):
         msg = e.strerror

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -1,7 +1,7 @@
+import os
 from gettext import gettext as _
 from gettext import ngettext
 
-from ._compat import filename_to_ui
 from ._compat import get_text_stderr
 from .utils import echo
 
@@ -226,12 +226,11 @@ class FileError(ClickException):
     """Raised if a file cannot be opened."""
 
     def __init__(self, filename, hint=None):
-        ui_filename = filename_to_ui(filename)
         if hint is None:
             hint = _("unknown error")
 
         super().__init__(hint)
-        self.ui_filename = ui_filename
+        self.ui_filename = os.fsdecode(filename)
         self.filename = filename
 
     def format_message(self):

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -6,7 +6,6 @@ from gettext import gettext as _
 from gettext import ngettext
 
 from ._compat import _get_argv_encoding
-from ._compat import filename_to_ui
 from ._compat import get_filesystem_encoding
 from ._compat import get_strerror
 from ._compat import open_stream
@@ -655,7 +654,7 @@ class File(ParamType):
                     ctx.call_on_close(safecall(f.flush))
             return f
         except OSError as e:  # noqa: B014
-            self.fail(f"{filename_to_ui(value)!r}: {get_strerror(e)}", param, ctx)
+            self.fail(f"{os.fsdecode(value)!r}: {get_strerror(e)}", param, ctx)
 
     def shell_complete(self, ctx, param, incomplete):
         """Return a special completion marker that tells the completion
@@ -776,7 +775,7 @@ class Path(ParamType):
                     return self.coerce_path_result(rv)
                 self.fail(
                     _("{name} {filename!r} does not exist.").format(
-                        name=self.name.title(), filename=filename_to_ui(value)
+                        name=self.name.title(), filename=os.fsdecode(value)
                     ),
                     param,
                     ctx,
@@ -785,7 +784,7 @@ class Path(ParamType):
             if not self.file_okay and stat.S_ISREG(st.st_mode):
                 self.fail(
                     _("{name} {filename!r} is a file.").format(
-                        name=self.name.title(), filename=filename_to_ui(value)
+                        name=self.name.title(), filename=os.fsdecode(value)
                     ),
                     param,
                     ctx,
@@ -793,7 +792,7 @@ class Path(ParamType):
             if not self.dir_okay and stat.S_ISDIR(st.st_mode):
                 self.fail(
                     _("{name} {filename!r} is a directory.").format(
-                        name=self.name.title(), filename=filename_to_ui(value)
+                        name=self.name.title(), filename=os.fsdecode(value)
                     ),
                     param,
                     ctx,
@@ -801,7 +800,7 @@ class Path(ParamType):
             if self.writable and not os.access(value, os.W_OK):
                 self.fail(
                     _("{name} {filename!r} is not writable.").format(
-                        name=self.name.title(), filename=filename_to_ui(value)
+                        name=self.name.title(), filename=os.fsdecode(value)
                     ),
                     param,
                     ctx,
@@ -809,7 +808,7 @@ class Path(ParamType):
             if self.readable and not os.access(value, os.R_OK):
                 self.fail(
                     _("{name} {filename!r} is not readable.").format(
-                        name=self.name.title(), filename=filename_to_ui(value)
+                        name=self.name.title(), filename=os.fsdecode(value)
                     ),
                     param,
                     ctx,

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -7,7 +7,6 @@ from ._compat import _default_text_stdout
 from ._compat import _find_binary_writer
 from ._compat import auto_wrap_for_ansi
 from ._compat import binary_streams
-from ._compat import filename_to_ui
 from ._compat import get_filesystem_encoding
 from ._compat import get_strerror
 from ._compat import is_bytes
@@ -355,7 +354,8 @@ def format_filename(filename, shorten=False):
     """
     if shorten:
         filename = os.path.basename(filename)
-    return filename_to_ui(filename)
+
+    return os.fsdecode(filename)
 
 
 def get_app_dir(app_name, roaming=True, force_posix=False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,7 @@ def test_filename_formatting():
 
     # filesystem encoding on windows permits this.
     if not WIN:
-        assert click.format_filename(b"/x/foo\xff.txt", shorten=True) == "foo\ufffd.txt"
+        assert click.format_filename(b"/x/foo\xff.txt", shorten=True) == "foo\udcff.txt"
 
 
 def test_prompts(runner):


### PR DESCRIPTION
Works with `pathlib.Path`. Consistent with Python's output, `fsdecode` uses `errors="surrogatescape"` instead of `"replace"`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1844 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
