### PR TITLE
install importlib_metadata on Python < 3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 -   Fix some types that weren't available in Python 3.6.0. :issue:`1882`
 -   Fix type checking for iterating over ``ProgressBar`` object.
     :issue:`1892`
+-   The ``importlib_metadata`` backport package is installed on Python <
+    3.8. :issue:`1889`
 
 
 Version 8.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,8 +34,6 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.0.1
-    # via -r requirements/tests.in
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
@@ -133,8 +131,6 @@ virtualenv==20.4.6
     # via
     #   pre-commit
     #   tox
-zipp==3.4.1
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,2 +1,1 @@
 pytest
-importlib_metadata

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,8 +6,6 @@
 #
 attrs==21.2.0
     # via pytest
-importlib-metadata==4.0.1
-    # via -r requirements/tests.in
 iniconfig==1.1.1
     # via pytest
 packaging==20.9
@@ -22,5 +20,3 @@ pytest==6.2.4
     # via -r requirements/tests.in
 toml==0.10.2
     # via pytest
-zipp==3.4.1
-    # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
 from setuptools import setup
 
-setup(name="click", install_requires=["colorama; platform_system == 'Windows'"])
+setup(
+    name="click",
+    install_requires=[
+        "colorama; platform_system == 'Windows'",
+        "importlib-metadata; python_version < '3.8'",
+    ],
+)

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -370,15 +370,7 @@ def version_option(
                 from importlib import metadata  # type: ignore
             except ImportError:
                 # Python < 3.8
-                try:
-                    import importlib_metadata as metadata  # type: ignore
-                except ImportError:
-                    metadata = None
-
-            if metadata is None:
-                raise RuntimeError(
-                    "Install 'importlib_metadata' to get the version on Python < 3.8."
-                )
+                import importlib_metadata as metadata  # type: ignore
 
             try:
                 version = metadata.version(package_name)  # type: ignore


### PR DESCRIPTION
Install `importlib_metadata` backport package when on Python < 3.8, instead of asking the user to do so.

As stated on the original issue, feel free to express any concerns, doubts or point that I've missed that makes this unreasonable in Click's context.

- fixes #1889

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
