### PR TITLE
Docs: fix small mistake in section on callbacks

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -538,10 +538,10 @@ parameter ``--foo`` was required and defined before, you would need to
 specify it for ``--version`` to work.  For more information, see
 :ref:`callback-evaluation-order`.
 
-A callback is a function that is invoked with two parameters: the current
-:class:`Context` and the value.  The context provides some useful features
-such as quitting the application and gives access to other already
-processed parameters.
+A callback is a function that is invoked with three parameters: the
+current :class:`Context`, the current :class:`Parameter`, and the value.
+The context provides some useful features such as quitting the
+application and gives access to other already processed parameters.
 
 Here an example for a ``--version`` flag:
 


### PR DESCRIPTION
The documentation still referred to only two parameters being passed to
a parameter callback, whereas the new signature takes three.

- fixes #2113

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
