### PR TITLE
Disable double dash on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Unreleased
 Version 8.0.2
 -------------
 
-Unreleased
+-   Using double-dash separator between command and subcommands
+-   can be turned off. :issue:`619`
 
 
 Version 8.0.1

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -389,7 +389,7 @@ disable_double_dash=True to your `CommandCollection` instance.
 
 .. note::
 
-    It is still possible to use '--' between a command and an argument.
+    Using '--' between multicommand and its argument will generate the same user error.
 
 Multi Command Pipelines
 -----------------------

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -390,7 +390,7 @@ disable_double_dash=True to your `CommandCollection` instance.
 .. note::
 
     Using '--' between multicommand and its argument will generate the same user Error.
-    ``disable_double_dash=True`` parameter is implemented on the Command level.
+    ``disable_double_dash`` parameter is implemented on the Command level.
 
 Multi Command Pipelines
 -----------------------

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -389,7 +389,8 @@ disable_double_dash=True to your `CommandCollection` instance.
 
 .. note::
 
-    Using '--' between multicommand and its argument will generate the same user error.
+    Using '--' between multicommand and its argument will generate the same user Error.
+    ``disable_double_dash=True`` parameter is implemented on the Command level.
 
 Multi Command Pipelines
 -----------------------

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -331,6 +331,65 @@ be handled are not yet available when the callback fires.
     It is currently not possible for chain commands to be nested.  This
     will be fixed in future versions of Click.
 
+Multi Command Switching Off The '--' Separator
+----------------------------------------------
+.. versionadded:: 8.0.2
+
+The default behaviour of Click is that you can use double-dash separator ('--') between
+the command and subcommands and also between subcommands when nesting them through
+multicommand instance. You can switch that off and using '--' will generate a user Error
+``can't use '--' separator between a command and a subcommand and between subcommands``.
+All you have to do is to pass ``disable_double_dash=True`` to your multicommand:
+
+.. click:example::
+
+    @click.group(disable_double_dash=True)
+    def cli():
+        pass
+
+
+    @cli.command('sdist')
+    def sdist():
+        click.echo('sdist called')
+
+
+    @cli.command('bdist_wheel')
+    def bdist_wheel():
+        click.echo('bdist_wheel called')
+
+This will also work when using ``chain=True`` in your multicommand. In that case using
+'--' will be also impossible  between subcommands too. Switching double-dash off may be
+used with :class:`CommandCollection` instance. To do that you should pass
+disable_double_dash=True to your `CommandCollection` instance.
+
+.. click:example::
+
+    import click
+
+    @click.group()
+    def cli1():
+        pass
+
+    @cli1.command()
+    def cmd1():
+        """Command on cli1"""
+
+    @click.group()
+    def cli2():
+        pass
+
+    @cli2.command()
+    def cmd2():
+        """Command on cli2"""
+
+    cli = click.CommandCollection(sources=[cli1, cli2], disable_double_dash=True)
+
+    if __name__ == '__main__':
+        cli()
+
+.. note::
+
+    It is still possible to use '--' between a command and an argument.
 
 Multi Command Pipelines
 -----------------------

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -32,6 +32,7 @@ from .exceptions import ClickException as ClickException
 from .exceptions import FileError as FileError
 from .exceptions import MissingParameter as MissingParameter
 from .exceptions import NoSuchOption as NoSuchOption
+from .exceptions import NotAllowedDoubleDash as NotAllowedDoubleDash
 from .exceptions import UsageError as UsageError
 from .formatting import HelpFormatter as HelpFormatter
 from .formatting import wrap_text as wrap_text

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1070,6 +1070,7 @@ class BaseCommand:
                     # even always obvious that `rv` indicates success/failure
                     # by its truthiness/falsiness
                     ctx.exit()
+
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()
@@ -1444,6 +1445,9 @@ class MultiCommand(Command):
     dispatches to subcommands.  The most common version is the
     :class:`Group`.
 
