### PR TITLE
small refactorings in command parsing methods

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1376,7 +1376,7 @@ class Command(BaseCommand):
         opts, args, param_order = parser.parse_args(args=args)
 
         for param in iter_params_for_processing(param_order, self.get_params(ctx)):
-            value, args = param.handle_parse_result(ctx, opts, args)
+            value = param.handle_parse_result(ctx, opts)
 
         if args and not ctx.allow_extra_args and not ctx.resilient_parsing:
             ctx.fail(
@@ -2353,9 +2353,7 @@ class Parameter:
 
         return rv
 
-    def handle_parse_result(
-        self, ctx: Context, opts: t.Mapping[str, t.Any], args: t.List[str]
-    ) -> t.Tuple[t.Any, t.List[str]]:
+    def handle_parse_result(self, ctx: Context, opts: t.Mapping[str, t.Any]) -> t.Any:
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
             ctx.set_parameter_source(self.name, source)  # type: ignore
@@ -2371,7 +2369,7 @@ class Parameter:
         if self.expose_value:
             ctx.params[self.name] = value  # type: ignore
 
-        return value, args
+        return value
 
     def get_help_record(self, ctx: Context) -> t.Optional[t.Tuple[str, str]]:
         pass

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1376,7 +1376,7 @@ class Command(BaseCommand):
         opts, args, param_order = parser.parse_args(args=args)
 
         for param in iter_params_for_processing(param_order, self.get_params(ctx)):
-            value = param.handle_parse_result(ctx, opts)
+            param.handle_parse_result(ctx, opts)
 
         if args and not ctx.allow_extra_args and not ctx.resilient_parsing:
             ctx.fail(
@@ -2353,7 +2353,7 @@ class Parameter:
 
         return rv
 
-    def handle_parse_result(self, ctx: Context, opts: t.Mapping[str, t.Any]) -> t.Any:
+    def handle_parse_result(self, ctx: Context, opts: t.Mapping[str, t.Any]) -> None:
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
             ctx.set_parameter_source(self.name, source)  # type: ignore
@@ -2368,8 +2368,6 @@ class Parameter:
 
         if self.expose_value:
             ctx.params[self.name] = value  # type: ignore
-
-        return value
 
     def get_help_record(self, ctx: Context) -> t.Optional[t.Tuple[str, str]]:
         pass


### PR DESCRIPTION
While reading the code, I noticed that:
- 'args' does not need to be passed to Command.handle_parse_result()
- the return value from Command.handle_parse_result() is not used by caller

I'm suggesting two changes which, IMO, make the code easier to follow.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
