### PR TITLE
update changelog about version_option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,8 +33,10 @@ Released 2021-05-11
 -   Add an optional parameter to ``ProgressBar.update`` to set the
     ``current_item``. :issue:`1226`, :pr:`1332`
 -   ``version_option`` uses ``importlib.metadata`` (or the
-    ``importlib_metadata`` backport) instead of ``pkg_resources``.
-    :issue:`1582`
+    ``importlib_metadata`` backport) instead of ``pkg_resources``. The
+    version is detected based on the package name, not the entry point
+    name. The Python package name must match the installed package
+    name, or be passed with ``package_name=``. :issue:`1582`
 -   If validation fails for a prompt with ``hide_input=True``, the value
     is not shown in the error message. :issue:`1460`
 -   An ``IntRange`` or ``FloatRange`` option shows the accepted range in

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -330,7 +330,10 @@ def version_option(
         value for messages.
 
     .. versionchanged:: 8.0
-        Use :mod:`importlib.metadata` instead of ``pkg_resources``.
+        Use :mod:`importlib.metadata` instead of ``pkg_resources``. The
+        version is detected based on the package name, not the entry
+        point name. The Python package name must match the installed
+        package name, or be passed with ``package_name=``.
     """
     if message is None:
         message = _("%(prog)s, version %(version)s")


### PR DESCRIPTION
Better documentation of the change in #1582. The version is detected from the package name instead of the entry point name, so the Python package name must match the installed package name, or the installed name must be given with `package_name=`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- closes #1884 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
