### PR TITLE
fix resolution of relative symlinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
     :issue:`1969`
 -   Fix shell completion for arguments that start with a forward slash
     such as absolute file paths. :issue:`1929`
+-   ``Path`` type with ``resolve_path=True`` resolves relative symlinks
+    to be relative to the containing directory. :issue:`1921`
 
 
 Version 8.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import tempfile
+
 import pytest
 
 from click.testing import CliRunner
@@ -6,3 +10,22 @@ from click.testing import CliRunner
 @pytest.fixture(scope="function")
 def runner(request):
     return CliRunner()
+
+
+def check_symlink_impl():
+    """This function checks if using symlinks is allowed
+    on the host machine"""
+    tempdir = tempfile.mkdtemp(prefix="click-")
+    test_pth = os.path.join(tempdir, "check_sym_impl")
+    sym_pth = os.path.join(tempdir, "link")
+    open(test_pth, "w").close()
+    rv = True
+    try:
+        os.symlink(test_pth, sym_pth)
+    except (NotImplementedError, OSError):
+        # Creating symlinks on Windows require elevated access.
+        # OSError is thrown if the function is called without it.
+        rv = False
+    finally:
+        shutil.rmtree(tempdir, ignore_errors=True)
+    return rv


### PR DESCRIPTION
This resolves (relative) symlinks to the right directory. This is done by prepending the absolute directory path of the relative symlink to the resolved path.

- fixes #1921 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
