### PR TITLE
detect type from flag_value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     3.8. :issue:`1889`
 -   Arguments with ``nargs=-1`` only use env var value if no command
     line values are given. :issue:`1903`
+-   Flag options guess their type from ``flag_value`` if given, like
+    regular options do from ``default``. :issue:`1886`
 
 
 Version 8.0.0

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1000,10 +1000,7 @@ def convert_type(ty: t.Optional[t.Any], default: t.Optional[t.Any] = None) -> Pa
     if ty is float:
         return FLOAT
 
-    # Booleans are only okay if not guessed. For is_flag options with
-    # flag_value, default=True indicates which flag_value is the
-    # default.
-    if ty is bool and not guessed_type:
+    if ty is bool:
         return BOOL
 
     if guessed_type:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -756,3 +756,10 @@ def test_option_with_optional_value(runner, args, expect):
 
     result = runner.invoke(cli, args, standalone_mode=False, catch_exceptions=False)
     assert result.return_value == expect
+
+
+def test_type_from_flag_value():
+    param = click.Option(["-a", "x"], default=True, flag_value=4)
+    assert param.type is click.INT
+    param = click.Option(["-b", "x"], flag_value=8)
+    assert param.type is click.INT


### PR DESCRIPTION
If `type` is not given and the option is a flag, the type is detected from `flag_value` instead of falling back to `STRING`. This works even if `default=True` is given for feature flags, which simplifies `convert_type` a bit.

For 8.1, a further change to consider is for `convert_type` to return `UNPROCESSED` instead of `STRING` if the type was guessed from the default value. In that case, what should really happen is that a custom `type` should have been provided that would recognize/return the value in `default`, but converting it to `STRING` isn't correct either.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1886

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
