### PR TITLE
Fix click.confirm not working with readline module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix issue with ``Path(resolve_path=True)`` type creating invalid
     paths. :issue:`2088`
+-   Importing ``readline`` does not cause the ``confirm()`` prompt to
+    disappear when pressing backspace. :issue:`2092`
 
 
 Version 8.0.2

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -231,8 +231,10 @@ def confirm(
         try:
             # Write the prompt separately so that we get nice
             # coloring through colorama on Windows
-            echo(prompt, nl=False, err=err)
-            value = visible_prompt_func("").lower().strip()
+            echo(prompt.rstrip(" "), nl=False, err=err)
+            # Echo a space to stdout to work around an issue where
+            # readline causes backspace to clear the whole line.
+            value = visible_prompt_func(" ").lower().strip()
         except (KeyboardInterrupt, EOFError):
             raise Abort() from None
         if value in ("y", "yes"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -275,8 +275,8 @@ def test_echo_writing_to_standard_error(capfd, monkeypatch):
     emulate_input("y\n")
     click.confirm("Prompt to stderr", err=True)
     out, err = capfd.readouterr()
-    assert out == ""
-    assert err == "Prompt to stderr [y/N]: "
+    assert out == " "
+    assert err == "Prompt to stderr [y/N]:"
 
     monkeypatch.setattr(click.termui, "isatty", lambda x: True)
     monkeypatch.setattr(click.termui, "getchar", lambda: " ")


### PR DESCRIPTION
Applies the patch from #665 (PR #1836) to `click.confirm` as well, so that the readline module does not interfere with the prompt text.

- fixes #2092

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
