### PR TITLE
Link code examples to reference documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,12 @@ extensions = [
     "pallets_sphinx_themes",
     "sphinx_issues",
     "sphinx_tabs.tabs",
+    "sphinx_codeautolink",
 ]
 autodoc_typehints = "description"
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 issues_github_path = "pallets/click"
+codeautolink_global_preface = "import click"
 
 # HTML -----------------------------------------------------------------
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -198,6 +198,7 @@ When passing a ``default`` with ``multiple=True``, the default value
 must be a list or tuple, otherwise it will be interpreted as a list of
 single characters.
 
+.. autolink-skip::
 .. code-block:: python
 
     @click.option("--format", multiple=True, default=["json"])

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,8 @@ babel==2.9.1
     # via sphinx
 backports.entry-points-selectable==1.1.1
     # via virtualenv
+beautifulsoup4==4.10.0
+    # via sphinx-codeautolink
 certifi==2021.10.8
     # via requests
 cfgv==3.3.1
@@ -92,13 +94,18 @@ six==1.16.0
     #   virtualenv
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.3.1
+    # via beautifulsoup4
 sphinx==4.3.2
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes
+    #   sphinx-codeautolink
     #   sphinx-issues
     #   sphinx-tabs
     #   sphinxcontrib-log-cabinet
+sphinx-codeautolink==0.8.0
+    # via -r requirements/docs.in
 sphinx-issues==1.2.0
     # via -r requirements/docs.in
 sphinx-tabs==3.2.0

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -3,3 +3,4 @@ Sphinx
 sphinx-issues
 sphinxcontrib-log-cabinet
 sphinx-tabs
+sphinx-codeautolink

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,6 +8,8 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
+beautifulsoup4==4.10.0
+    # via sphinx-codeautolink
 certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.9
@@ -42,13 +44,18 @@ requests==2.26.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.3.1
+    # via beautifulsoup4
 sphinx==4.3.2
     # via
     #   -r requirements/docs.in
     #   pallets-sphinx-themes
+    #   sphinx-codeautolink
     #   sphinx-issues
     #   sphinx-tabs
     #   sphinxcontrib-log-cabinet
+sphinx-codeautolink==0.8.0
+    # via -r requirements/docs.in
 sphinx-issues==1.2.0
     # via -r requirements/docs.in
 sphinx-tabs==3.2.0


### PR DESCRIPTION
Hi! This PR makes Click's code examples clickable (heh.) to take the user to reference documentation. The commit does a few things:

* introduce and configure [`sphinx-codeautolink`](https://sphinx-codeautolink.rtfd.io)
* skip the parsing of a single decorator example to avoid a syntax error
* update and pin docs requirements (on Python 3.9)

The result looks like this:

![home page](https://user-images.githubusercontent.com/25202257/142776007-44199dd9-b3ca-4f3e-b193-42b43c43e2f4.png)

So clicking in this case would take you to the reference entry of `click.option`. I think it improves navigation quite a bit when you're browsing examples.

I'm currently developing that extension and spent the weekend trying out a few big projects, Click being one of them. This time the setup was so easy that I couldn't resist just a cold PR 😄 If this isn't to your liking, feel free to shoot me down and close the PR right away! Or if any modifications are needed, I'd be happy to make them 👍 or even set up a demo RTD site if you'd like. I verified (to the best of my abilities) that the links are indeed everywhere they should be and that the build is completely clean.

Lemme know what you think!