### PR TITLE
fix(types): decorator typing fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.1.1
 
 Unreleased
 
+-   Fix an issue with decorator typing that caused type checking to
+    report that a command was not callable. :issue:`2227`
+
 
 Version 8.1.0
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1809,6 +1809,16 @@ class Group(MultiCommand):
         _check_multicommand(self, name, cmd, register=True)
         self.commands[name] = cmd
 
+    @t.overload
+    def command(self, __func: t.Callable[..., t.Any]) -> Command:
+        ...
+
+    @t.overload
+    def command(
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Callable[[t.Callable[..., t.Any]], Command]:
+        ...
+
     def command(
         self, *args: t.Any, **kwargs: t.Any
     ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], Command], Command]:
@@ -1834,8 +1844,11 @@ class Group(MultiCommand):
         func: t.Optional[t.Callable] = None
 
         if args and callable(args[0]):
-            func = args[0]
-            args = args[1:]
+            assert (
+                len(args) == 1 and not kwargs
+            ), "Use 'command(**kwargs)(callable)' to provide arguments."
+            (func,) = args
+            args = ()
 
         def decorator(f: t.Callable[..., t.Any]) -> Command:
             cmd: Command = command(*args, **kwargs)(f)
@@ -1846,6 +1859,16 @@ class Group(MultiCommand):
             return decorator(func)
 
         return decorator
+
+    @t.overload
+    def group(self, __func: t.Callable[..., t.Any]) -> "Group":
+        ...
+
+    @t.overload
+    def group(
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Callable[[t.Callable[..., t.Any]], "Group"]:
+        ...
 
     def group(
         self, *args: t.Any, **kwargs: t.Any
@@ -1869,8 +1892,11 @@ class Group(MultiCommand):
         func: t.Optional[t.Callable] = None
 
         if args and callable(args[0]):
-            func = args[0]
-            args = args[1:]
+            assert (
+                len(args) == 1 and not kwargs
+            ), "Use 'group(**kwargs)(callable)' to provide arguments."
+            (func,) = args
+            args = ()
 
         if self.group_class is not None and kwargs.get("cls") is None:
             if self.group_class is type:

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -126,10 +126,8 @@ CmdType = t.TypeVar("CmdType", bound=Command)
 
 @t.overload
 def command(
-    name: t.Optional[str] = None,
-    cls: t.Type[CmdType] = ...,
-    **attrs: t.Any,
-) -> t.Callable[..., CmdType]:
+    __func: t.Callable[..., t.Any],
+) -> Command:
     ...
 
 
@@ -143,18 +141,10 @@ def command(
 
 @t.overload
 def command(
-    name: t.Callable,
+    name: t.Optional[str] = None,
     cls: t.Type[CmdType] = ...,
     **attrs: t.Any,
-) -> CmdType:
-    ...
-
-
-@t.overload
-def command(
-    name: t.Callable,
-    **attrs: t.Any,
-) -> Command:
+) -> t.Callable[..., CmdType]:
     ...
 
 
@@ -191,14 +181,17 @@ def command(
         The ``params`` argument can be used. Decorated params are
         appended to the end of the list.
     """
-    if cls is None:
-        cls = Command
 
     func: t.Optional[t.Callable] = None
 
     if callable(name):
         func = name
         name = None
+        assert cls is None, "Use 'command(cls=cls)(callable)' to specify a class."
+        assert not attrs, "Use 'command(**kwargs)(callable)' to provide arguments."
+
+    if cls is None:
+        cls = Command
 
     def decorator(f: t.Callable[..., t.Any]) -> Command:
         if isinstance(f, Command):
@@ -235,17 +228,16 @@ def command(
 
 @t.overload
 def group(
-    name: t.Optional[str] = None,
-    **attrs: t.Any,
-) -> t.Callable[[F], Group]:
+    __func: t.Callable,
+) -> Group:
     ...
 
 
 @t.overload
 def group(
-    name: t.Callable,
+    name: t.Optional[str] = None,
     **attrs: t.Any,
-) -> Group:
+) -> t.Callable[[F], Group]:
     ...
 
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2227

I've tried the fix suggested in the issue above by @Dreamsorcerer, and it seems to fix the typing issue locally.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
