### PR TITLE
restore Path param order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 -   Fix error message for readable path check that was mixed up with the
     executable check. :pr:`2236`
+-   Restore parameter order for ``Path``, placing the ``executable``
+    parameter at the end. It is recommended to use keyword arguments
+    instead of positional arguments. :issue:`2235`
 
 
 Version 8.1.1

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -790,12 +790,12 @@ class Path(ParamType):
         exists: bool = False,
         file_okay: bool = True,
         dir_okay: bool = True,
-        readable: bool = True,
         writable: bool = False,
-        executable: bool = False,
+        readable: bool = True,
         resolve_path: bool = False,
         allow_dash: bool = False,
         path_type: t.Optional[t.Type] = None,
+        executable: bool = False,
     ):
         self.exists = exists
         self.file_okay = file_okay


### PR DESCRIPTION
When adding the `executable` parameter, #1962 also reordered the parameters to match the standard "read, write, execute" order. Restore the order to be "writable, readable", with "executable" at the end.

fixes #2235 