### PR TITLE
group without command passes return value to result callback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,9 @@ Version 8.1.0
     :issue:`2131`.
 -   ``@command`` decorator is annotated as returning the correct type if
     a ``cls`` argument is used. :issue:`2211`
+-   A ``Group`` with ``invoke_without_command=True`` and ``chain=False``
+    will invoke its result callback with the group function's return
+    value. :issue:`2124`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1626,11 +1626,11 @@ class MultiCommand(Command):
         if not ctx.protected_args:
             if self.invoke_without_command:
                 # No subcommand was invoked, so the result callback is
-                # invoked with None for regular groups, or an empty list
-                # for chained groups.
+                # invoked with the group return value for regular
+                # groups, or an empty list for chained groups.
                 with ctx:
-                    super().invoke(ctx)
-                    return _process_result([] if self.chain else None)
+                    rv = super().invoke(ctx)
+                    return _process_result([] if self.chain else rv)
             ctx.fail(_("Missing command."))
 
         # Fetch args back out

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -85,20 +85,20 @@ def test_chaining_with_options(runner):
     assert result.output.splitlines() == ["bdist called 1", "sdist called 2"]
 
 
-@pytest.mark.parametrize(("chain", "expect"), [(False, "None"), (True, "[]")])
+@pytest.mark.parametrize(("chain", "expect"), [(False, "1"), (True, "[]")])
 def test_no_command_result_callback(runner, chain, expect):
     """When a group has ``invoke_without_command=True``, the result
     callback is always invoked. A regular group invokes it with
-    ``None``, a chained group with ``[]``.
+    its return value, a chained group with ``[]``.
     """
 
     @click.group(invoke_without_command=True, chain=chain)
     def cli():
-        pass
+        return 1
 
     @cli.result_callback()
     def process_result(result):
-        click.echo(str(result), nl=False)
+        click.echo(result, nl=False)
 
     result = runner.invoke(cli, [])
     assert result.output == expect


### PR DESCRIPTION
A non-chained group invoked without a subcommand will pass its return value to its result callback, instead of `None`.

fixes #2124 