### PR TITLE
Use t.Mapping not t.Dict for parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 8.1.4
 
 Unreleased
 
+-   Replace all ``typing.Dict`` occurrences to ``typing.MutableMapping`` for
+    parameter hints.  :issue:`2255`
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1804,7 +1804,9 @@ class Group(MultiCommand):
     def __init__(
         self,
         name: t.Optional[str] = None,
-        commands: t.Optional[t.Union[t.Mapping[str, Command], t.Sequence[Command]]] = None,
+        commands: t.Optional[
+            t.Union[t.Mapping[str, Command], t.Sequence[Command]]
+        ] = None,
         **attrs: t.Any,
     ) -> None:
         super().__init__(name, **attrs)

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -264,7 +264,7 @@ class Context:
         info_name: t.Optional[str] = None,
         obj: t.Optional[t.Any] = None,
         auto_envvar_prefix: t.Optional[str] = None,
-        default_map: t.Optional[t.Dict[str, t.Any]] = None,
+        default_map: t.Optional[t.Mapping[str, t.Any]] = None,
         terminal_width: t.Optional[int] = None,
         max_content_width: t.Optional[int] = None,
         resilient_parsing: bool = False,
@@ -862,7 +862,7 @@ class BaseCommand:
     def __init__(
         self,
         name: t.Optional[str],
-        context_settings: t.Optional[t.Dict[str, t.Any]] = None,
+        context_settings: t.Optional[t.Mapping[str, t.Any]] = None,
     ) -> None:
         #: the name the command thinks it has.  Upon registering a command
         #: on a :class:`Group` the group will default the command name
@@ -1117,7 +1117,7 @@ class BaseCommand:
 
     def _main_shell_completion(
         self,
-        ctx_args: t.Dict[str, t.Any],
+        ctx_args: t.Mapping[str, t.Any],
         prog_name: str,
         complete_var: t.Optional[str] = None,
     ) -> None:
@@ -1193,7 +1193,7 @@ class Command(BaseCommand):
     def __init__(
         self,
         name: t.Optional[str],
-        context_settings: t.Optional[t.Dict[str, t.Any]] = None,
+        context_settings: t.Optional[t.Mapping[str, t.Any]] = None,
         callback: t.Optional[t.Callable[..., t.Any]] = None,
         params: t.Optional[t.List["Parameter"]] = None,
         help: t.Optional[str] = None,
@@ -1804,7 +1804,7 @@ class Group(MultiCommand):
     def __init__(
         self,
         name: t.Optional[str] = None,
-        commands: t.Optional[t.Union[t.Dict[str, Command], t.Sequence[Command]]] = None,
+        commands: t.Optional[t.Union[t.Mapping[str, Command], t.Sequence[Command]]] = None,
         **attrs: t.Any,
     ) -> None:
         super().__init__(name, **attrs)

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -264,7 +264,7 @@ class Context:
         info_name: t.Optional[str] = None,
         obj: t.Optional[t.Any] = None,
         auto_envvar_prefix: t.Optional[str] = None,
-        default_map: t.Optional[t.Mapping[str, t.Any]] = None,
+        default_map: t.Optional[t.MutableMapping[str, t.Any]] = None,
         terminal_width: t.Optional[int] = None,
         max_content_width: t.Optional[int] = None,
         resilient_parsing: bool = False,
@@ -311,7 +311,7 @@ class Context:
         ):
             default_map = parent.default_map.get(info_name)
 
-        self.default_map: t.Optional[t.Dict[str, t.Any]] = default_map
+        self.default_map: t.Optional[t.MutableMapping[str, t.Any]] = default_map
 
         #: This flag indicates if a subcommand is going to be executed. A
         #: group callback can use this information to figure out if it's
@@ -862,7 +862,7 @@ class BaseCommand:
     def __init__(
         self,
         name: t.Optional[str],
-        context_settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        context_settings: t.Optional[t.MutableMapping[str, t.Any]] = None,
     ) -> None:
         #: the name the command thinks it has.  Upon registering a command
         #: on a :class:`Group` the group will default the command name
@@ -874,7 +874,7 @@ class BaseCommand:
             context_settings = {}
 
         #: an optional dictionary with defaults passed to the context.
