### PR TITLE
Fix default value for flags with multiple=True

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2532,6 +2532,9 @@ class Option(Parameter):
         if is_flag and default_is_missing and not self.required:
             self.default: t.Union[t.Any, t.Callable[[], t.Any]] = False
 
+            if multiple:
+                self.default = ()
+
         if flag_value is None:
             flag_value = not self.default
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -904,3 +904,24 @@ def test_type_from_flag_value():
 )
 def test_is_bool_flag_is_correctly_set(option, expected):
     assert option.is_bool_flag is expected
+
+
+def test_flag_multiple_no_default(runner):
+    @click.command()
+    @click.option("--version", "-V", is_flag=True, multiple=True)
+    def cli(version):
+        return version
+
+    result = runner.invoke(cli, [], standalone_mode=False, catch_exceptions=False)
+    assert result.return_value == ()
+
+    result = runner.invoke(
+        cli, ["--version"], standalone_mode=False, catch_exceptions=False
+    )
+    assert result.return_value == (True,)
+
+    result = runner.invoke(cli, ["-V"], standalone_mode=False, catch_exceptions=False)
+    assert result.return_value == (True,)
+
+    result = runner.invoke(cli, ["-VVV"], standalone_mode=False, catch_exceptions=False)
+    assert result.return_value == (True, True, True)


### PR DESCRIPTION
Sets a default value (empty tuple) for flags with `multiple=True`. Adds a test case (that fails on 8.1.2) to help prevent future regression.

Fixes #2246

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
