### PR TITLE
Store raw help string for commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,14 +27,15 @@ Version 8.1.0
 -   Parameter decorators and ``@group`` handles ``cls=None`` the same as
     not passing ``cls``. ``@option`` handles ``help=None`` the same as
     not passing ``help``. :issue:`#1959`
+-   A flag option with ``required=True`` requires that the flag is
+    passed instead of choosing the implicit default value. :issue:`1978`
 -   Indentation in help text passed to ``Option`` and ``Command`` is
     cleaned the same as using the ``@option`` and ``@command``
     decorators does. A command's ``epilog`` and ``short_help`` are also
     processed. :issue:`1985`
--   A flag option with ``required=True`` requires that the flag is
-    passed instead of choosing the implicit default value. :issue:`1978`
--   Store untruncated help string in ``Command.help``, and perform
-    truncation when formatting. :issue:`2149`
+-   Store unprocessed ``Command.help``, ``epilog`` and ``short_help``
+    strings. Processing is only done when formatting help text for
+    output. :issue:`2149`
 
 
 Version 8.0.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Version 8.1.0
     processed. :issue:`1985`
 -   A flag option with ``required=True`` requires that the flag is
     passed instead of choosing the implicit default value. :issue:`1978`
+-   Store untruncated help string in ``Command.help``, and perform
+    truncation when formatting. :issue:`2149`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1156,13 +1156,9 @@ class Command(BaseCommand):
                              the command is deprecated.
 
     .. versionchanged:: 8.1
-        ``help`` is stored untruncated, the formatter applied
-        truncation later.
-
-    .. versionchanged:: 8.1
-        Indentation in ``help`` is cleaned here instead of only in the
-        ``@command`` decorator. ``epilog`` and ``short_help`` are also
-        cleaned.
+        ``help``, ``epilog``, and ``short_help`` are stored unprocessed,
+        all formatting is done when outputting help text, not at init,
+        and is done even if not using the ``@command`` decorator.
 
     .. versionchanged:: 8.0
         Added a ``repr`` showing the command name.
@@ -1197,16 +1193,6 @@ class Command(BaseCommand):
         #: should show up in the help page and execute.  Eager parameters
         #: will automatically be handled before non eager ones.
         self.params: t.List["Parameter"] = params or []
-
-        if help:
-            help = inspect.cleandoc(help)
-
-        if epilog:
-            epilog = inspect.cleandoc(epilog)
-
-        if short_help:
-            short_help = inspect.cleandoc(short_help)
-
         self.help = help
         self.epilog = epilog
         self.options_metavar = options_metavar
@@ -1220,9 +1206,7 @@ class Command(BaseCommand):
         info_dict = super().to_info_dict(ctx)
         info_dict.update(
             params=[param.to_info_dict() for param in self.get_params(ctx)],
-            # truncate help text to the content preceding the first form feed,
-            # if any
-            help=self.help.split("\f", 1)[0] if self.help else self.help,
+            help=self.help,
             epilog=self.epilog,
             short_help=self.short_help,
             hidden=self.hidden,
@@ -1316,10 +1300,12 @@ class Command(BaseCommand):
         """Gets short help for the command or makes it by shortening the
         long help string.
         """
-        text = self.short_help or ""
-
-        if not text and self.help:
+        if self.short_help:
+            text = inspect.cleandoc(self.short_help)
+        elif self.help:
             text = make_default_short_help(self.help, limit)
+        else:
+            text = ""
 
         if self.deprecated:
             text = _("(Deprecated) {text}").format(text=text)
@@ -1345,16 +1331,13 @@ class Command(BaseCommand):
 
     def format_help_text(self, ctx: Context, formatter: HelpFormatter) -> None:
         """Writes the help text to the formatter if it exists."""
-        text = self.help or ""
-
-        # truncate the help text to the content preceding the first form feed,
-        # if any
-        text = text.split("\f", 1)[0]
+        text = self.help if self.help is not None else ""
 
         if self.deprecated:
             text = _("(Deprecated) {text}").format(text=text)
 
         if text:
+            text = inspect.cleandoc(text).partition("\f")[0]
             formatter.write_paragraph()
 
             with formatter.indentation():
@@ -1375,9 +1358,11 @@ class Command(BaseCommand):
     def format_epilog(self, ctx: Context, formatter: HelpFormatter) -> None:
         """Writes the epilog into the formatter if it exists."""
         if self.epilog:
+            epilog = inspect.cleandoc(self.epilog)
             formatter.write_paragraph()
+
             with formatter.indentation():
-                formatter.write_text(self.epilog)
+                formatter.write_text(epilog)
 
     def parse_args(self, ctx: Context, args: t.List[str]) -> t.List[str]:
         if not args and self.no_args_is_help and not ctx.resilient_parsing:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -95,6 +95,20 @@ def test_auto_shorthelp(runner):
     )
 
 
+def test_help_truncation(runner):
+    @click.command()
+    def cli():
+        """This is a command with truncated help.
+        \f
+
+        This text should be truncated.
+        """
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "This is a command with truncated help." in result.output
+
+
 def test_no_args_is_help(runner):
     @click.command(no_args_is_help=True)
     def cli():


### PR DESCRIPTION
Some tools, such as [sphinx-click](https://github.com/click-contrib/sphinx-click/issues/56), may wish to access the full help string for a command including any text after the form feed character ([which indicates truncation](https://click.palletsprojects.com/en/latest/documentation/#truncating-help-texts)). Make this possible by storing this help string before truncation. Truncation is achieved by the users of the attribute.

This is an alternative to #2150, based on feedback on the issue, #2149

- fixes #2149

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
