### PR TITLE
remove deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
         ``shell_complete``.
     -   ``get_terminal_size`` is removed, use
         ``shutil.get_terminal_size`` instead.
+    -   ``get_os_args`` is removed, use ``sys.argv[1:]`` instead.
 
 -   Single options boolean flags with ``show_default=True`` only show
     the default if it is ``True``. :issue:`1971`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
     -   ``Group.resultcallback`` is renamed to ``result_callback``.
     -   ``autocompletion`` parameter to ``Command`` is renamed to
         ``shell_complete``.
+    -   ``get_terminal_size`` is removed, use
+        ``shutil.get_terminal_size`` instead.
 
 -   Single options boolean flags with ``show_default=True`` only show
     the default if it is ``True``. :issue:`1971`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Version 8.1.0
 Unreleased
 
 -   Drop support for Python 3.6. :pr:`2129`
+-   Remove previously deprecated code. :pr:`2130`
+
+    -   ``Group.resultcallback`` is renamed to ``result_callback``.
+
 -   Single options boolean flags with ``show_default=True`` only show
     the default if it is ``True``. :issue:`1971`
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 -   Remove previously deprecated code. :pr:`2130`
 
     -   ``Group.resultcallback`` is renamed to ``result_callback``.
+    -   ``autocompletion`` parameter to ``Command`` is renamed to
+        ``shell_complete``.
 
 -   Single options boolean flags with ``show_default=True`` only show
     the default if it is ``True``. :issue:`1971`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,8 +63,6 @@ Utilities
 
 .. autofunction:: pause
 
-.. autofunction:: get_terminal_size
-
 .. autofunction:: get_binary_stream
 
 .. autofunction:: get_text_stream

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -41,7 +41,6 @@ from .termui import clear as clear
 from .termui import confirm as confirm
 from .termui import echo_via_pager as echo_via_pager
 from .termui import edit as edit
-from .termui import get_terminal_size as get_terminal_size
 from .termui import getchar as getchar
 from .termui import launch as launch
 from .termui import pause as pause

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -67,7 +67,6 @@ from .utils import echo as echo
 from .utils import format_filename as format_filename
 from .utils import get_app_dir as get_app_dir
 from .utils import get_binary_stream as get_binary_stream
-from .utils import get_os_args as get_os_args
 from .utils import get_text_stream as get_text_stream
 from .utils import open_file as open_file
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2009,11 +2009,6 @@ class Parameter:
                 t.Union[t.List["CompletionItem"], t.List[str]],
             ]
         ] = None,
-        autocompletion: t.Optional[
-            t.Callable[
-                [Context, t.List[str], str], t.List[t.Union[t.Tuple[str, str], str]]
-            ]
-        ] = None,
     ) -> None:
         self.name, self.opts, self.secondary_opts = self._parse_decls(
             param_decls or (), expose_value
@@ -2037,36 +2032,6 @@ class Parameter:
         self.is_eager = is_eager
         self.metavar = metavar
         self.envvar = envvar
-
-        if autocompletion is not None:
-            import warnings
-
-            warnings.warn(
-                "'autocompletion' is renamed to 'shell_complete'. The old name is"
-                " deprecated and will be removed in Click 8.1. See the docs about"
-                " 'Parameter' for information about new behavior.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-            def shell_complete(
-                ctx: Context, param: "Parameter", incomplete: str
-            ) -> t.List["CompletionItem"]:
-                from click.shell_completion import CompletionItem
-
-                out = []
-
-                for c in autocompletion(ctx, [], incomplete):  # type: ignore
-                    if isinstance(c, tuple):
-                        c = CompletionItem(c[0], help=c[1])
-                    elif isinstance(c, str):
-                        c = CompletionItem(c)
-
-                    if c.value.startswith(incomplete):
-                        out.append(c)
-
-                return out
-
         self._custom_shell_complete = shell_complete
 
         if __debug__:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1568,17 +1568,6 @@ class MultiCommand(Command):
 
         return decorator
 
-    def resultcallback(self, replace: bool = False) -> t.Callable[[F], F]:
-        import warnings
-
-        warnings.warn(
-            "'resultcallback' has been renamed to 'result_callback'."
-            " The old name will be removed in Click 8.1.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.result_callback(replace=replace)
-
     def format_commands(self, ctx: Context, formatter: HelpFormatter) -> None:
         """Extra format methods for multi methods that adds all the commands
         after the options.

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -252,26 +252,6 @@ def confirm(
     return rv
 
 
-def get_terminal_size() -> os.terminal_size:
-    """Returns the current size of the terminal as tuple in the form
-    ``(width, height)`` in columns and rows.
-
-    .. deprecated:: 8.0
-        Will be removed in Click 8.1. Use
-        :func:`shutil.get_terminal_size` instead.
-    """
-    import shutil
-    import warnings
-
-    warnings.warn(
-        "'click.get_terminal_size()' is deprecated and will be removed"
-        " in Click 8.1. Use 'shutil.get_terminal_size()' instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return shutil.get_terminal_size()
-
-
 def echo_via_pager(
     text_or_generator: t.Union[t.Iterable[str], t.Callable[[], t.Iterable[str]], str],
     color: t.Optional[bool] = None,

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -379,25 +379,6 @@ def open_file(
     return f
 
 
-def get_os_args() -> t.Sequence[str]:
-    """Returns the argument part of ``sys.argv``, removing the first
-    value which is the name of the script.
-
-    .. deprecated:: 8.0
-        Will be removed in Click 8.1. Access ``sys.argv[1:]`` directly
-        instead.
-    """
-    import warnings
-
-    warnings.warn(
-        "'get_os_args' is deprecated and will be removed in Click 8.1."
-        " Access 'sys.argv[1:]' directly instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return sys.argv[1:]
-
-
 def format_filename(
     filename: t.Union[str, bytes, os.PathLike], shorten: bool = False
 ) -> str:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -161,20 +161,6 @@ def test_option_custom():
     assert _get_words(cli, ["a", "b"], "c") == ["C"]
 
 
-def test_autocompletion_deprecated():
-    # old function takes args and not param, returns all values, can mix
-    # strings and tuples
-    def custom(ctx, args, incomplete):
-        assert isinstance(args, list)
-        return [("art", "x"), "bat", "cat"]
-
-    with pytest.deprecated_call():
-        cli = Command("cli", params=[Argument(["x"], autocompletion=custom)])
-
-    assert _get_words(cli, [], "") == ["art", "bat", "cat"]
-    assert _get_words(cli, [], "c") == ["cat"]
-
-
 def test_option_multiple():
     cli = Command(
         "type",


### PR DESCRIPTION
* `Group.resultcallback` renamed to `result_callback`.
* `autocompletion` parameter to `Command` replaced by `shell_complete`.
* `get_terminal_size` removed.
* `get_os_args` removed.