### PR TITLE
Add platform check to gate _fast_exit()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Unreleased
     :issue:`1969`
 -   Fix shell completion for arguments that start with a forward slash
     such as absolute file paths. :issue:`1929`
+-   Fix use of ``_fast_exit`` on non-Linux platforms.
+    :issue:`2017`
 
 
 Version 8.0.1

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1,6 +1,7 @@
 import enum
 import errno
 import os
+import platform
 import sys
 import typing
 import typing as t
@@ -1130,7 +1131,11 @@ class BaseCommand:
         from .shell_completion import shell_complete
 
         rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
-        _fast_exit(rv)
+
+        if platform.system() == "Linux":
+            _fast_exit(rv)
+        else:
+            sys.exit(rv)
 
     def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Alias for :meth:`main`."""

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -53,6 +53,9 @@ def _fast_exit(code: int) -> "te.NoReturn":
     Fallback to sys.exit() on non-Linux platforms.
 
     :param code: Exit code.
+
+    .. versionchanged:: 8.0.2
+        Use ``sys.exit`` on non-Linux platforms.
     """
 
     import platform

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1143,7 +1143,6 @@ class BaseCommand:
         rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
         _fast_exit(rv)
 
-
     def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Alias for :meth:`main`."""
         return self.main(*args, **kwargs)

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1132,6 +1132,7 @@ class BaseCommand:
         rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
 
         import platform
+
         if platform.system() == "Linux":
             _fast_exit(rv)
         else:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1,7 +1,6 @@
 import enum
 import errno
 import os
-import platform
 import sys
 import typing
 import typing as t
@@ -1132,6 +1131,7 @@ class BaseCommand:
 
         rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
 
+        import platform
         if platform.system() == "Linux":
             _fast_exit(rv)
         else:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -345,4 +345,4 @@ def test_fast_exit_multiprocessing():
     result = subprocess.run(command, shell=False, capture_output=True)
     stderr = result.stderr.decode("UTF-8")
 
-    assert "UserWarning: resource_tracker:" not in stderr
+    assert stderr == ""

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,6 +1,6 @@
-import textwrap
 import subprocess
 import sys
+import textwrap
 
 import pytest
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,3 +1,5 @@
+import textwrap
+import subprocess
 import sys
 
 import pytest
@@ -320,3 +322,27 @@ def test_choice_case_sensitive(value, expect):
     )
     completions = _get_words(cli, ["-a"], "a")
     assert completions == expect
+
+
+def test_fast_exit_multiprocessing():
+
+    script = textwrap.dedent(
+        """
+        from multiprocessing import SimpleQueue
+        from click.core import _fast_exit
+
+        my_queue = SimpleQueue()
+        _fast_exit(0)
+        """
+    ).strip()
+
+    command = [
+        sys.executable,
+        "-c",
+        script,
+    ]
+
+    result = subprocess.run(command, shell=False, capture_output=True)
+    stderr = result.stderr.decode("UTF-8")
+
+    assert "UserWarning: resource_tracker:" not in stderr


### PR DESCRIPTION
    - Platforms that do not support using fork for multiprocessing have issues freeing
    up resources correctly when using os._exit() as opposed to sys.exit()

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2017 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
