### PR TITLE
Store raw help string for commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased
 
 -   Single options boolean flags with ``show_default=True`` only show
     the default if it is ``True``. :issue:`1971`
+-   Store untruncated help string in ``Command.raw_help`` attribute.
+    :issue:`2149`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1161,6 +1161,9 @@ class Command(BaseCommand):
 
     :param deprecated: issues a message indicating that
                              the command is deprecated.
+
+    .. versionchanged:: 8.1
+        Added ``raw_help`` attribute
     """
 
     def __init__(
@@ -1186,6 +1189,9 @@ class Command(BaseCommand):
         #: should show up in the help page and execute.  Eager parameters
         #: will automatically be handled before non eager ones.
         self.params: t.List["Parameter"] = params or []
+        #: the raw, unadulterated help string, suitable for consumption by
+        #: external tooling
+        self.raw_help = help
 
         # if a form feed (page break) is found in the help text, truncate help
         # text to the content preceding the first form feed


### PR DESCRIPTION
Some tools, such as [sphinx-click](https://github.com/click-contrib/sphinx-click/issues/56), may wish to access the full help string for a command including any text after the form feed character ([which indicates truncation](https://click.palletsprojects.com/en/latest/documentation/#truncating-help-texts)). Make this possible by storing this help string before truncation.

An alternative to this approach would be store the untruncated string in `help` and simply truncate on load. That's technically a breaking change. Another one is to do nothing, and I can close the RFE against sphinx-click.

- fixes #2149

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
