### PR TITLE
bash version detection is locale independent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   ``is_bool_flag`` is not set to ``True`` if ``is_flag`` is ``False``.
     :issue:`1925`
+-   Bash version detection is locale independent. :issue:`1940`
 
 
 Version 8.0.1

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -302,8 +302,10 @@ class BashComplete(ShellComplete):
     def _check_version(self) -> None:
         import subprocess
 
-        output = subprocess.run(["bash", "--version"], stdout=subprocess.PIPE)
-        match = re.search(r"version (\d)\.(\d)\.\d", output.stdout.decode())
+        output = subprocess.run(
+            ["bash", "-c", "echo ${BASH_VERSION}"], stdout=subprocess.PIPE
+        )
+        match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 
         if match is not None:
             major, minor = match.groups()


### PR DESCRIPTION
The `BASH_VERSION` variable holds the bash version number in a much 
better consumable and especially locale independent format than the 
`--version` flag.

This fixes #1940

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
