### PR TITLE
ProgressBar inherits Generic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   Annotate ``Context.obj`` as ``Any`` so type checking allows all
     operations on the arbitrary object. :issue:`1885`
 -   Fix some types that weren't available in Python 3.6.0. :issue:`1882`
+-   Fix type checking for iterating over ``ProgressBar`` object.
+    :issue:`1892`
 
 
 Version 8.0.0

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -32,7 +32,7 @@ else:
     AFTER_BAR = "\033[?25h\n"
 
 
-class ProgressBar:
+class ProgressBar(t.Generic[V]):
     def __init__(
         self,
         iterable: t.Optional[t.Iterable[V]],
@@ -50,7 +50,7 @@ class ProgressBar:
         color: t.Optional[bool] = None,
         update_min_steps: int = 1,
         width: int = 30,
-    ):
+    ) -> None:
         self.fill_char = fill_char
         self.empty_char = empty_char
         self.bar_template = bar_template
@@ -101,7 +101,7 @@ class ProgressBar:
     def __exit__(self, exc_type, exc_value, tb):  # type: ignore
         self.render_finish()
 
-    def __iter__(self) -> t.Iterable[V]:
+    def __iter__(self) -> t.Iterator[V]:
         if not self.entered:
             raise RuntimeError("You need to use progress bars in a with block.")
         self.render_progress()
@@ -113,7 +113,7 @@ class ProgressBar:
         # because `self.iter` is an iterable consumed by that generator,
         # so it is re-entry safe. Calling `next(self.generator())`
         # twice works and does "what you want".
-        return next(iter(self))  # type: ignore
+        return next(iter(self))
 
     def render_finish(self) -> None:
         if self.is_hidden:

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -318,7 +318,7 @@ def progressbar(
     file: t.Optional[t.TextIO] = None,
     color: t.Optional[bool] = None,
     update_min_steps: int = 1,
-) -> "ProgressBar":
+) -> "ProgressBar[V]":
     """This function creates an iterable context manager that can be used
     to iterate over something while showing a progress bar.  It will
     either iterate over the `iterable` or `length` items (that are counted


### PR DESCRIPTION
For some reason this still reports the type of `for x in bar` as `Any` instead of the type of the data being iterated over, but this does fix the issue with `iter` returning the wrong type or saying `x` was untyped.

- fixes #1892

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
