### PR TITLE
postpone referencing sys.modules["__main__"]

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -475,7 +475,7 @@ class PacifyFlushWrapper:
 
 
 def _detect_program_name(
-    path: t.Optional[str] = None, _main: ModuleType = sys.modules["__main__"]
+    path: t.Optional[str] = None, _main: t.Optional[ModuleType] = None
 ) -> str:
     """Determine the command used to run the program, for use in help
     text. If a file or entry point was executed, the file name is
@@ -497,6 +497,9 @@ def _detect_program_name(
 
     :meta private:
     """
+    if _main is None:
+        _main = sys.modules["__main__"]
+
     if not path:
         path = sys.argv[0]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -444,20 +444,12 @@ class MockMain:
         ("example.py", None, "example.py"),
         (str(pathlib.Path("/foo/bar/example.py")), None, "example.py"),
         ("example", None, "example"),
-        (
-            str(pathlib.Path("example/__main__.py")),
-            MockMain(".example"),
-            "python -m example",
-        ),
-        (
-            str(pathlib.Path("example/cli.py")),
-            MockMain(".example"),
-            "python -m example.cli",
-        ),
+        (str(pathlib.Path("example/__main__.py")), "example", "python -m example"),
+        (str(pathlib.Path("example/cli.py")), "example", "python -m example.cli"),
     ],
 )
 def test_detect_program_name(path, main, expected):
-    assert click.utils._detect_program_name(path, _main=main) == expected
+    assert click.utils._detect_program_name(path, _main=MockMain(main)) == expected
 
 
 def test_expand_args(monkeypatch):


### PR DESCRIPTION
This currently breaks anyio (and presumably other things that do multiprocessing stuff) _just from an import_. 
To reproduce:

```python
from time import sleep

from anyio import to_process, run
import click  # this import breaks the program

async def main() -> None:
    await to_process.run_sync(sleep, 0)

if __name__ == "__main__":
    run(main)
```

cc @agronholm