### PR TITLE
Remove fast exit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
     such as absolute file paths. :issue:`1929`
 -   ``Path`` type with ``resolve_path=True`` resolves relative symlinks
     to be relative to the containing directory. :issue:`1921`
+-   Completion does not skip Python's resource cleanup when exiting,
+    avoiding some unexpected warning output. :issue:`1738, 2017`
 
 
 Version 8.0.1

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -46,17 +46,6 @@ F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 V = t.TypeVar("V")
 
 
-def _fast_exit(code: int) -> "te.NoReturn":
-    """Low-level exit that skips Python's cleanup but speeds up exit by
-    about 10ms for things like shell completion.
-
-    :param code: Exit code.
-    """
-    sys.stdout.flush()
-    sys.stderr.flush()
-    os._exit(code)
-
-
 def _complete_visible_commands(
     ctx: "Context", incomplete: str
 ) -> t.Iterator[t.Tuple[str, "Command"]]:
@@ -1130,7 +1119,7 @@ class BaseCommand:
         from .shell_completion import shell_complete
 
         rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
-        _fast_exit(rv)
+        sys.exit(rv)
 
     def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
         """Alias for :meth:`main`."""

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from click.core import Argument
@@ -265,7 +263,6 @@ def test_completion_item_data():
 
 @pytest.fixture()
 def _patch_for_completion(monkeypatch):
-    monkeypatch.setattr("click.core._fast_exit", sys.exit)
     monkeypatch.setattr(
         "click.shell_completion.BashComplete._check_version", lambda self: True
     )


### PR DESCRIPTION
-   Remove _fast_exit() function and use sys.exit() instead due to issues with resource cleanup in some cases.
- fixes #2017

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
