### PR TITLE
Replaced deprecated mktemp() with mkstemp()  (#1754)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: reorder-python-imports
         args: ["--application-directories", "src"]
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Version 7.2
 -----------
 
 -   Include ``--help`` option in completion. :pr:`1504`
+-   Use ``mkstemp()`` instead of ``mktemp()`` in pager implementation.
+    :issue:`1752`
 
 
 Version 7.1.2

--- a/examples/termui/termui.py
+++ b/examples/termui/termui.py
@@ -71,7 +71,7 @@ def progress(count):
         length=count,
         label="Counting",
         bar_template="%(label)s  %(bar)s | %(info)s",
-        fill_char=click.style(u"█", fg="cyan"),
+        fill_char=click.style("█", fg="cyan"),
         empty_char=" ",
     ) as bar:
         for item in bar:
@@ -94,7 +94,7 @@ def progress(count):
         length=count,
         show_percent=False,
         label="Slowing progress bar",
-        fill_char=click.style(u"█", fg="green"),
+        fill_char=click.style("█", fg="green"),
     ) as bar:
         for item in steps:
             time.sleep(item)

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -270,7 +270,6 @@ if PY2:
             value = value.decode(get_filesystem_encoding(), "replace")
         return value
 
-
 else:
     import io
 
@@ -724,7 +723,6 @@ if WIN:
                 colorama.win32.STDOUT
             ).srWindow
             return win.Right - win.Left, win.Bottom - win.Top
-
 
 else:
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -405,7 +405,7 @@ def _tempfilepager(generator, cmd, color):
     """Page through text by invoking a program on a temporary file."""
     import tempfile
 
-    filename = tempfile.mktemp()
+    filename = tempfile.mkstemp()
     # TODO: This never terminates if the passed generator never terminates.
     text = "".join(generator)
     if not color:

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -467,7 +467,7 @@ class Editor(object):
             if exit_code != 0:
                 raise ClickException("{}: Editing failed!".format(editor))
         except OSError as e:
-            raise ClickException("{}: Editing failed: {}".format(editor, e))
+            raise ClickException("{}: Editing failed: {}".format(editor, e)) from e
 
     def edit(self, text):
         import tempfile

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -459,7 +459,9 @@ class Editor(object):
             environ = None
         try:
             c = subprocess.Popen(
-                '{} "{}"'.format(editor, filename), env=environ, shell=True,
+                '{} "{}"'.format(editor, filename),
+                env=environ,
+                shell=True,
             )
             exit_code = c.wait()
             if exit_code != 0:
@@ -563,11 +565,11 @@ def open_url(url, wait=False, locate=False):
 
 
 def _translate_ch_to_exc(ch):
-    if ch == u"\x03":
+    if ch == "\x03":
         raise KeyboardInterrupt()
-    if ch == u"\x04" and not WIN:  # Unix-like, Ctrl+D
+    if ch == "\x04" and not WIN:  # Unix-like, Ctrl+D
         raise EOFError()
-    if ch == u"\x1a" and WIN:  # Windows, Ctrl+Z
+    if ch == "\x1a" and WIN:  # Windows, Ctrl+Z
         raise EOFError()
 
 
@@ -614,13 +616,12 @@ if WIN:
             func = msvcrt.getwch
 
         rv = func()
-        if rv in (u"\x00", u"\xe0"):
+        if rv in ("\x00", "\xe0"):
             # \x00 and \xe0 are control characters that indicate special key,
             # see above.
             rv += func()
         _translate_ch_to_exc(rv)
         return rv
-
 
 else:
     import tty

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -792,7 +792,7 @@ class BaseCommand(object):
                     ctx.exit()
             except (EOFError, KeyboardInterrupt):
                 echo(file=sys.stderr)
