### PR TITLE
Update typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.0.1
 
 Unreleased
 
+-   Mark top-level names as exported so type checking understand imports
+    in user projects. :issue:`1879`
+
 
 Version 8.0.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Mark top-level names as exported so type checking understand imports
     in user projects. :issue:`1879`
+-   Annotate ``Context.obj`` as ``Any`` so type checking allows all
+    operations on the arbitrary object. :issue:`
 
 
 Version 8.0.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Unreleased
 -   Mark top-level names as exported so type checking understand imports
     in user projects. :issue:`1879`
 -   Annotate ``Context.obj`` as ``Any`` so type checking allows all
-    operations on the arbitrary object. :issue:`
+    operations on the arbitrary object. :issue:`1885`
+-   Fix some types that weren't available in Python 3.6.0. :issue:`1882`
 
 
 Version 8.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,9 +93,6 @@ warn_unused_ignores = True
 warn_return_any = True
 warn_unreachable = True
 
-[mypy-click]
-no_implicit_reexport = False
-
 [mypy-colorama.*]
 ignore_missing_imports = True
 

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -4,72 +4,72 @@ writing command line scripts fun. Unlike other modules, it's based
 around a simple API that does not come with too much magic and is
 composable.
 """
-from .core import Argument
-from .core import BaseCommand
-from .core import Command
-from .core import CommandCollection
-from .core import Context
-from .core import Group
-from .core import MultiCommand
-from .core import Option
-from .core import Parameter
-from .decorators import argument
-from .decorators import command
-from .decorators import confirmation_option
-from .decorators import group
-from .decorators import help_option
-from .decorators import make_pass_decorator
-from .decorators import option
-from .decorators import pass_context
-from .decorators import pass_obj
-from .decorators import password_option
-from .decorators import version_option
-from .exceptions import Abort
-from .exceptions import BadArgumentUsage
-from .exceptions import BadOptionUsage
-from .exceptions import BadParameter
-from .exceptions import ClickException
-from .exceptions import FileError
-from .exceptions import MissingParameter
-from .exceptions import NoSuchOption
-from .exceptions import UsageError
-from .formatting import HelpFormatter
-from .formatting import wrap_text
-from .globals import get_current_context
-from .parser import OptionParser
-from .termui import clear
-from .termui import confirm
-from .termui import echo_via_pager
-from .termui import edit
-from .termui import get_terminal_size
-from .termui import getchar
-from .termui import launch
-from .termui import pause
-from .termui import progressbar
-from .termui import prompt
-from .termui import secho
-from .termui import style
-from .termui import unstyle
-from .types import BOOL
-from .types import Choice
-from .types import DateTime
-from .types import File
-from .types import FLOAT
-from .types import FloatRange
-from .types import INT
-from .types import IntRange
-from .types import ParamType
-from .types import Path
-from .types import STRING
-from .types import Tuple
-from .types import UNPROCESSED
-from .types import UUID
-from .utils import echo
-from .utils import format_filename
-from .utils import get_app_dir
-from .utils import get_binary_stream
-from .utils import get_os_args
-from .utils import get_text_stream
-from .utils import open_file
+from .core import Argument as Argument
+from .core import BaseCommand as BaseCommand
+from .core import Command as Command
+from .core import CommandCollection as CommandCollection
+from .core import Context as Context
+from .core import Group as Group
+from .core import MultiCommand as MultiCommand
+from .core import Option as Option
+from .core import Parameter as Parameter
+from .decorators import argument as argument
+from .decorators import command as command
+from .decorators import confirmation_option as confirmation_option
+from .decorators import group as group
+from .decorators import help_option as help_option
+from .decorators import make_pass_decorator as make_pass_decorator
+from .decorators import option as option
+from .decorators import pass_context as pass_context
+from .decorators import pass_obj as pass_obj
+from .decorators import password_option as password_option
+from .decorators import version_option as version_option
+from .exceptions import Abort as Abort
+from .exceptions import BadArgumentUsage as BadArgumentUsage
+from .exceptions import BadOptionUsage as BadOptionUsage
+from .exceptions import BadParameter as BadParameter
+from .exceptions import ClickException as ClickException
+from .exceptions import FileError as FileError
+from .exceptions import MissingParameter as MissingParameter
+from .exceptions import NoSuchOption as NoSuchOption
+from .exceptions import UsageError as UsageError
+from .formatting import HelpFormatter as HelpFormatter
+from .formatting import wrap_text as wrap_text
+from .globals import get_current_context as get_current_context
+from .parser import OptionParser as OptionParser
+from .termui import clear as clear
+from .termui import confirm as confirm
+from .termui import echo_via_pager as echo_via_pager
+from .termui import edit as edit
+from .termui import get_terminal_size as get_terminal_size
+from .termui import getchar as getchar
+from .termui import launch as launch
+from .termui import pause as pause
+from .termui import progressbar as progressbar
+from .termui import prompt as prompt
+from .termui import secho as secho
+from .termui import style as style
+from .termui import unstyle as unstyle
+from .types import BOOL as BOOL
+from .types import Choice as Choice
+from .types import DateTime as DateTime
+from .types import File as File
+from .types import FLOAT as FLOAT
+from .types import FloatRange as FloatRange
+from .types import INT as INT
+from .types import IntRange as IntRange
+from .types import ParamType as ParamType
+from .types import Path as Path
+from .types import STRING as STRING
+from .types import Tuple as Tuple
+from .types import UNPROCESSED as UNPROCESSED
+from .types import UUID as UUID
+from .utils import echo as echo
+from .utils import format_filename as format_filename
+from .utils import get_app_dir as get_app_dir
+from .utils import get_binary_stream as get_binary_stream
+from .utils import get_os_args as get_os_args
+from .utils import get_text_stream as get_text_stream
+from .utils import open_file as open_file
 
 __version__ = "8.0.1.dev0"

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -308,7 +308,7 @@ class Context:
             obj = parent.obj
 
         #: the user object stored.
-        self.obj: t.Optional[t.Any] = obj
+        self.obj: t.Any = obj
         self._meta: t.Dict[str, t.Any] = getattr(parent, "meta", {})
 
         #: A dictionary (-like object) with defaults for parameters.

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -50,7 +50,7 @@ F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 V = t.TypeVar("V")
 
 
-def _fast_exit(code: int) -> t.NoReturn:
+def _fast_exit(code: int) -> "te.NoReturn":
     """Low-level exit that skips Python's cleanup but speeds up exit by
     about 10ms for things like shell completion.
 
