### PR TITLE
use pathlib to resolve symlinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: click
 
+Version 8.0.3
+-------------
+
+Unreleased
+
+-   Fix issue with ``Path(resolve_path=True)`` type creating invalid
+    paths. :issue:`2088`
+
+
 Version 8.0.2
 -------------
 

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -836,20 +836,11 @@ class Path(ParamType):
 
         if not is_dash:
             if self.resolve_path:
-                # Get the absolute directory containing the path.
-                dir_ = os.path.dirname(os.path.abspath(rv))
+                # os.path.realpath doesn't resolve symlinks on Windows
+                # until Python 3.8. Use pathlib for now.
+                import pathlib
 
-                # Resolve a symlink. realpath on Windows Python < 3.9
-                # doesn't resolve symlinks. This might return a relative
-                # path even if the path to the link is absolute.
-                if os.path.islink(rv):
-                    rv = os.readlink(rv)
-
-                # Join dir_ with the resolved symlink if the resolved
-                # path is relative. This will make it relative to the
-                # original containing directory.
-                if not os.path.isabs(rv):
-                    rv = os.path.join(dir_, rv)
+                rv = os.fsdecode(pathlib.Path(rv).resolve())
 
             try:
                 st = os.stat(rv)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 
 import pytest
@@ -12,20 +11,17 @@ def runner(request):
     return CliRunner()
 
 
-def check_symlink_impl():
-    """This function checks if using symlinks is allowed
-    on the host machine"""
-    tempdir = tempfile.mkdtemp(prefix="click-")
-    test_pth = os.path.join(tempdir, "check_sym_impl")
-    sym_pth = os.path.join(tempdir, "link")
-    open(test_pth, "w").close()
-    rv = True
-    try:
-        os.symlink(test_pth, sym_pth)
-    except (NotImplementedError, OSError):
-        # Creating symlinks on Windows require elevated access.
-        # OSError is thrown if the function is called without it.
-        rv = False
-    finally:
-        shutil.rmtree(tempdir, ignore_errors=True)
-    return rv
+def _check_symlinks_supported():
+    with tempfile.TemporaryDirectory(prefix="click-pytest-") as tempdir:
+        target = os.path.join(tempdir, "target")
+        open(target, "w").close()
+        link = os.path.join(tempdir, "link")
+
+        try:
+            os.symlink(target, link)
+            return True
+        except OSError:
+            return False
+
+
+symlinks_supported = _check_symlinks_supported()


### PR DESCRIPTION
`pathlib.Path(value).resolve()` will resolve paths with symlinks consistently, including on Windows Python < 3.8.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2088 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