-                raise Abort()
+                raise Abort() from None
             except ClickException as e:
                 if not standalone_mode:
                     raise

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -20,9 +20,9 @@ def get_current_context(silent=False):
     """
     try:
         return _local.stack[-1]
-    except (AttributeError, IndexError):
+    except (AttributeError, IndexError) as e:
         if not silent:
-            raise RuntimeError("There is no active click context.")
+            raise RuntimeError("There is no active click context.") from e
 
 
 def push_context(ctx):

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -36,7 +36,7 @@ def pop_context():
 
 
 def resolve_color_default(color=None):
-    """"Internal helper to get the default value of the color flag.  If a
+    """ "Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
     the current context.
     """

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -133,7 +133,7 @@ def prompt(
             # A doc bug has been filed at https://bugs.python.org/issue24711
             if hide_input:
                 echo(None, err=err)
-            raise Abort()
+            raise Abort() from None
 
     if value_proc is None:
         value_proc = convert_type(type, default)
@@ -199,7 +199,7 @@ def confirm(
             echo(prompt, nl=False, err=err)
             value = visible_prompt_func("").lower().strip()
         except (KeyboardInterrupt, EOFError):
-            raise Abort()
+            raise Abort() from None
         if value in ("y", "yes"):
             rv = True
         elif value in ("n", "no"):
@@ -497,12 +497,12 @@ def style(
         try:
             bits.append("\033[{}m".format(_ansi_colors[fg]))
         except KeyError:
-            raise TypeError("Unknown color '{}'".format(fg))
+            raise TypeError("Unknown color '{}'".format(fg)) from None
     if bg:
         try:
             bits.append("\033[{}m".format(_ansi_colors[bg] + 10))
         except KeyError:
-            raise TypeError("Unknown color '{}'".format(bg))
+            raise TypeError("Unknown color '{}'".format(bg)) from None
     if bold is not None:
         bits.append("\033[{}m".format(1 if bold else 22))
     if dim is not None:

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -234,9 +234,9 @@ def echo(message=None, file=None, nl=True, err=False, color=None):
         message = text_type(message)
 
     if nl:
-        message = message or u""
+        message = message or ""
         if isinstance(message, text_type):
-            message += u"\n"
+            message += "\n"
         else:
             message += b"\n"
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -129,7 +129,7 @@ class LazyFile(object):
         except (IOError, OSError) as e:  # noqa: E402
             from .exceptions import FileError
 
-            raise FileError(self.name, hint=get_streerror(e))
+            raise FileError(self.name, hint=get_streerror(e)) from e
         self._f = rv
         return rv
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -126,7 +126,7 @@ class LazyFile(object):
             rv, self.should_close = open_stream(
                 self.name, self.mode, self.encoding, self.errors, atomic=self.atomic
             )
-        except (IOError, OSError) as e:  # noqa: E402
+        except OSError as e:  # noqa: E402
             from .exceptions import FileError
 
             raise FileError(self.name, hint=get_streerror(e)) from e

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -98,7 +98,7 @@ def test_bytes_args(runner, monkeypatch):
 
     runner.invoke(
         from_bytes,
-        [u"Something outside of ASCII range: 林".encode("UTF-8")],
+        ["Something outside of ASCII range: 林".encode("UTF-8")],
         catch_exceptions=False,
     )
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -82,7 +82,7 @@ def test_basic_option(runner):
     @click.command()
     @click.option("--foo", default="no value")
     def cli(foo):
-        click.echo(u"FOO:[{}]".format(foo))
+        click.echo("FOO:[{}]".format(foo))
 
     result = runner.invoke(cli, [])
     assert not result.exception
@@ -100,9 +100,9 @@ def test_basic_option(runner):
     assert not result.exception
     assert "FOO:[]" in result.output
 
-    result = runner.invoke(cli, [u"--foo=\N{SNOWMAN}"])
+    result = runner.invoke(cli, ["--foo=\N{SNOWMAN}"])
     assert not result.exception
-    assert u"FOO:[\N{SNOWMAN}]" in result.output
+    assert "FOO:[\N{SNOWMAN}]" in result.output
 
 
 def test_int_option(runner):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -53,13 +53,11 @@ def test_basic_functionality(runner):
 def test_wrapping_long_options_strings(runner):
     @click.group()
     def cli():
-        """Top level command
-        """
+        """Top level command"""
 
     @cli.group()
     def a_very_long():
-        """Second level
-        """
+        """Second level"""
 
     @a_very_long.command()
     @click.argument("first")
@@ -69,8 +67,7 @@ def test_wrapping_long_options_strings(runner):
     @click.argument("fifth")
     @click.argument("sixth")
     def command():
-        """A command.
-        """
+        """A command."""
 
     # 54 is chosen as a length where the second line is one character
     # longer than the maximum length.
@@ -91,13 +88,11 @@ def test_wrapping_long_options_strings(runner):
 def test_wrapping_long_command_name(runner):
     @click.group()
     def cli():
-        """Top level command
-        """
+        """Top level command"""
 
     @cli.group()
     def a_very_very_very_long():
-        """Second level
-        """
+        """Second level"""
 
     @a_very_very_very_long.command()
     @click.argument("first")
@@ -107,8 +102,7 @@ def test_wrapping_long_command_name(runner):
     @click.argument("fifth")
     @click.argument("sixth")
     def command():
-        """A command.
-        """
+        """A command."""
 
     result = runner.invoke(
         cli, ["a-very-very-very-long", "command", "--help"], terminal_width=54
@@ -129,9 +123,7 @@ def test_wrapping_long_command_name(runner):
 def test_formatting_empty_help_lines(runner):
     @click.command()
     def cli():
-        """Top level command
-
-        """
+        """Top level command"""
 
     result = runner.invoke(cli, ["--help"])
     assert not result.exception
@@ -307,7 +299,10 @@ def test_global_show_default(runner):
     def cli():
         pass
 
-    result = runner.invoke(cli, ["--help"],)
+    result = runner.invoke(
+        cli,
+        ["--help"],
+    )
     assert result.output.splitlines() == [
         "Usage: cli [OPTIONS]",
         "",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -421,7 +421,10 @@ def test_option_help_preserve_paragraphs(runner):
     def cmd(config):
         pass
 
-    result = runner.invoke(cmd, ["--help"],)
+    result = runner.invoke(
+        cmd,
+        ["--help"],
+    )
     assert result.exit_code == 0
     assert (
         "  -C, --config PATH  Configuration file to use.\n"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -46,8 +46,8 @@ def test_nargs_tup_composite_mult(runner):
     @click.command()
     @click.option("--item", type=(str, int), multiple=True)
     def copy(item):
-        for item in item:
-            click.echo("name={0[0]} id={0[1]:d}".format(item))
+        for name, id in item:
+            click.echo("name={} id={:d}".format(name, id))
 
     result = runner.invoke(copy, ["--item", "peter", "1", "--item", "max", "2"])
     assert not result.exception

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -285,7 +285,7 @@ def test_progressbar_update(runner, monkeypatch):
     assert "100%          " in lines[3]
 
 
-@pytest.mark.parametrize("key_char", (u"h", u"H", u"é", u"À", u" ", u"字", u"àH", u"àR"))
+@pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")
 def test_getchar_windows(runner, monkeypatch, key_char, echo):
@@ -296,7 +296,7 @@ def test_getchar_windows(runner, monkeypatch, key_char, echo):
 
 
 @pytest.mark.parametrize(
-    "special_key_char, key_char", [(u"\x00", "a"), (u"\x00", "b"), (u"\xe0", "c")]
+    "special_key_char, key_char", [("\x00", "a"), ("\x00", "b"), ("\xe0", "c")]
 )
 @pytest.mark.skipif(
     not WIN, reason="Tests special character inputs using the msvcrt module."
@@ -311,7 +311,8 @@ def test_getchar_special_key_windows(runner, monkeypatch, special_key_char, key_
 
 
 @pytest.mark.parametrize(
-    ("key_char", "exc"), [(u"\x03", KeyboardInterrupt), (u"\x1a", EOFError)],
+    ("key_char", "exc"),
+    [("\x03", KeyboardInterrupt), ("\x1a", EOFError)],
 )
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")
 def test_getchar_windows_exceptions(runner, monkeypatch, key_char, exc):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from click._compat import WIN
 
 def test_echo(runner):
     with runner.isolation() as outstreams:
-        click.echo(u"\N{SNOWMAN}")
+        click.echo("\N{SNOWMAN}")
         click.echo(b"\x44\x44")
         click.echo(42, nl=False)
         click.echo(b"a", nl=False)
@@ -49,8 +49,8 @@ def test_echo_custom_file():
     import io
 
     f = io.StringIO()
-    click.echo(u"hello", file=f)
-    assert f.getvalue() == u"hello\n"
+    click.echo("hello", file=f)
+    assert f.getvalue() == "hello\n"
 
 
 @pytest.mark.parametrize(
@@ -91,14 +91,12 @@ def test_unstyle_other_ansi(text, expect):
 def test_filename_formatting():
     assert click.format_filename(b"foo.txt") == "foo.txt"
     assert click.format_filename(b"/x/foo.txt") == "/x/foo.txt"
-    assert click.format_filename(u"/x/foo.txt") == "/x/foo.txt"
-    assert click.format_filename(u"/x/foo.txt", shorten=True) == "foo.txt"
+    assert click.format_filename("/x/foo.txt") == "/x/foo.txt"
+    assert click.format_filename("/x/foo.txt", shorten=True) == "foo.txt"
 
     # filesystem encoding on windows permits this.
     if not WIN:
-        assert (
-            click.format_filename(b"/x/foo\xff.txt", shorten=True) == u"foo\ufffd.txt"
-        )
+        assert click.format_filename(b"/x/foo\xff.txt", shorten=True) == "foo\ufffd.txt"
 
 
 def test_prompts(runner):


### PR DESCRIPTION
Replaced deprecated function with the recommended alternative. Cherry-pick of https://github.com/pallets/click/pull/1754 to `7.x` branch with additional black and flake8 changes. 

The [safety-db](https://github.com/pyupio/safety-db) marks click [<8.0.0 as vulnerable](https://github.com/pyupio/safety-db/blob/c3d4f3a9cbacd8e4954188517e43eba5792b2ba8/data/insecure.json#L926) due to the usage of `mktemp`. I would like to backport this change to mitigate this issue on the `7.x` branch.

I also had to change a few other files due to pre-commit.ci failures.

- fixes #1752 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed. (tox failes unchanged files)
