### PR TITLE
Fix typing issue in `click.secho`

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -604,7 +604,7 @@ def unstyle(text: str) -> str:
 
 def secho(
     message: t.Optional[t.Any] = None,
-    file: t.Optional[t.IO] = None,
+    file: t.Optional[t.IO[t.Any]] = None,
     nl: bool = True,
     err: bool = False,
     color: t.Optional[bool] = None,


### PR DESCRIPTION
[Pyright](https://github.com/microsoft/pyright) tells that there's type checking issue: IO descriptors are not specified.

This PR fixes it.
