### PR TITLE
allow exception text override

### DIFF
--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -31,7 +31,7 @@ class ClickException(Exception):
         self.message = message
 
     def format_message(self) -> str:
-        return self.message
+        return _("Error: {message}").format(message=self.message)
 
     def __str__(self) -> str:
         return self.message
@@ -40,7 +40,7 @@ class ClickException(Exception):
         if file is None:
             file = get_text_stderr()
 
-        echo(_("Error: {message}").format(message=self.format_message()), file=file)
+        echo(self.format_message(), file=file)
 
 
 class UsageError(ClickException):

--- a/tests/test_custom_classes.py
+++ b/tests/test_custom_classes.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from typing import IO
+import io
 
 import click
 
@@ -123,19 +122,6 @@ def test_custom_exception_class():
         def format_message(self) -> str:
             return f"CustomError: {self.message}"
 
-    class MockStdIO(IO, metaclass=ABCMeta):
-        value = None
-
-        def write(self, *args, **kwargs):
-            self.value = args[0]
-
-    try:
-        raise CustomException("Bad things happened")
-    except CustomException as excinfo:
-        exc = excinfo
-
-    mock_file = MockStdIO()
-    exc.show(mock_file)
-
-    assert isinstance(exc, click.ClickException)
-    assert str(mock_file.value.strip()) == "CustomError: Bad things happened"
+    mock_file = io.StringIO()
+    CustomException("Bad things happened").show(mock_file)
+    assert str(mock_file.getvalue().strip()) == "CustomError: Bad things happened"


### PR DESCRIPTION
This is to allow overriding of the base Exception text: "Error: {message}"
Accomplished by moving the error-text definition and translation to format_message()

- fixes #1917

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