@@ -679,7 +679,7 @@ class Context:
 
         return None
 
-    def fail(self, message: str) -> t.NoReturn:
+    def fail(self, message: str) -> "te.NoReturn":
         """Aborts the execution of the program with a specific error
         message.
 
@@ -687,11 +687,11 @@ class Context:
         """
         raise UsageError(message, self)
 
-    def abort(self) -> t.NoReturn:
+    def abort(self) -> "te.NoReturn":
         """Aborts the script."""
         raise Abort()
 
-    def exit(self, code: int = 0) -> t.NoReturn:
+    def exit(self, code: int = 0) -> "te.NoReturn":
         """Exits the application with a given exit code."""
         raise Exit(code)
 
@@ -977,7 +977,7 @@ class BaseCommand:
         complete_var: t.Optional[str] = None,
         standalone_mode: "te.Literal[True]" = True,
         **extra: t.Any,
-    ) -> t.NoReturn:
+    ) -> "te.NoReturn":
         ...
 
     @typing.overload

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -32,6 +32,7 @@ from .exceptions import NoSuchOption
 from .exceptions import UsageError
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from .core import Argument as CoreArgument
     from .core import Context
     from .core import Option as CoreOption
@@ -62,7 +63,7 @@ def _unpack_args(
     rv: t.List[t.Union[str, t.Tuple[t.Optional[str], ...], None]] = []
     spos: t.Optional[int] = None
 
-    def _fetch(c: t.Deque[V]) -> t.Optional[V]:
+    def _fetch(c: "te.Deque[V]") -> t.Optional[V]:
         try:
             if spos is None:
                 return c.popleft()

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -123,7 +123,7 @@ class ParamType:
         message: str,
         param: t.Optional["Parameter"] = None,
         ctx: t.Optional["Context"] = None,
-    ) -> t.NoReturn:
+    ) -> "t.NoReturn":
         """Helper method to fail with an invalid value message."""
         raise BadParameter(message, ctx=ctx, param=param)
 


### PR DESCRIPTION
* Mark imports in `__init__` as exports.
* Mark `ctx.obj` as `Any`.
* Use `typing_extensions` for some types that aren't available in 3.6.0.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1879 
- fixes #1885 
- fixes #1882 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
