### PR TITLE
Give `Option.show_default` higher priority wrt `Context.show_default`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Version 8.1.0
     without parentheses. :issue:`1359`
 -   The ``Path`` type can check whether the target is executable.
     :issue:`1961`
+-   ``Command.show_default`` overrides ``Context.show_default``, instead
+    of the other way around. :issue:`1963`
 
 
 Version 8.0.4

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -643,7 +643,6 @@ def test_option_custom_class_reusable(runner):
 
     # Both of the commands should have the --help option now.
     for cmd in (cmd1, cmd2):
-
         result = runner.invoke(cmd, ["--help"])
         assert "I am a help text" in result.output
         assert "you wont see me" not in result.output
@@ -793,6 +792,28 @@ def test_do_not_show_default_empty_multiple():
     ctx = click.Context(click.Command("cli"))
     message = opt.get_help_record(ctx)[1]
     assert message == "values"
+
+
+@pytest.mark.parametrize(
+    ("ctx_value", "opt_value", "expect"),
+    [
+        (None, None, False),
+        (None, False, False),
+        (None, True, True),
+        (False, None, False),
+        (False, False, False),
+        (False, True, True),
+        (True, None, True),
+        (True, False, False),
+        (True, True, True),
+        (False, "one", True),
+    ],
+)
+def test_show_default_precedence(ctx_value, opt_value, expect):
+    ctx = click.Context(click.Command("test"), show_default=ctx_value)
+    opt = click.Option("-a", default=1, help="value", show_default=opt_value)
+    help = opt.get_help_record(ctx)[1]
+    assert ("default:" in help) is expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1963. 

After this, a non-null `show_default` passed to an option overrides the corresponding context setting. 

### Implementation notes
- This also fixes the previous type hint of `Option.show_default`, adding `str` to the `Union`. 
- I didn't include `str` in the type of `Context.show_default` because, as far as I understand, passing a `str` makes sense for dynamic options (not for a global default).
- Added a static constant `Option.DEFAULT_SHOW_DEFAULT = False`. If you change your mind about the default, the tests I added don't require any change.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