+    .. versionchanged:: 8.0.2
+       Added the `disable_double_dash` parameter.
+
     :param invoke_without_command: this controls how the multi command itself
                                    is invoked.  By default it's only invoked
                                    if a subcommand is provided.
@@ -1462,6 +1466,10 @@ class MultiCommand(Command):
     :param result_callback: The result callback to attach to this multi
         command. This can be set or changed later with the
         :meth:`result_callback` decorator.
+    :param disable_double_dash: if this is set to 'True' using '--' between the
+        group name and the command name, and between subcommands is disabled and will
+        print an error message to the user. The default is 'False' in order to save the
+        originall behaviour.
     """
 
     allow_extra_args = True
@@ -1475,6 +1483,7 @@ class MultiCommand(Command):
         subcommand_metavar: t.Optional[str] = None,
         chain: bool = False,
         result_callback: t.Optional[t.Callable[..., t.Any]] = None,
+        disable_double_dash: bool = False,
         **attrs: t.Any,
     ) -> None:
         super().__init__(name, **attrs)
@@ -1505,7 +1514,10 @@ class MultiCommand(Command):
                         " optional arguments."
                     )
 
+        self.disable_double_dash = disable_double_dash
+
     def to_info_dict(self, ctx: Context) -> t.Dict[str, t.Any]:
+
         info_dict = super().to_info_dict(ctx)
         commands = {}
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1143,12 +1143,14 @@ class Command(BaseCommand):
     Click.  A basic command handles command line parsing and might dispatch
     more parsing to commands nested below it.
 
-    .. versionchanged:: 2.0
-       Added the `context_settings` parameter.
+    .. versionchanged:: 8.0.2
+       Added the `disable_double_dash` parameter.
     .. versionchanged:: 8.0
        Added repr showing the command name
     .. versionchanged:: 7.1
        Added the `no_args_is_help` parameter.
+    .. versionchanged:: 2.0
+       Added the `context_settings` parameter.
 
     :param name: the name of the command to use unless a group overrides it.
     :param context_settings: an optional dictionary with defaults that are
@@ -1168,9 +1170,12 @@ class Command(BaseCommand):
                             If enabled this will add ``--help`` as argument
                             if no arguments are passed
     :param hidden: hide this command from help outputs.
-
-    :param deprecated: issues a message indicating that
-                             the command is deprecated.
+    :param deprecated: issues a message indicating that the command is deprecated.
+    :param disable_double_dash: if this is set to 'True' using '--' between the group
+                                name and the command name and between subcommands is
+                                disabled and will print an error message to the user.
+                                The default is 'False' in order to save the originall
+                                behaviour.
     """
 
     def __init__(
@@ -1187,6 +1192,7 @@ class Command(BaseCommand):
         no_args_is_help: bool = False,
         hidden: bool = False,
         deprecated: bool = False,
+        disable_double_dash: bool = False,
     ) -> None:
         super().__init__(name, context_settings)
         #: the callback to execute when the command fires.  This might be
@@ -1210,6 +1216,7 @@ class Command(BaseCommand):
         self.no_args_is_help = no_args_is_help
         self.hidden = hidden
         self.deprecated = deprecated
+        self.disable_double_dash = disable_double_dash
 
     def to_info_dict(self, ctx: Context) -> t.Dict[str, t.Any]:
         info_dict = super().to_info_dict(ctx)
@@ -1445,9 +1452,6 @@ class MultiCommand(Command):
     dispatches to subcommands.  The most common version is the
     :class:`Group`.
 
-    .. versionchanged:: 8.0.2
-       Added the `disable_double_dash` parameter.
-
     :param invoke_without_command: this controls how the multi command itself
                                    is invoked.  By default it's only invoked
                                    if a subcommand is provided.
@@ -1466,10 +1470,6 @@ class MultiCommand(Command):
     :param result_callback: The result callback to attach to this multi
         command. This can be set or changed later with the
         :meth:`result_callback` decorator.
