### PR TITLE
Minor doc fix (o not?): Usage of `!!!!111` as a suffix for `shout` examples looks a typo

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -265,7 +265,7 @@ Example:
     def info(shout):
         rv = sys.platform
         if shout:
-            rv = rv.upper() + '!!!!111'
+            rv = rv.upper() + '!!!!!!!'
         click.echo(rv)
 
 And on the command line:
@@ -288,7 +288,7 @@ manually inform Click that something is a flag:
     def info(shout):
         rv = sys.platform
         if shout:
-            rv = rv.upper() + '!!!!111'
+            rv = rv.upper() + '!!!!!!!'
         click.echo(rv)
 
 And on the command line:
@@ -328,7 +328,7 @@ Example:
     def info(shout):
         rv = sys.platform
         if shout:
-            rv = rv.upper() + '!!!!111'
+            rv = rv.upper() + '!!!!!!!'
         click.echo(rv)
 
 .. click:run::


### PR DESCRIPTION
But maybe not, and there is a historical reason, joke, or something else I may be missing because of my ignorance... Already checked the commit history, and nothing made me think that this was intentional.
