### PR TITLE
Fix TypeVar for decorators that handle Commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   ``open_file`` recognizes ``Path("-")`` as a standard stream, the
     same as the string ``"-"``. :issue:`2106`
+-   The ``option`` and ``argument`` decorators preserve the type
+    annotation of the decorated function. :pr:`2155`
 
 
 Version 8.0.3

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -14,7 +14,7 @@ from .globals import get_current_context
 from .utils import echo
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
-FC = t.TypeVar("FC", t.Callable[..., t.Any], Command)
+FC = t.TypeVar("FC", bound=t.Union[t.Callable[..., t.Any], Command])
 
 
 def pass_context(f: F) -> F:


### PR DESCRIPTION
The old type var would throw away the types of Callables.

```
import click

@click.option("--name", prompt="Your name", help="The person to greet.")
def hello(name: str) -> None:
    ...

reveal_type(hello)   #  note: Revealed type is 'def (*Any, **Any) -> Any'
```

With this small adjustment mypy now knows that it's a `'def (name: builtins.str)'`

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