-    :param disable_double_dash: if this is set to 'True' using '--' between the
-        group name and the command name and between subcommands is disabled and will
-        print an error message to the user. The default is 'False' in order to save the
-        originall behaviour.
     """
 
     allow_extra_args = True
@@ -1483,7 +1483,6 @@ class MultiCommand(Command):
         subcommand_metavar: t.Optional[str] = None,
         chain: bool = False,
         result_callback: t.Optional[t.Callable[..., t.Any]] = None,
-        disable_double_dash: bool = False,
         **attrs: t.Any,
     ) -> None:
         super().__init__(name, **attrs)
@@ -1513,8 +1512,6 @@ class MultiCommand(Command):
                         "Multi commands in chain mode cannot have"
                         " optional arguments."
                     )
-
-        self.disable_double_dash = disable_double_dash
 
     def to_info_dict(self, ctx: Context) -> t.Dict[str, t.Any]:
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1070,6 +1070,7 @@ class BaseCommand:
                     # even always obvious that `rv` indicates success/failure
                     # by its truthiness/falsiness
                     ctx.exit()
+
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
                 raise Abort()
@@ -1462,6 +1463,10 @@ class MultiCommand(Command):
     :param result_callback: The result callback to attach to this multi
         command. This can be set or changed later with the
         :meth:`result_callback` decorator.
+    :param disable_double_dash: if this is set to 'True' using '--' between the
+        group name and the command name is disabled and will print
+        an error message to the user. The default is 'False' in order to save the
+        originall behaviour.
     """
 
     allow_extra_args = True
@@ -1475,6 +1480,7 @@ class MultiCommand(Command):
         subcommand_metavar: t.Optional[str] = None,
         chain: bool = False,
         result_callback: t.Optional[t.Callable[..., t.Any]] = None,
+        disable_double_dash: bool = False,
         **attrs: t.Any,
     ) -> None:
         super().__init__(name, **attrs)
@@ -1505,7 +1511,10 @@ class MultiCommand(Command):
                         " optional arguments."
                     )
 
+        self.disable_double_dash = disable_double_dash
+
     def to_info_dict(self, ctx: Context) -> t.Dict[str, t.Any]:
+
         info_dict = super().to_info_dict(ctx)
         commands = {}
 

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -285,3 +285,14 @@ class Exit(RuntimeError):
 
     def __init__(self, code: int = 0) -> None:
         self.exit_code = code
+
+
+class NotAllowedDoubleDash(UsageError):
+    """Raised if '--' argument appears in sys.argv and multicommand.disable_double_dash
+    is set to 'True'.
+
+       .. versionadded:: 8.0.2
+    """
+
+    def __init__(self, message: str, ctx: t.Optional["Context"] = None) -> None:
+        super().__init__(message, ctx)

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -343,7 +343,9 @@ class OptionParser:
             "<class 'click.core.Group'>",
             "<class 'click.core.CommandCollection'>",
         )
-        try:
+        if self.ctx is None:
+            pass
+        else:
             typechecker = type(self.ctx.command)
             strtypechecker = str(typechecker)
             if (
@@ -356,9 +358,6 @@ class OptionParser:
                     " and between subcommands",
                     self.ctx,
                 )
-        # if self.ctx is None we handle the AttributeError silently
-        except AttributeError:
-            pass
 
         state = ParsingState(args)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -350,3 +350,47 @@ def test_deprecated_in_invocation(runner):
 
     result = runner.invoke(deprecated_cmd)
     assert "DeprecationWarning:" in result.output
