### PR TITLE
Add `EnumChoice` parameter type

### DIFF
--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -52,6 +52,7 @@ from .termui import unstyle as unstyle
 from .types import BOOL as BOOL
 from .types import Choice as Choice
 from .types import DateTime as DateTime
+from .types import EnumChoice as EnumChoice
 from .types import File as File
 from .types import FLOAT as FLOAT
 from .types import FloatRange as FloatRange

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections.abc as cabc
+import enum
 import os
 import stat
 import sys
@@ -334,6 +335,23 @@ class Choice(ParamType):
             matched = (c for c in str_choices if c.lower().startswith(incomplete))
 
         return [CompletionItem(c) for c in matched]
+
+
+class EnumChoice(Choice):
+    def __init__(self, enum_type: type[enum.Enum], case_sensitive: bool = True):
+        super().__init__(
+            choices=[element.name for element in enum_type],
+            case_sensitive=case_sensitive,
+        )
+        self.enum_type = enum_type
+
+    def convert(
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
+    ) -> t.Any:
+        value = super().convert(value=value, param=param, ctx=ctx)
+        if value is None:
+            return None
+        return self.enum_type[value]
 
 
 class DateTime(ParamType):

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -1,8 +1,11 @@
+import enum
+
 import pytest
 
 import click.types
 
 # Common (obj, expect) pairs used to construct multiple tests.
+
 STRING_PARAM_TYPE = (click.STRING, {"param_type": "String", "name": "text"})
 INT_PARAM_TYPE = (click.INT, {"param_type": "Int", "name": "integer"})
 BOOL_PARAM_TYPE = (click.BOOL, {"param_type": "Bool", "name": "boolean"})
@@ -91,6 +94,15 @@ HELLO_GROUP = (
 )
 
 
+class MyEnum(enum.Enum):
+    """Dummy enum for unit tests."""
+
+    ONE = "one"
+    TWO = "two"
+    THREE = "three"
+    ONE_ALIAS = ONE
+
+
 @pytest.mark.parametrize(
     ("obj", "expect"),
     [
@@ -111,6 +123,16 @@ HELLO_GROUP = (
                 "param_type": "Choice",
                 "name": "choice",
                 "choices": ["a", "b"],
+                "case_sensitive": True,
+            },
+            id="Choice ParamType",
+        ),
+        pytest.param(
+            click.EnumChoice(MyEnum),
+            {
+                "param_type": "EnumChoice",
+                "name": "choice",
+                "choices": ["ONE", "TWO", "THREE"],
                 "case_sensitive": True,
             },
             id="Choice ParamType",

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -135,7 +135,7 @@ class MyEnum(enum.Enum):
                 "choices": ["ONE", "TWO", "THREE"],
                 "case_sensitive": True,
             },
-            id="Choice ParamType",
+            id="EnumChoice ParamType",
         ),
         pytest.param(
             click.DateTime(["%Y-%m-%d"]),

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,6 +1,17 @@
+import enum
+
 import click
 
 CONTEXT_SETTINGS = dict(token_normalize_func=lambda x: x.lower())
+
+
+class MyEnum(enum.Enum):
+    """Dummy enum for unit tests."""
+
+    ONE = "one"
+    TWO = "two"
+    THREE = "three"
+    ONE_ALIAS = ONE
 
 
 def test_option_normalization(runner):
@@ -23,6 +34,16 @@ def test_choice_normalization(runner):
 
     result = runner.invoke(cli, ["--CHOICE", "FOO"])
     assert result.output == "Foo\n"
+
+
+def test_enum_choice_normalization(runner):
+    @click.command(context_settings=CONTEXT_SETTINGS)
+    @click.option("--choice", type=click.EnumChoice(MyEnum))
+    def cli(choice):
+        click.echo(choice)
+
+    result = runner.invoke(cli, ["--CHOICE", "ONE"])
+    assert result.output == "MyEnum.ONE\n"
 
 
 def test_command_normalization(runner):


### PR DESCRIPTION
Added a new ability to be able to create a choice parameter type from enum class.

How does it differ from `Choice`? Enums are the way of python to allow only a finite number of values to be accepted in a given scenario. It seems logical to me that click should offer a `Choice`-like parameter type that gets its values from an enum and returns an enum.

Now, using `click.EnumChoice`, one can create a `Choice`-like parameter that returns an enum instead of a string.
Moreover, once you add a new value to your enum class, it will automatically update as a valid choice for the paramater type.

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
