### PR TITLE
Fix click.prompt() printing a single space to stdout when err=True.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Unreleased
     :issue:`2062`
 -   Fix overline and italic styles, which were incorrectly added when
     adding underline. :pr:`2058`
+-   Fix `prompt(..., err=True)` sending characters to `stdout`.
+    :issue:`2018`
+
 
 
 Version 8.0.1

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -67,11 +67,7 @@ def hidden_prompt_func(prompt: str, err: bool = False) -> str:
     """
     import getpass
 
-    try:
-        sys.stdout = sys.__stderr__ if err else sys.__stdout__
-        return getpass.getpass(prompt)
-    finally:
-        sys.stdout = sys.__stdout__
+    return getpass.getpass(prompt, stream=sys.stderr if err else sys.stdout)
 
 
 def _build_prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -53,10 +53,12 @@ def visible_prompt_func(prompt: str, err: bool = False) -> str:
 
     """
     try:
-        sys.stdout = sys.__stderr__ if err else sys.__stdout__
+        old_stdout = sys.stdout
+        if err:
+            sys.stdout = sys.stderr
         return input(prompt)
     finally:
-        sys.stdout = sys.__stdout__
+        sys.stdout = old_stdout
 
 
 def hidden_prompt_func(prompt: str, err: bool = False) -> str:

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -275,17 +275,23 @@ class CliRunner:
             )
 
         @_pause_echo(echo_input)  # type: ignore
-        def visible_input(prompt: t.Optional[str] = None) -> str:
-            sys.stdout.write(prompt or "")
+        def visible_input(
+            prompt: t.Optional[str] = None, err: t.Optional[bool] = False
+        ) -> str:
+            out = sys.stderr if err else sys.stdout
+            out.write(prompt or "")
             val = text_input.readline().rstrip("\r\n")
-            sys.stdout.write(f"{val}\n")
-            sys.stdout.flush()
+            out.write(f"{val}\n")
+            out.flush()
             return val
 
         @_pause_echo(echo_input)  # type: ignore
-        def hidden_input(prompt: t.Optional[str] = None) -> str:
-            sys.stdout.write(f"{prompt or ''}\n")
-            sys.stdout.flush()
+        def hidden_input(
+            prompt: t.Optional[str] = None, err: t.Optional[bool] = False
+        ) -> str:
+            out = sys.stderr if err else sys.stdout
+            out.write(f"{prompt or ''}\n")
+            out.flush()
             return text_input.readline().rstrip("\r\n")
 
         @_pause_echo(echo_input)  # type: ignore

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,7 +154,7 @@ def test_confirm_repeat(runner):
 
 @pytest.mark.skipif(WIN, reason="Different behavior on windows.")
 def test_prompts_abort(monkeypatch, capsys):
-    def f(_):
+    def f(prompt, err):
         raise KeyboardInterrupt()
 
     monkeypatch.setattr("click.termui.hidden_prompt_func", f)
@@ -263,8 +263,8 @@ def test_echo_writing_to_standard_error(capfd, monkeypatch):
     emulate_input("asdlkj\n")
     click.prompt("Prompt to stderr", err=True)
     out, err = capfd.readouterr()
-    assert out == " "
-    assert err == "Prompt to stderr:"
+    assert out == ""
+    assert err == "Prompt to stderr: "
 
     emulate_input("y\n")
     click.confirm("Prompt to stdin")


### PR DESCRIPTION
When using `click.prompt(..., err=True)`, the underlying code sends a single space to `stdout`, which may confuse programs who are trying to digest the output. This PR fixes that by sending the space to whatever output stream was chosen instead. For `err=True`, the space is sent to `sys.stdout`.

Note that I am not sure how to test this behaviour, that's why this PR is a WIP. Any suggestions are welcome.

- fixes #2018

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.