+
+
+def test_disable_double_dash(runner):
+    @click.group(disable_double_dash=True)
+    def cli():
+        pass
+
+    @cli.command("sdist")
+    def sdist():
+        click.echo("sdist called")
+
+    result = runner.invoke(cli, ["--", "sdist"])
+    assert result.exit_code == 2
+    assert (
+        "Error: can't use '--' separator between a command and a subcommand and "
+        "between subcommands" in result.output
+    )
+
+
+def test_multicommand_disable_double_dash(runner):
+    @click.group()
+    def cli1():
+        pass
+
+    @cli1.command()
+    def cmd1():
+        """Command on cli1"""
+
+    @click.group()
+    def cli2():
+        pass
+
+    @cli2.command()
+    def cmd2():
+        """Command on cli2"""
+
+    cli = click.CommandCollection(sources=[cli1, cli2], disable_double_dash=True)
+
+    result = runner.invoke(cli, ["--", "cmd1"])
+    assert result.exit_code == 2
+    assert (
+        "Error: can't use '--' separator between a command and a subcommand and "
+        "between subcommands" in result.output
+    )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -332,7 +332,7 @@ def test_global_show_default(runner):
 
 
 def test_formatting_with_options_metavar_empty(runner):
-    cli = click.Command("cli", options_metavar="", params=[click.Argument(["var"])])
+    cli = click.Command("cli", params=[click.Argument(["var"])], options_metavar="")
     result = runner.invoke(cli, ["--help"])
     assert "Usage: cli VAR\n" in result.output
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -93,11 +93,11 @@ def test_argument_order():
 def test_argument_default():
     cli = Command(
         "cli",
-        add_help_option=False,
         params=[
             Argument(["a"], type=Choice(["a"]), default="a"),
             Argument(["b"], type=Choice(["b"]), default="b"),
         ],
+        add_help_option=False,
     )
     assert _get_words(cli, [], "") == ["a"]
     assert _get_words(cli, ["a"], "b") == ["b"]
@@ -128,11 +128,11 @@ def test_path_types(type, expect):
 def test_option_flag():
     cli = Command(
         "cli",
-        add_help_option=False,
         params=[
             Option(["--on/--off"]),
             Argument(["a"], type=Choice(["a1", "a2", "b"])),
         ],
+        add_help_option=False,
     )
     assert _get_words(cli, [], "--") == ["--on", "--off"]
     # flag option doesn't take value, use choice argument
@@ -209,11 +209,11 @@ def test_argument_nargs():
 def test_double_dash():
     cli = Command(
         "cli",
-        add_help_option=False,
         params=[
             Option(["--opt"]),
             Argument(["name"], type=Choice(["name", "--", "-o", "--opt"])),
         ],
+        add_help_option=False,
     )
     assert _get_words(cli, [], "-") == ["--opt"]
     assert _get_words(cli, ["value"], "-") == ["--opt"]
@@ -227,12 +227,12 @@ def test_hidden():
         commands=[
             Command(
                 "hidden",
-                add_help_option=False,
-                hidden=True,
                 params=[
                     Option(["-a"]),
                     Option(["-b"], type=Choice(["a", "b"]), hidden=True),
                 ],
+                add_help_option=False,
+                hidden=True,
             )
         ],
     )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -76,7 +76,7 @@ def test_cast_multi_default(runner, nargs, multiple, default, expect):
     else:
         param = click.Option(["-a"], nargs=nargs, multiple=multiple, default=default)
 
-    cli = click.Command("cli", params=[param], callback=lambda a: a)
+    cli = click.Command("cli", callback=lambda a: a, params=[param])
     result = runner.invoke(cli, standalone_mode=False)
     assert result.exception is None
     assert result.return_value == expect
@@ -94,8 +94,8 @@ def test_cast_multi_default(runner, nargs, multiple, default, expect):
 def test_path_type(runner, cls, expect):
     cli = click.Command(
         "cli",
-        params=[click.Argument(["p"], type=click.Path(path_type=cls))],
         callback=lambda p: p,
+        params=[click.Argument(["p"], type=click.Path(path_type=cls))],
     )
     result = runner.invoke(cli, ["a/b/c.txt"], standalone_mode=False)
     assert result.exception is None


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket. 
--> Using double-dash separator between a group and a subcommand and between subcommands can be switched off.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #619 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
