### PR TITLE
Remove logically-dead code in decorators.py::version_option()

### DIFF
--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -340,9 +340,8 @@ def version_option(
 
     if version is None and package_name is None:
         frame = inspect.currentframe()
-        assert frame is not None
-        assert frame.f_back is not None
-        f_globals = frame.f_back.f_globals if frame is not None else None
+        f_back = frame.f_back if frame is not None else None
+        f_globals = f_back.f_globals if f_back is not None else None
         # break reference cycle
         # https://docs.python.org/3/library/inspect.html#the-interpreter-stack
         del frame


### PR DESCRIPTION
Remove redundant null checks from decorators.py's version_option() function as highlighted by Coverity scans

- fixes #1989

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