-        self.context_settings: t.Dict[str, t.Any] = context_settings
+        self.context_settings: t.MutableMapping[str, t.Any] = context_settings
 
     def to_info_dict(self, ctx: Context) -> t.Dict[str, t.Any]:
         """Gather information that could be useful for a tool generating
@@ -1117,7 +1117,7 @@ class BaseCommand:
 
     def _main_shell_completion(
         self,
-        ctx_args: t.Mapping[str, t.Any],
+        ctx_args: t.MutableMapping[str, t.Any],
         prog_name: str,
         complete_var: t.Optional[str] = None,
     ) -> None:
@@ -1193,7 +1193,7 @@ class Command(BaseCommand):
     def __init__(
         self,
         name: t.Optional[str],
-        context_settings: t.Optional[t.Mapping[str, t.Any]] = None,
+        context_settings: t.Optional[t.MutableMapping[str, t.Any]] = None,
         callback: t.Optional[t.Callable[..., t.Any]] = None,
         params: t.Optional[t.List["Parameter"]] = None,
         help: t.Optional[str] = None,
@@ -1805,7 +1805,7 @@ class Group(MultiCommand):
         self,
         name: t.Optional[str] = None,
         commands: t.Optional[
-            t.Union[t.Mapping[str, Command], t.Sequence[Command]]
+            t.Union[t.MutableMapping[str, Command], t.Sequence[Command]]
         ] = None,
         **attrs: t.Any,
     ) -> None:
@@ -1817,7 +1817,7 @@ class Group(MultiCommand):
             commands = {c.name: c for c in commands if c.name is not None}
 
         #: The registered subcommands by their exported names.
-        self.commands: t.Dict[str, Command] = commands
+        self.commands: t.MutableMapping[str, Command] = commands
 
     def add_command(self, cmd: Command, name: t.Optional[str] = None) -> None:
         """Registers another :class:`Command` with this group.  If the name

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -16,7 +16,7 @@ from .utils import echo
 
 def shell_complete(
     cli: BaseCommand,
-    ctx_args: t.Dict[str, t.Any],
+    ctx_args: t.Mapping[str, t.Any],
     prog_name: str,
     complete_var: str,
     instruction: str,
@@ -214,7 +214,7 @@ class ShellComplete:
     def __init__(
         self,
         cli: BaseCommand,
-        ctx_args: t.Dict[str, t.Any],
+        ctx_args: t.Mapping[str, t.Any],
         prog_name: str,
         complete_var: str,
     ) -> None:
@@ -482,7 +482,7 @@ def _is_incomplete_option(ctx: Context, args: t.List[str], param: Parameter) -> 
 
 
 def _resolve_context(
-    cli: BaseCommand, ctx_args: t.Dict[str, t.Any], prog_name: str, args: t.List[str]
+    cli: BaseCommand, ctx_args: t.Mapping[str, t.Any], prog_name: str, args: t.List[str]
 ) -> Context:
     """Produce the context hierarchy starting with the command and
     traversing the complete arguments. This only follows the commands,

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -16,7 +16,7 @@ from .utils import echo
 
 def shell_complete(
     cli: BaseCommand,
-    ctx_args: t.Mapping[str, t.Any],
+    ctx_args: t.MutableMapping[str, t.Any],
     prog_name: str,
     complete_var: str,
     instruction: str,
@@ -214,7 +214,7 @@ class ShellComplete:
     def __init__(
         self,
         cli: BaseCommand,
-        ctx_args: t.Mapping[str, t.Any],
+        ctx_args: t.MutableMapping[str, t.Any],
         prog_name: str,
         complete_var: str,
     ) -> None:
@@ -482,7 +482,7 @@ def _is_incomplete_option(ctx: Context, args: t.List[str], param: Parameter) -> 
 
 
 def _resolve_context(
-    cli: BaseCommand, ctx_args: t.Mapping[str, t.Any], prog_name: str, args: t.List[str]
+    cli: BaseCommand, ctx_args: t.MutableMapping[str, t.Any], prog_name: str, args: t.List[str]
 ) -> Context:
     """Produce the context hierarchy starting with the command and
     traversing the complete arguments. This only follows the commands,

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -482,7 +482,10 @@ def _is_incomplete_option(ctx: Context, args: t.List[str], param: Parameter) -> 
 
 
 def _resolve_context(
-    cli: BaseCommand, ctx_args: t.MutableMapping[str, t.Any], prog_name: str, args: t.List[str]
+    cli: BaseCommand,
+    ctx_args: t.MutableMapping[str, t.Any],
+    prog_name: str,
+    args: t.List[str],
 ) -> Context:
     """Produce the context hierarchy starting with the command and
     traversing the complete arguments. This only follows the commands,


### PR DESCRIPTION
https://docs.python.org/3/library/typing.html#typing.Dict
> To annotate arguments it is preferred to use an abstract collection type such as Mapping.

This PR does almost that to fix the issue below.  I instead use `MutableMapping` here since we do mutate in some cases.  I chose to use `MutableMapping` everywhere for consistency and leaving it open for more mutation in the future.  I understand that this may not be preferred and would be happy to use `Mapping` where possible instead.

- fixes #2264

It was suggested I could follow https://github.com/pallets/click/pull/2256 as a guide for how much of this checklist applies to hint-only changes.  As such some have been skipped.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
