### PR TITLE
fix: allow 'autocompletion' function to return any kind of iterable 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,3 +101,6 @@ ignore_missing_imports = True
 
 [mypy-importlib_metadata.*]
 ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ per-file-ignores =
     src/click/__init__.py: F401
 
 [mypy]
-files = src/click
+files = src/click, tests/test_shell_completion.py
 python_version = 3.6
 disallow_subclassing_any = True
 disallow_untyped_calls = True

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2027,7 +2027,7 @@ class Parameter:
         ] = None,
         autocompletion: t.Optional[
             t.Callable[
-                [Context, t.List[str], str], t.List[t.Union[t.Tuple[str, str], str]]
+                [Context, t.List[str], str], t.Iterable[t.Union[t.Tuple[str, str], str]]
             ]
         ] = None,
     ) -> None:


### PR DESCRIPTION
This is related to #1856 (0103c9570650daa59560baf42ad0a27e57b3157f) and addresses the same issue as in python/typeshed#5265.

Specifically the type annotation introduced there forces the `autocompletion` function to have `List[str]` as return type even though the implementation never required that. It only needs `Iterable[str]`. This causes some [functional autocompletion functions](https://github.com/tomtom-international/hopic/blob/release/1/hopic/cli/autocomplete.py#L91-L100) to get rejected by `mypy` even though there's (ostensibly) no reason for that.

I'm not sure whether an issue needs to be created for this as this problem isn't present in any released code (yet).

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

no relevant docs:

- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add `.. versionchanged::` entries in any relevant code docs.