### PR TITLE
Add Python3 classifiers to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
 
 [options]
 packages = find:


### PR DESCRIPTION
This adds python 3 / python 3 only classifiers to the setup.cfg, which is e.g. used for searching packages on PyPI. It is only metadata, not used for any actual checks (this is what `python_requires` is for). 

Checklist:

Not relevant for this change
