### PR TITLE
use alias for `t.overload` with flake8 4.0

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2,7 +2,6 @@ import enum
 import errno
 import os
 import sys
-import typing
 import typing as t
 from collections import abc
 from contextlib import contextmanager
@@ -632,13 +631,13 @@ class Context:
             self.obj = rv = object_type()
         return rv
 
-    @typing.overload
+    @t.overload
     def lookup_default(
         self, name: str, call: "te.Literal[True]" = True
     ) -> t.Optional[t.Any]:
         ...
 
-    @typing.overload
+    @t.overload
     def lookup_default(
         self, name: str, call: "te.Literal[False]" = ...
     ) -> t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]]:
@@ -956,7 +955,7 @@ class BaseCommand:
 
         return results
 
-    @typing.overload
+    @t.overload
     def main(
         self,
         args: t.Optional[t.Sequence[str]] = None,
@@ -967,7 +966,7 @@ class BaseCommand:
     ) -> "te.NoReturn":
         ...
 
-    @typing.overload
+    @t.overload
     def main(
         self,
         args: t.Optional[t.Sequence[str]] = None,
@@ -2172,13 +2171,13 @@ class Parameter:
 
         return metavar
 
-    @typing.overload
+    @t.overload
     def get_default(
         self, ctx: Context, call: "te.Literal[True]" = True
     ) -> t.Optional[t.Any]:
         ...
 
-    @typing.overload
+    @t.overload
     def get_default(
         self, ctx: Context, call: bool = ...
     ) -> t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]]:
@@ -2753,13 +2752,13 @@ class Option(Parameter):
 
         return ("; " if any_prefix_is_slash else " / ").join(rv), help
 
-    @typing.overload
+    @t.overload
     def get_default(
         self, ctx: Context, call: "te.Literal[True]" = True
     ) -> t.Optional[t.Any]:
         ...
 
-    @typing.overload
+    @t.overload
     def get_default(
         self, ctx: Context, call: bool = ...
     ) -> t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]]:

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -1,4 +1,3 @@
-import typing
 import typing as t
 from threading import local
 
@@ -9,12 +8,12 @@ if t.TYPE_CHECKING:
 _local = local()
 
 
-@typing.overload
+@t.overload
 def get_current_context(silent: "te.Literal[False]" = False) -> "Context":
     ...
 
 
-@typing.overload
+@t.overload
 def get_current_context(silent: bool = ...) -> t.Optional["Context"]:
     ...
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -3,7 +3,6 @@ import io
 import itertools
 import os
 import sys
-import typing
 import typing as t
 from gettext import gettext as _
 


### PR DESCRIPTION
- fixes #2102 

No additional tests needed as flake8 is already run as a pre-commit hook.
flake8 version is not mentioned in the docs.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
