### PR TITLE
return resolved name, not original name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Unreleased
     regular options do from ``default``. :issue:`1886`
 -   Added documentation that custom parameter types may be passed
     already valid values in addition to strings. :issue:`1898`
+-   Resolving commands returns the name that was given, not
+    ``command.name``, fixing an unintended change to help text and
+    ``default_map`` lookups. When using patterns like ``AliasedGroup``,
+    override ``resolve_command`` to change the name that is returned if
+    needed. :issue:`1895`
 
 
 Version 8.0.0

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -35,7 +35,6 @@ it would accept ``pus`` as an alias (so long as it was unique):
 .. click:example::
 
     class AliasedGroup(click.Group):
-
         def get_command(self, ctx, cmd_name):
             rv = click.Group.get_command(self, ctx, cmd_name)
             if rv is not None:
@@ -47,6 +46,11 @@ it would accept ``pus`` as an alias (so long as it was unique):
             elif len(matches) == 1:
                 return click.Group.get_command(self, ctx, matches[0])
             ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+
+        def resolve_command(self, ctx, args):
+            # always return the full command name
+            _, cmd, args = super().resolve_command(ctx, args)
+            return cmd.name, cmd, args
 
 And it can then be used like this:
 

--- a/examples/aliases/aliases.py
+++ b/examples/aliases/aliases.py
@@ -67,6 +67,11 @@ class AliasedGroup(click.Group):
             return click.Group.get_command(self, ctx, matches[0])
         ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
 
+    def resolve_command(self, ctx, args):
+        # always return the command's name, not the alias
+        _, cmd, args = super().resolve_command(ctx, args)
+        return cmd.name, cmd, args
+
 
 def read_config(ctx, param, value):
     """Callback that is used whenever --config is passed.  We use this to

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1717,7 +1717,7 @@ class MultiCommand(Command):
             if split_opt(cmd_name)[0]:
                 self.parse_args(ctx, ctx.args)
             ctx.fail(_("No such command {name!r}.").format(name=original_cmd_name))
-        return cmd.name if cmd else None, cmd, args[1:]
+        return cmd_name if cmd else None, cmd, args[1:]
 
     def get_command(self, ctx: Context, cmd_name: str) -> t.Optional[Command]:
         """Given a context and a command name, this returns a


### PR DESCRIPTION
Reverts #1422, but updates the documentation to get the desired behavior instead. Always returning the command's original name ignored that the command could be registered with a different name like `group.add_command(cmd, name)`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1895 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
