### PR TITLE
Across the codebase, handle the case a keyword argument is provided but set to `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Version 8.1.0
     :issue:`1961`
 -   ``Command.show_default`` overrides ``Context.show_default``, instead
     of the other way around. :issue:`1963`
+-   Parameter decorators and ``@group`` handles ``cls=None`` the same as
+    not passing ``cls``. ``@option`` handles ``help=None`` the same as
+    not passing ``help``. :issue:`#1959`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1819,7 +1819,7 @@ class Group(MultiCommand):
         """
         from .decorators import command
 
-        if self.command_class is not None and "cls" not in kwargs:
+        if self.command_class and kwargs.get("cls") is None:
             kwargs["cls"] = self.command_class
 
         func: t.Optional[t.Callable] = None
@@ -1863,7 +1863,7 @@ class Group(MultiCommand):
             func = args[0]
             args = args[1:]
 
-        if self.group_class is not None and "cls" not in kwargs:
+        if self.group_class is not None and kwargs.get("cls") is None:
             if self.group_class is type:
                 kwargs["cls"] = type(self)
             else:

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -244,7 +244,8 @@ def group(
     .. versionchanged:: 8.1
         This decorator can be applied without parentheses.
     """
-    attrs.setdefault("cls", Group)
+    if attrs.get("cls") is None:
+        attrs["cls"] = Group
 
     if callable(name):
         grp: t.Callable[[F], Group] = t.cast(Group, command(**attrs))
@@ -275,7 +276,7 @@ def argument(*param_decls: str, **attrs: t.Any) -> t.Callable[[FC], FC]:
     """
 
     def decorator(f: FC) -> FC:
-        ArgumentClass = attrs.pop("cls", Argument)
+        ArgumentClass = attrs.pop("cls", None) or Argument
         _param_memo(f, ArgumentClass(param_decls, **attrs))
         return f
 
@@ -297,9 +298,9 @@ def option(*param_decls: str, **attrs: t.Any) -> t.Callable[[FC], FC]:
         # Issue 926, copy attrs, so pre-defined options can re-use the same cls=
         option_attrs = attrs.copy()
 
-        if "help" in option_attrs:
+        if option_attrs.get("help"):
             option_attrs["help"] = inspect.cleandoc(option_attrs["help"])
-        OptionClass = option_attrs.pop("cls", Option)
+        OptionClass = option_attrs.pop("cls", None) or Option
         _param_memo(f, OptionClass(param_decls, **option_attrs))
         return f
 


### PR DESCRIPTION
In several points, Click relies _exclusively_ on the following check to verify if an argument `arg_name` has been provided: `arg_name in attrs`. Then it assumes that `attrs[arg_name] is not None`. This PR is about treating `None` values in `attrs` as "not provided" too.

- Fixes #1959 and similar issues in command decorators (see commit messages).

There are probably other points in the codebase that do the same thing. If you intend to merge this, I'll go on and search more in depth. I'll also add a test and a changelog entry.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
