### PR TITLE
rename resultcallback to result_callback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -206,6 +206,8 @@ Unreleased
 -   Add all kwargs passed to ``Context.invoke()`` to ``ctx.params``.
     Fixes an inconsistency when nesting ``Context.forward()`` calls.
     :issue:`1568`
+-   The ``MultiCommand.resultcallback`` decorator is renamed to
+    ``result_callback``. The old name is deprecated. :issue:`1160`
 
 
 Version 7.1.2

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -351,7 +351,7 @@ how to do its processing.  At that point it then returns a processing
 function and returns.
 
 Where do the returned functions go?  The chained multicommand can register
-a callback with :meth:`MultiCommand.resultcallback` that goes over all
+a callback with :meth:`MultiCommand.result_callback` that goes over all
 these functions and then invoke them.
 
 To make this a bit more concrete consider this example:
@@ -363,7 +363,7 @@ To make this a bit more concrete consider this example:
     def cli(input):
         pass
 
-    @cli.resultcallback()
+    @cli.result_callback()
     def process_pipeline(processors, input):
         iterator = (x.rstrip('\r\n') for x in input)
         for processor in processors:

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -90,7 +90,7 @@ restored.
 If you do require the know which exact commands will be invoked there are
 different ways to cope with this.  The first one is to let the subcommands
 all return functions and then to invoke the functions in a
-:meth:`Context.resultcallback`.
+:meth:`Context.result_callback`.
 
 
 .. _upgrade-to-2.0:

--- a/examples/imagepipe/imagepipe.py
+++ b/examples/imagepipe/imagepipe.py
@@ -20,7 +20,7 @@ def cli():
     """
 
 
-@cli.resultcallback()
+@cli.result_callback()
 def process_commands(processors):
     """This result callback is invoked with an iterable of all the chained
     subcommands.  As in this example each subcommand returns a function

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -99,7 +99,7 @@ def test_no_command_result_callback(runner, chain, expect):
     def cli():
         pass
 
-    @cli.resultcallback()
+    @cli.result_callback()
     def process_result(result):
         click.echo(str(result), nl=False)
 
@@ -133,7 +133,7 @@ def test_pipeline(runner):
     def cli(input):
         pass
 
-    @cli.resultcallback()
+    @cli.result_callback()
     def process_pipeline(processors, input):
         iterator = (x.rstrip("\r\n") for x in input)
         for processor in processors:


### PR DESCRIPTION
This is a clearer name for the decorator. The attribute is renamed to `_result_callback`, the only mention in the docs already implied that it shouldn't be used directly and should be set with the parameter or decorator.

- fixes #1160 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
