### PR TITLE
Empty default value in help output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   ``is_bool_flag`` is not set to ``True`` if ``is_flag`` is ``False``.
     :issue:`1925`
 -   Bash version detection is locale independent. :issue:`1940`
+-   Empty ``default`` value is not shown for ``multiple=True``.
+    :issue:`1969`
 
 
 Version 8.0.1

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2748,7 +2748,8 @@ class Option(Parameter):
             else:
                 default_string = str(default_value)
 
-            extra.append(_("default: {default}").format(default=default_string))
+            if default_string:
+                extra.append(_("default: {default}").format(default=default_string))
 
         if isinstance(self.type, types._NumberRangeBase):
             range_str = self.type._describe_range()

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2461,7 +2461,7 @@ class Option(Parameter):
     def __init__(
         self,
         param_decls: t.Optional[t.Sequence[str]] = None,
-        show_default: bool = False,
+        show_default: t.Union[bool, str] = False,
         prompt: t.Union[bool, str] = False,
         confirmation_prompt: t.Union[bool, str] = False,
         prompt_required: bool = True,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -728,6 +728,16 @@ def test_do_not_show_no_default(runner):
     assert "[default: None]" not in message
 
 
+def test_do_not_show_default_empty_multiple():
+    """When show_default is True and multiple=True is set, it should not
+    print empty default value in --help output.
+    """
+    opt = click.Option(["-a"], multiple=True, help="values", show_default=True)
+    ctx = click.Context(click.Command("cli"))
+    message = opt.get_help_record(ctx)[1]
+    assert message == "values"
+
+
 @pytest.mark.parametrize(
     ("args", "expect"),
     [


### PR DESCRIPTION
This PR solves the problem with printing empty default values in `--help` output when `@click.option` has `multiple=True` set.

- fixes #1969

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
