### PR TITLE
Fix failing symlink test

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -845,20 +845,11 @@ class Path(ParamType):
                 if os.path.islink(rv):
                     rv = os.readlink(rv)
 
-                    # absolute links
-                    if os.path.isabs(rv):
-                        # os.readlink prepends path prefixes to absolute
-                        # links in windows.
-                        # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
-                        # Here we strip prefix from the resolved path
-                        rv_drive, rv_path = os.path.splitdrive(rv)
-                        stripped_rv_drive = rv_drive.split(os.path.sep)[-1]
-                        rv = os.path.join(stripped_rv_drive, rv_path)
-                    else:
-                        # For relative symlinks we join dir_ to the resolved
-                        # symlink. This will make it relative to the original
-                        # containing directory.
-                        rv = os.path.join(dir_, rv)
+                # Join dir_ with the resolved symlink if the resolved
+                # path is relative. This will make it relative to the
+                # original containing directory.
+                if not os.path.isabs(rv):
+                    rv = os.path.join(dir_, rv)
 
             try:
                 st = os.stat(rv)

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -847,8 +847,9 @@ class Path(ParamType):
 
                     # absolute links
                     if os.path.isabs(rv):
-                        # os.readlink prepends path prefixes to absolute links
-                        # in windows.
+                        # os.readlink prepends path prefixes to absolute
+                        # links in windows.
+                        # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
                         # Here we strip prefix from the resolved path
                         rv_drive, rv_path = os.path.splitdrive(rv)
                         stripped_rv_drive = rv_drive.split(os.path.sep)[-1]

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -845,11 +845,19 @@ class Path(ParamType):
                 if os.path.islink(rv):
                     rv = os.readlink(rv)
 
-                # Join dir_ with the resolved symlink. If the resolved
-                # path is relative, this will make it relative to the
-                # original containing directory. If it is absolute, this
-                # has no effect.
-                rv = os.path.join(dir_, rv)
+                    # absolute links
+                    if os.path.isabs(rv):
+                        # os.readlink prepends path prefixes to absolute links
+                        # in windows.
+                        # Here we strip prefix from the resolved path
+                        rv_drive, rv_path = os.path.splitdrive(rv)
+                        stripped_rv_drive = rv_drive.split(os.path.sep)[-1]
+                        rv = os.path.join(stripped_rv_drive, rv_path)
+                    else:
+                        # For relative symlinks we join dir_ to the resolved
+                        # symlink. This will make it relative to the original
+                        # containing directory.
+                        rv = os.path.join(dir_, rv)
 
             try:
                 st = os.stat(rv)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -127,16 +127,14 @@ def test_symlink_resolution(tmpdir, sym_file, abs_fun):
     ctx = click.Context(click.Command("do_stuff"))
     rv = click.Path(resolve_path=True).convert(sym_path, None, ctx)
 
-    if os.path.isabs(rv):
-        # os.readlink prepends path prefixes to absolute
-        # links in windows.
-        # https://docs.microsoft.com/en-us/windows/win32/
-        # ... fileio/naming-a-file#win32-file-namespaces
-        #
-        # Here we strip win32 path prefix from the resolved path
-        rv_drive, rv_path = os.path.splitdrive(rv)
-        stripped_rv_drive = rv_drive.split(os.path.sep)[-1]
-        rv = os.path.join(stripped_rv_drive, rv_path)
+    # os.readlink prepends path prefixes to absolute
+    # links in windows.
+    # https://docs.microsoft.com/en-us/windows/win32/
+    # ... fileio/naming-a-file#win32-file-namespaces
+    #
+    # Here we strip win32 path prefix from the resolved path
+    rv_drive, rv_path = os.path.splitdrive(rv)
+    stripped_rv_drive = rv_drive.split(os.path.sep)[-1]
+    rv = os.path.join(stripped_rv_drive, rv_path)
 
-    assert pathlib.Path(rv) == pathlib.Path(real_path)
     assert rv == real_path

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -126,4 +126,17 @@ def test_symlink_resolution(tmpdir, sym_file, abs_fun):
     # test
     ctx = click.Context(click.Command("do_stuff"))
     rv = click.Path(resolve_path=True).convert(sym_path, None, ctx)
+
+    if os.path.isabs(rv):
+        # os.readlink prepends path prefixes to absolute
+        # links in windows.
+        # https://docs.microsoft.com/en-us/windows/win32/
+        # ... fileio/naming-a-file#win32-file-namespaces
+        #
+        # Here we strip win32 path prefix from the resolved path
+        rv_drive, rv_path = os.path.splitdrive(rv)
+        stripped_rv_drive = rv_drive.split(os.path.sep)[-1]
+        rv = os.path.join(stripped_rv_drive, rv_path)
+
+    assert pathlib.Path(rv) == pathlib.Path(real_path)
     assert rv == real_path


### PR DESCRIPTION
Fix failing test on #2006.

`os.readlink` prepends [path prefixes](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces) to absolute links in windows. This fix takes that into account in the test

- Related to #1921 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
