### PR TITLE
close temporary file used by echo_via_pager

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -426,7 +426,7 @@ def _tempfilepager(
     """Page through text by invoking a program on a temporary file."""
     import tempfile
 
-    _, filename = tempfile.mkstemp()
+    fd, filename = tempfile.mkstemp()
     # TODO: This never terminates if the passed generator never terminates.
     text = "".join(generator)
     if not color:
@@ -437,6 +437,8 @@ def _tempfilepager(
     try:
         os.system(f'{cmd} "{filename}"')
     finally:
+        if WIN:
+            os.close(fd)
         os.unlink(filename)
 
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -437,8 +437,7 @@ def _tempfilepager(
     try:
         os.system(f'{cmd} "{filename}"')
     finally:
-        if WIN:
-            os.close(fd)
+        os.close(fd)
         os.unlink(filename)
 
 


### PR DESCRIPTION
On Windows, `unlink` would fail because the file was still open.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<https://github.com/pallets/click/issues/1905>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
