### PR TITLE
Fix typing on command and group decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.1.3
 
 Unreleased
 
+-   Use verbose form of ``typing.Callable`` for ``@command`` and
+    ``@group``. :issue:`2255`
+
 
 Version 8.1.2
 -------------

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -149,7 +149,7 @@ def command(
 
 
 def command(
-    name: t.Union[str, t.Callable, None] = None,
+    name: t.Union[str, t.Callable[..., t.Any], None] = None,
     cls: t.Optional[t.Type[Command]] = None,
     **attrs: t.Any,
 ) -> t.Union[Command, t.Callable[..., Command]]:
@@ -182,7 +182,7 @@ def command(
         appended to the end of the list.
     """
 
-    func: t.Optional[t.Callable] = None
+    func: t.Optional[t.Callable[..., t.Any]] = None
 
     if callable(name):
         func = name
@@ -228,7 +228,7 @@ def command(
 
 @t.overload
 def group(
-    __func: t.Callable,
+    __func: t.Callable[..., t.Any],
 ) -> Group:
     ...
 
@@ -242,7 +242,7 @@ def group(
 
 
 def group(
-    name: t.Union[str, t.Callable, None] = None, **attrs: t.Any
+    name: t.Union[str, t.Callable[..., t.Any], None] = None, **attrs: t.Any
 ) -> t.Union[Group, t.Callable[[F], Group]]:
     """Creates a new :class:`Group` with a function as callback.  This
     works otherwise the same as :func:`command` just that the `cls`


### PR DESCRIPTION
This PR adds generics to the `typing.Callable` type hint inside the command and group decorators.

- fixes #2255 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
