### PR TITLE
show help text with invalid default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
     ``default_map`` lookups. When using patterns like ``AliasedGroup``,
     override ``resolve_command`` to change the name that is returned if
     needed. :issue:`1895`
+-   If a default value is invalid, it does not prevent showing help
+    text. :issue:`1889`
 
 
 Version 8.0.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -547,3 +547,20 @@ def test_summary_line(runner):
     result = runner.invoke(cli, ["--help"])
     assert "Summary line without period" in result.output
     assert "Here is a sentence." not in result.output
+
+
+def test_help_invalid_default(runner):
+    cli = click.Command(
+        "cli",
+        params=[
+            click.Option(
+                ["-a"],
+                type=click.Path(exists=True),
+                default="not found",
+                show_default=True,
+            ),
+        ],
+    )
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "default: not found" in result.output

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -553,7 +553,7 @@ def test_option_help_preserve_paragraphs(runner):
 
 def test_argument_custom_class(runner):
     class CustomArgument(click.Argument):
-        def get_default(self, ctx):
+        def get_default(self, ctx, call=True):
             """a dumb override of a default value for testing"""
             return "I am a default"
 


### PR DESCRIPTION
If `ctx.resilient_parsing` is enabled, type casting can fail when getting the default, and the raw invalid value will be returned instead. Showing help text temporarily enables resilient parsing mode when fetching the default. I wasn't sure what the effect would be of enabling that for the entire help formatting, so it's just local to the default right now.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1899

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
