### PR TITLE
Added DateTime type documentation under API types reference.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,6 +141,8 @@ Types
 
 .. autoclass:: FloatRange
 
+.. autoclass:: DateTime
+
 .. autoclass:: Tuple
 
 .. autoclass:: ParamType


### PR DESCRIPTION
Documentation-only change, adding autoclass for DateTime under API types reference, as described in #1974 .

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1974