### PR TITLE
Fix help text when using env vars with defaults

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2760,7 +2760,7 @@ class Option(Parameter):
             extra.append(_("required"))
 
         if extra:
-            extra_str = ";".join(extra)
+            extra_str = "; ".join(extra)
             help = f"{help}  [{extra_str}]" if help else f"[{extra_str}]"
 
         return ("; " if any_prefix_is_slash else " / ").join(rv), help


### PR DESCRIPTION
```
Options:
  -t, --target TEXT  The release plugin to use  [env var:
                     HATCH_RELEASE_TARGET;default: pypi]
```

to

```
Options:
  -t, --target TEXT  The release plugin to use  [env var:
                     HATCH_RELEASE_TARGET; default: pypi]
```

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
