### PR TITLE
Fix HelpFormatter.write_text() to use the full line width

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,8 @@ Unreleased
 -   When defining a parameter, ``default`` is validated with
     ``multiple`` and ``nargs``. More validation is done for values being
     processed as well. :issue:`1806`
+-   ``HelpFormatter.write_text`` uses the full line width when wrapping
+    text. :issue:`1871`
 
 
 Version 7.1.2

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -195,12 +195,11 @@ class HelpFormatter:
         """Writes re-indented text into the buffer.  This rewraps and
         preserves paragraphs.
         """
-        text_width = max(self.width - self.current_indent, 11)
         indent = " " * self.current_indent
         self.write(
             wrap_text(
                 text,
-                text_width,
+                self.width,
                 initial_indent=indent,
                 subsequent_indent=indent,
                 preserve_paragraphs=True,

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -335,3 +335,13 @@ def test_formatting_with_options_metavar_empty(runner):
     cli = click.Command("cli", options_metavar="", params=[click.Argument(["var"])])
     result = runner.invoke(cli, ["--help"])
     assert "Usage: cli VAR\n" in result.output
+
+
+def test_help_formatter_write_text():
+    text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    formatter = click.HelpFormatter(width=len("  Lorem ipsum dolor sit amet,"))
+    formatter.current_indent = 2
+    formatter.write_text(text)
+    actual = formatter.getvalue()
+    expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
+    assert actual == expected


### PR DESCRIPTION
Fixes #1871.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
