### PR TITLE
don't ignore value when nargs=-1 and envvar set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 -   Annotate ``Context.obj`` as ``Any`` so type checking allows all
     operations on the arbitrary object. :issue:`1885`
 -   Fix some types that weren't available in Python 3.6.0. :issue:`1882`
+-   Fix arguments with ``nargs=-1`` and ``envvar`` set. :issue:`1903`
 
 
 Version 8.0.0

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -233,7 +233,9 @@ class Argument:
                     )
                 )
 
-        if self.nargs == -1 and self.obj.envvar is not None:
+        if self.nargs == -1 and self.obj.envvar is not None and value == ():
+            # Replace empty tuple with None so that the value from the
+            # environment is used.
             value = None
 
         state.opts[self.dest] = value  # type: ignore

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -194,6 +194,19 @@ def test_nargs_envvar(runner, nargs, value, expect):
         assert result.return_value == expect
 
 
+def test_vararg_envvar_not_used(runner):
+    @click.command()
+    @click.argument("arg", envvar="X", nargs=-1)
+    def cmd(arg):
+        return arg
+
+    value = ("arg1", "arg2")
+
+    result = runner.invoke(cmd, args=value, standalone_mode=False)
+
+    assert result.return_value == value
+
+
 def test_empty_nargs(runner):
     @click.command()
     @click.argument("arg", nargs=-1)


### PR DESCRIPTION
A change in 3d3ea9c6 broke variadic arguments with an `envvar`
setting: the `process` method replaced `value` with `None`
uncoditionally, thus ignoring the values passed on the command line.
The intention of this was probably to replace the empty tuple (when no
arguments were passed) with `None` so that the value from the
environment would be picked later on. Adjust the condition accordingly
and add a test that covers this.

- fixes #1903

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
