### PR TITLE
drop Python 3.6

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
           - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v2.6.0
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Version 8.1.0
 
 Unreleased
 
+-   Drop support for Python 3.6. :pr:`2129`
 -   Single options boolean flags with ``show_default=True`` only show
-    the default if it is ``True``. :issue:`1971`:
+    the default if it is ``True``. :issue:`1971`
 
 
 Version 8.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.6
+python_requires = >= 3.7
 # Dependencies are in setup.py for GitHub's dependency graph.
 
 [options.packages.find]
@@ -78,7 +78,7 @@ per-file-ignores =
 
 [mypy]
 files = src/click
-python_version = 3.6
+python_version = 3.7
 disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_defs = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7,6},pypy37
+    py3{11,10,9,8,7},pypy3{8,7}
     style
     typing
     docs


### PR DESCRIPTION
[Python 3.6 is end-of-life on December 2021.](https://www.python.org/dev/peps/pep-0494/#lifespan)