### PR TITLE
treat empty auto_envvar as None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ Version 8.1.0
     ``name``. :issue:`2168`
 -   Shell completion prioritizes option values with option prefixes over
     new options. :issue:`2040`
+-   Options that get an environment variable value using
+    ``autoenvvar_prefix`` treat an empty value as ``None``, consistent
+    with a direct ``envvar``. :issue:`2146`
 
 
 Version 8.0.4

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2834,7 +2834,10 @@ class Option(Parameter):
             envvar = f"{ctx.auto_envvar_prefix}_{self.name.upper()}"
             rv = os.environ.get(envvar)
 
-        return rv
+            if rv:
+                return rv
+
+        return None
 
     def value_from_envvar(self, ctx: Context) -> t.Optional[t.Any]:
         rv: t.Optional[t.Any] = self.resolve_envvar_value(ctx)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -153,14 +153,15 @@ def test_init_bad_default_list(runner, multiple, nargs, default):
         click.Option(["-a"], type=type, multiple=multiple, nargs=nargs, default=default)
 
 
-def test_empty_envvar(runner):
+@pytest.mark.parametrize("env_key", ["MYPATH", "AUTO_MYPATH"])
+def test_empty_envvar(runner, env_key):
     @click.command()
     @click.option("--mypath", type=click.Path(exists=True), envvar="MYPATH")
     def cli(mypath):
         click.echo(f"mypath: {mypath}")
 
-    result = runner.invoke(cli, [], env={"MYPATH": ""})
-    assert result.exit_code == 0
+    result = runner.invoke(cli, env={env_key: ""}, auto_envvar_prefix="AUTO")
+    assert result.exception is None
     assert result.output == "mypath: None\n"
 
 


### PR DESCRIPTION
#1687 fixed empty value in env var specified with `envvar`, but missed that the same logic needed to happen for option `auto_envvar`.

fixes #2146