### PR TITLE
Stop using exception.message

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -177,7 +177,7 @@ def prompt(
             if hide_input:
                 echo(_("Error: The value you entered was invalid."), err=err)
             else:
-                echo(_("Error: {e.message}").format(e=e), err=err)  # noqa: B306
+                echo(_("Error: {}").format(e), err=err)  # noqa: B306
             continue
         if not confirmation_prompt:
             return result


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1713825#c0

> In PEP 352, exception.message was deprecated (now, you can get the string from of an exception by simply doing str(exception). As of Python 3.0, exception.message was dropped, and attempting to access it causes an error.