### PR TITLE
argument with nargs=-1 and envvar prefers command line value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
     :issue:`1892`
 -   The ``importlib_metadata`` backport package is installed on Python <
     3.8. :issue:`1889`
+-   Arguments with ``nargs=-1`` only use env var value if no command
+    line values are given. :issue:`1903`
 
 
 Version 8.0.0

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -233,7 +233,9 @@ class Argument:
                     )
                 )
 
-        if self.nargs == -1 and self.obj.envvar is not None:
+        if self.nargs == -1 and self.obj.envvar is not None and value == ():
+            # Replace empty tuple with None so that a value from the
+            # environment may be tried.
             value = None
 
         state.opts[self.dest] = value  # type: ignore

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -194,6 +194,19 @@ def test_nargs_envvar(runner, nargs, value, expect):
         assert result.return_value == expect
 
 
+def test_nargs_envvar_only_if_values_empty(runner):
+    @click.command()
+    @click.argument("arg", envvar="X", nargs=-1)
+    def cli(arg):
+        return arg
+
+    result = runner.invoke(cli, ["a", "b"], standalone_mode=False)
+    assert result.return_value == ("a", "b")
+
+    result = runner.invoke(cli, env={"X": "a"}, standalone_mode=False)
+    assert result.return_value == ("a",)
+
+
 def test_empty_nargs(runner):
     @click.command()
     @click.argument("arg", nargs=-1)


### PR DESCRIPTION
Resubmitting #1906 with some cleanup, cc @MarcSchmitzer. Rebased to 8.0.x, updated test with value from envvar, updated changelog and comment.

If an `Argument` has `nargs=-1` and `envvar` set, it was ignoring command line values and always trying the env var. Now it only does that if no command line values were given (empty tuple).

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1903

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
