### PR TITLE
Move processing of `help` from `@option` into `Option`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Version 8.1.0
 -   Parameter decorators and ``@group`` handles ``cls=None`` the same as
     not passing ``cls``. ``@option`` handles ``help=None`` the same as
     not passing ``help``. :issue:`#1959`
+-   Help text passed to ``Option`` is processed the same way as using
+    the ``@option`` decorator. :issue:`1985`
 
 
 Version 8.0.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,8 +27,10 @@ Version 8.1.0
 -   Parameter decorators and ``@group`` handles ``cls=None`` the same as
     not passing ``cls``. ``@option`` handles ``help=None`` the same as
     not passing ``help``. :issue:`#1959`
--   Help text passed to ``Option`` is processed the same way as using
-    the ``@option`` decorator. :issue:`1985`
+-   Indentation in help text passed to ``Option`` and ``Command`` is
+    cleaned the same as using the ``@option`` and ``@command``
+    decorators does. A command's ``epilog`` and ``short_help`` are also
+    processed. :issue:`1985`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2416,6 +2416,10 @@ class Option(Parameter):
     :param hidden: hide this option from help outputs.
 
     .. versionchanged:: 8.1.0
+        Help text indentation is cleaned here instead of only in the
+        ``@option`` decorator.
+
+    .. versionchanged:: 8.1.0
         The ``show_default`` parameter overrides
         ``Context.show_default``.
 
@@ -2449,6 +2453,9 @@ class Option(Parameter):
         show_envvar: bool = False,
         **attrs: t.Any,
     ) -> None:
+        if help:
+            help = inspect.cleandoc(help)
+
         default_is_missing = "default" not in attrs
         super().__init__(param_decls, type=type, multiple=multiple, **attrs)
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1133,13 +1133,6 @@ class Command(BaseCommand):
     Click.  A basic command handles command line parsing and might dispatch
     more parsing to commands nested below it.
 
-    .. versionchanged:: 2.0
-       Added the `context_settings` parameter.
-    .. versionchanged:: 8.0
-       Added repr showing the command name
-    .. versionchanged:: 7.1
-       Added the `no_args_is_help` parameter.
-
     :param name: the name of the command to use unless a group overrides it.
     :param context_settings: an optional dictionary with defaults that are
                              passed to the context object.
@@ -1161,6 +1154,20 @@ class Command(BaseCommand):
 
     :param deprecated: issues a message indicating that
                              the command is deprecated.
+
+    .. versionchanged:: 8.1
+        Indentation in ``help`` is cleaned here instead of only in the
+        ``@command`` decorator. ``epilog`` and ``short_help`` are also
+        cleaned.
+
+    .. versionchanged:: 8.0
+        Added a ``repr`` showing the command name.
+
+    .. versionchanged:: 7.1
+        Added the ``no_args_is_help`` parameter.
+
+    .. versionchanged:: 2.0
+        Added the ``context_settings`` parameter.
     """
 
     def __init__(
@@ -1187,10 +1194,20 @@ class Command(BaseCommand):
         #: will automatically be handled before non eager ones.
         self.params: t.List["Parameter"] = params or []
 
-        # if a form feed (page break) is found in the help text, truncate help
-        # text to the content preceding the first form feed
-        if help and "\f" in help:
-            help = help.split("\f", 1)[0]
+        if help:
+            help = inspect.cleandoc(help)
+
+            # Discard help text after a first form feed (page break)
+            # character, to allow writing longer documentation in
+            # docstrings that does not show in help output.
+            if "\f" in help:
+                help = help.partition("\f")[0]
+
+        if epilog:
+            epilog = inspect.cleandoc(epilog)
+
+        if short_help:
+            short_help = inspect.cleandoc(short_help)
 
         self.help = help
         self.epilog = epilog

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -137,14 +137,9 @@ def _make_command(
     except AttributeError:
         params = []
 
-    help = attrs.get("help")
+    if attrs.get("help") is None:
+        attrs["help"] = inspect.getdoc(f)
 
-    if help is None:
-        help = inspect.getdoc(f)
-    else:
-        help = inspect.cleandoc(help)
-
-    attrs["help"] = help
     return cls(
         name=name or f.__name__.lower().replace("_", "-"),
         callback=f,

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -297,9 +297,6 @@ def option(*param_decls: str, **attrs: t.Any) -> t.Callable[[FC], FC]:
     def decorator(f: FC) -> FC:
         # Issue 926, copy attrs, so pre-defined options can re-use the same cls=
         option_attrs = attrs.copy()
-
-        if option_attrs.get("help"):
-            option_attrs["help"] = inspect.cleandoc(option_attrs["help"])
         OptionClass = option_attrs.pop("cls", None) or Option
         _param_memo(f, OptionClass(param_decls, **option_attrs))
         return f


### PR DESCRIPTION
- Fixes #1985.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
