### PR TITLE
count help doesn't show default range type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     :issue:`2062`
 -   Fix overline and italic styles, which were incorrectly added when
     adding underline. :pr:`2058`
+-   An option with ``count=True`` will not show "[x>=0]" in help text.
+    :issue:`2072`
 
 
 Version 8.0.1

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2740,7 +2740,11 @@ class Option(Parameter):
             if default_string:
                 extra.append(_("default: {default}").format(default=default_string))
 
-        if isinstance(self.type, types._NumberRangeBase):
+        if (
+            isinstance(self.type, types._NumberRangeBase)
+            # skip count with default range type
+            and not (self.count and self.type.min == 0 and self.type.max is None)
+        ):
             range_str = self.type._describe_range()
 
             if range_str:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -314,11 +314,19 @@ def test_dynamic_default_help_text(runner):
         (click.IntRange(max=32), "x<=32"),
     ],
 )
-def test_intrange_default_help_text(runner, type, expect):
-    option = click.Option(["--count"], type=type, show_default=True, default=2)
+def test_intrange_default_help_text(type, expect):
+    option = click.Option(["--num"], type=type, show_default=True, default=2)
     context = click.Context(click.Command("test"))
     result = option.get_help_record(context)[1]
     assert expect in result
+
+
+def test_count_default_type_help():
+    """A count option with the default type should not show >=0 in help."""
+    option = click.Option(["--couunt"], count=True, help="some words")
+    context = click.Context(click.Command("test"))
+    result = option.get_help_record(context)[1]
+    assert result == "some words"
 
 
 def test_toupper_envvar_prefix(runner):


### PR DESCRIPTION
Click 8 began showing help text for range types. A `count` option gets a default type of `IntRange(min=0)`. If the type is `IntRange` but the option is `count` with this default type, the range help will not be shown. If a different range is used, it will still be shown.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2072 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
