### PR TITLE
fix argument parsing when generating help text

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2219,7 +2219,15 @@ class Parameter:
 
             value = value()
 
-        return self.type_cast_value(ctx, value)
+        try:
+            # allow the type casting to fail if ``call`` is False which is used for
+            # generating help.
+            return self.type_cast_value(ctx, value)
+        except BadParameter:
+            if not call:
+                return value
+
+            raise
 
     def add_to_parser(self, parser: OptionParser, ctx: Context) -> None:
         raise NotImplementedError()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -345,3 +345,25 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_invalid_default(runner):
+    @click.command()
+    @click.option(
+        "-f",
+        type=click.Path(exists=True, file_okay=True),
+        default="this does not exist",
+        help="Output file name",
+        show_default=True,
+    )
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.output.splitlines() == [
+        "Usage: cli [OPTIONS]",
+        "",
+        "Options:",
+        "  -f PATH  Output file name  [default: this does not exist]",
+        "  --help   Show this message and exit.",
+    ]


### PR DESCRIPTION
Using `click.Path` for an argument may prevent the `--help` from showing up. A simple example is the following:

```
@click.command()
@click.option(
    "-f",
    type=click.Path(exists=True, file_okay=True),
    default="this does not exist",
    help="Output file name",
    show_default=True,
)
def cli():
    pass
```

When trying to print the `--help` the default argument will be checked for validity and instead print an error that `-f` is an invalid value. This change allows the default value to be displayed even if parsing of the value failed (but it will still try to parse in case it can better represent the default).

Environment:

- Python version: Python 3.8.9
- Click version: 8.0.0

- fixes #1899

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
