### PR TITLE
Fix version parsing

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -303,7 +303,7 @@ class BashComplete(ShellComplete):
         import subprocess
 
         output = subprocess.run(["bash", "--version"], stdout=subprocess.PIPE)
-        match = re.search(r"version (\d)\.(\d)\.\d", output.stdout.decode())
+        match = re.search(r"(\d+)\.(\d+)\.\d", output.stdout.decode())
 
         if match is not None:
             major, minor = match.groups()


### PR DESCRIPTION
- issue described in https://github.com/pallets/click/issues/1967
- PR removes string `'versions'` from regex intended to parse version from `bash --version` 
- it also allows multidigit numbers for possibly higher bash version

