### PR TITLE
allow empty str input in prompt() when confirmation_prompt=True and default=""

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Version 8.1.0
 -   Store unprocessed ``Command.help``, ``epilog`` and ``short_help``
     strings. Processing is only done when formatting help text for
     output. :issue:`2149`
+-   Allow empty str input for ``prompt()`` when
+    ``confirmation_prompt=True`` and ``default=""``. :issue:`2157`
 
 
 Version 8.0.4

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -181,7 +181,8 @@ def prompt(
             return result
         while True:
             value2 = prompt_func(confirmation_prompt)
-            if value2:
+            is_empty = not value and not value2
+            if value2 or is_empty:
                 break
         if value == value2:
             return result

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -420,17 +420,22 @@ def test_prompt_required_false(runner, args, expect):
 
 
 @pytest.mark.parametrize(
-    ("prompt", "input", "expect"),
+    ("prompt", "input", "default", "expect"),
     [
-        (True, "password\npassword", "password"),
-        ("Confirm Password", "password\npassword\n", "password"),
-        (False, None, None),
+        (True, "password\npassword", None, "password"),
+        ("Confirm Password", "password\npassword\n", None, "password"),
+        (True, "", "", ""),
+        (False, None, None, None),
     ],
 )
-def test_confirmation_prompt(runner, prompt, input, expect):
+def test_confirmation_prompt(runner, prompt, input, default, expect):
     @click.command()
     @click.option(
-        "--password", prompt=prompt, hide_input=True, confirmation_prompt=prompt
+        "--password",
+        prompt=prompt,
+        hide_input=True,
+        default=default,
+        confirmation_prompt=prompt,
     )
     def cli(password):
         return password


### PR DESCRIPTION
Check to see if the user inputted nothing (empty str) for their first answer and second answer in the `prompt()` method when `confirmation_prompt=True`

- fixes #2157

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
