### PR TITLE
glob expansion on Windows doesn't fail on invalid values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Version 8.1.0
     output. :issue:`2149`
 -   Allow empty str input for ``prompt()`` when
     ``confirmation_prompt=True`` and ``default=""``. :issue:`2157`
+-   Windows glob pattern expansion doesn't fail if a value is an invalid
+    pattern. :issue:`2195`
 
 
 Version 8.0.4

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import typing as t
 from functools import update_wrapper
@@ -536,13 +537,17 @@ def _expand_args(
     See :func:`glob.glob`, :func:`os.path.expanduser`, and
     :func:`os.path.expandvars`.
 
-    This intended for use on Windows, where the shell does not do any
+    This is intended for use on Windows, where the shell does not do any
     expansion. It may not exactly match what a Unix shell would do.
 
     :param args: List of command line arguments to expand.
     :param user: Expand user home directory.
     :param env: Expand environment variables.
     :param glob_recursive: ``**`` matches directories recursively.
+
+    .. versionchanged:: 8.1
+        Invalid glob patterns are treated as empty expansions rather
+        than raising an error.
 
     .. versionadded:: 8.0
 
@@ -559,7 +564,10 @@ def _expand_args(
         if env:
             arg = os.path.expandvars(arg)
 
-        matches = glob(arg, recursive=glob_recursive)
+        try:
+            matches = glob(arg, recursive=glob_recursive)
+        except re.error:
+            matches = []
 
         if not matches:
             out.append(arg)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -468,6 +468,8 @@ def test_expand_args(monkeypatch):
     assert "setup.cfg" in click.utils._expand_args(["*.cfg"])
     assert os.path.join("docs", "conf.py") in click.utils._expand_args(["**/conf.py"])
     assert "*.not-found" in click.utils._expand_args(["*.not-found"])
+    # a bad glob pattern, such as a pytest identifier, should return itself
+    assert click.utils._expand_args(["test.py::test_bad"])[0] == "test.py::test_bad"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When we do glob pattern expansion on Windows, don't raise an error when attempting to expand a value that is an invalid pattern.

closes #2195 