### PR TITLE
invoke type casts default values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     paths. :issue:`2088`
 -   Importing ``readline`` does not cause the ``confirm()`` prompt to
     disappear when pressing backspace. :issue:`2092`
+-   Any default values injected by ``invoke()`` are cast to the
+    corresponding parameter's type. :issue:`2089, 2090`
 
 
 Version 8.0.2

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -739,7 +739,9 @@ class Context:
 
             for param in other_cmd.params:
                 if param.name not in kwargs and param.expose_value:
-                    kwargs[param.name] = param.get_default(ctx)  # type: ignore
+                    kwargs[param.name] = param.type_cast_value(  # type: ignore
+                        ctx, param.get_default(ctx)
+                    )
 
             # Track all kwargs as params, so that forward() will pass
             # them on in subsequent calls.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -246,15 +246,17 @@ def test_other_command_invoke_with_defaults(runner):
         return ctx.invoke(other_cmd)
 
     @click.command()
-    @click.option("--foo", type=click.INT, default=42)
+    @click.option("-a", type=click.INT, default=42)
+    @click.option("-b", type=click.INT, default="15")
+    @click.option("-c", multiple=True)
     @click.pass_context
-    def other_cmd(ctx, foo):
-        assert ctx.info_name == "other-cmd"
-        click.echo(foo)
+    def other_cmd(ctx, a, b, c):
+        return ctx.info_name, a, b, c
 
-    result = runner.invoke(cli, [])
-    assert not result.exception
-    assert result.output == "42\n"
+    result = runner.invoke(cli, standalone_mode=False)
+    # invoke should type cast default values, str becomes int, empty
+    # multiple should be empty tuple instead of None
+    assert result.return_value == ("other-cmd", 42, 15, ())
 
 
 def test_invoked_subcommand(runner):


### PR DESCRIPTION
#2085 reverted applying type casting when *getting* defaults, casting was only done when processing the values. However, `invoke` also relies on getting defaults, so it also needs to cast the values.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2089 
- fixes #2090 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
