### PR TITLE
flag to control Windows pattern expansion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Unreleased
     needed. :issue:`1895`
 -   If a default value is invalid, it does not prevent showing help
     text. :issue:`1889`
+-   Pass ``windows_expand_args=False`` when calling the main command to
+    disable pattern expansion on Windows. There is no way to escape
+    patterns in CMD, so if the program needs to pass them on as-is then
+    expansion must be disabled. :issue:`1901`
 
 
 Version 8.0.0

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -993,6 +993,7 @@ class BaseCommand:
         prog_name: t.Optional[str] = None,
         complete_var: t.Optional[str] = None,
         standalone_mode: bool = True,
+        windows_expand_args: bool = True,
         **extra: t.Any,
     ) -> t.Any:
         """This is the way to invoke a script with all the bells and
@@ -1021,8 +1022,14 @@ class BaseCommand:
                                 propagated to the caller and the return
                                 value of this function is the return value
                                 of :meth:`invoke`.
+        :param windows_expand_args: Expand glob patterns, user dir, and
+            env vars in command line args on Windows.
         :param extra: extra keyword arguments are forwarded to the context
                       constructor.  See :class:`Context` for more information.
+
+        .. versionchanged:: 8.0.1
+            Added the ``windows_expand_args`` parameter to allow
+            disabling command line arg expansion on Windows.
 
         .. versionchanged:: 8.0
             When taking arguments from ``sys.argv`` on Windows, glob
@@ -1038,7 +1045,7 @@ class BaseCommand:
         if args is None:
             args = sys.argv[1:]
 
-            if os.name == "nt":
+            if os.name == "nt" and windows_expand_args:
                 args = _expand_args(args)
         else:
             args = list(args)


### PR DESCRIPTION
Windows terminals don't do pattern expansion, so #1096 requested simulating it in Click. However, Windows also doesn't have a way to escape patterns so that the literal value is used. This adds a flag `cli(windows_expand_args=False)` to disable expansion.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1901 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
