### PR TITLE
Improve type hints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ Version 8.1.0
 -   It's possible to pass a list of ``params`` to ``@command``. Any
     params defined with decorators are appended to the passed params.
     :issue:`2131`.
+-   ``@command`` decorator is annotated as returning the correct type if
+    a ``cls`` argument is used. :issue:`2211`
 
 
 Version 8.0.4

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -121,19 +121,38 @@ def pass_meta_key(
     return decorator
 
 
+CmdType = t.TypeVar("CmdType", bound=Command)
+
+
 @t.overload
 def command(
     name: t.Optional[str] = None,
-    cls: t.Optional[t.Type[Command]] = None,
+    cls: t.Type[CmdType] = ...,
     **attrs: t.Any,
-) -> t.Callable[[F], Command]:
+) -> t.Callable[..., CmdType]:
+    ...
+
+
+@t.overload
+def command(
+    name: t.Optional[str] = None,
+    **attrs: t.Any,
+) -> t.Callable[..., Command]:
     ...
 
 
 @t.overload
 def command(
     name: t.Callable,
-    cls: t.Optional[t.Type[Command]] = None,
+    cls: t.Type[CmdType] = ...,
+    **attrs: t.Any,
+) -> CmdType:
+    ...
+
+
+@t.overload
+def command(
+    name: t.Callable,
     **attrs: t.Any,
 ) -> Command:
     ...
@@ -143,7 +162,7 @@ def command(
     name: t.Union[str, t.Callable, None] = None,
     cls: t.Optional[t.Type[Command]] = None,
     **attrs: t.Any,
-) -> t.Union[Command, t.Callable[[F], Command]]:
+) -> t.Union[Command, t.Callable[..., Command]]:
     r"""Creates a new :class:`Command` and uses the decorated function as
     callback.  This will also automatically attach all decorated
     :func:`option`\s and :func:`argument`\s as parameters to the command.


### PR DESCRIPTION
This PR improves the typpe annotation on `@command` decorator so that when `cls` is submitted, the return value is an instance of `cls`.

In addition, as a small tweak, I lowered the requirement on `choices` of `Choice` to `Collection` -- we only need iteration and length. This way `Choice(choices=somedict.keys())` is valid.

- fixes #2211

Checklist:

- [ ] (n/a) Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] (n/a) Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] (n/a) Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
