### PR TITLE
update types to pass `pyright --verifytypes click`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
     function. :pr:`2421`
 -   Bash version detection doesn't fail on Windows. :issue:`2461`
 -   Completion works if there is a dot (``.``) in the program name. :issue:`2166`
+-   Improve type annotations for pyright type checker. :issue:`2268`
 
 
 Version 8.1.3

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -367,7 +367,7 @@ def get_text_stderr(
 
 
 def _wrap_io_open(
-    file: t.Union[str, "os.PathLike[t.AnyStr]", int],
+    file: t.Union[str, "os.PathLike[str]", int],
     mode: str,
     encoding: t.Optional[str],
     errors: t.Optional[str],

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -7,6 +7,7 @@ from ._compat import get_text_stderr
 from .utils import echo
 
 if t.TYPE_CHECKING:
+    from .core import Command
     from .core import Context
     from .core import Parameter
 
@@ -57,7 +58,7 @@ class UsageError(ClickException):
     def __init__(self, message: str, ctx: t.Optional["Context"] = None) -> None:
         super().__init__(message)
         self.ctx = ctx
-        self.cmd = self.ctx.command if self.ctx else None
+        self.cmd: t.Optional["Command"] = self.ctx.command if self.ctx else None
 
     def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
         if file is None:
@@ -261,7 +262,7 @@ class FileError(ClickException):
             hint = _("unknown error")
 
         super().__init__(hint)
-        self.ui_filename = os.fsdecode(filename)
+        self.ui_filename: str = os.fsdecode(filename)
         self.filename = filename
 
     def format_message(self) -> str:
@@ -284,4 +285,4 @@ class Exit(RuntimeError):
     __slots__ = ("exit_code",)
 
     def __init__(self, code: int = 0) -> None:
-        self.exit_code = code
+        self.exit_code: int = code

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -168,7 +168,7 @@ class Option:
     ):
         self._short_opts = []
         self._long_opts = []
-        self.prefixes = set()
+        self.prefixes: t.Set[str] = set()
 
         for opt in opts:
             prefix, value = split_opt(opt)
@@ -194,7 +194,7 @@ class Option:
     def takes_value(self) -> bool:
         return self.action in ("store", "append")
 
-    def process(self, value: str, state: "ParsingState") -> None:
+    def process(self, value: t.Any, state: "ParsingState") -> None:
         if self.action == "store":
             state.opts[self.dest] = value  # type: ignore
         elif self.action == "store_const":
@@ -272,12 +272,12 @@ class OptionParser:
         #: If this is set to `False`, the parser will stop on the first
         #: non-option.  Click uses this to implement nested subcommands
         #: safely.
-        self.allow_interspersed_args = True
+        self.allow_interspersed_args: bool = True
         #: This tells the parser how to deal with unknown options.  By
         #: default it will error out (which is sensible), but there is a
         #: second mode where it will ignore it and continue processing
         #: after shifting all the unknown options into the resulting args.
-        self.ignore_unknown_options = False
+        self.ignore_unknown_options: bool = False
 
         if ctx is not None:
             self.allow_interspersed_args = ctx.allow_interspersed_args

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -80,9 +80,9 @@ class CompletionItem:
         help: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
-        self.value = value
-        self.type = type
-        self.help = help
+        self.value: t.Any = value
+        self.type: str = type
+        self.help: t.Optional[str] = help
         self._info = kwargs
 
     def __getattr__(self, name: str) -> t.Any:
@@ -517,6 +517,8 @@ def _resolve_context(
                 ctx = cmd.make_context(name, args, parent=ctx, resilient_parsing=True)
                 args = ctx.protected_args + ctx.args
             else:
+                sub_ctx = ctx
+
                 while args:
                     name, cmd, args = command.resolve_command(ctx, args)
 

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -183,7 +183,7 @@ class CliRunner:
         mix_stderr: bool = True,
     ) -> None:
         self.charset = charset
-        self.env = env or {}
+        self.env: t.Mapping[str, t.Optional[str]] = env or {}
         self.echo_stdin = echo_stdin
         self.mix_stderr = mix_stderr
 

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -162,7 +162,7 @@ class CompositeParamType(ParamType):
 
 class FuncParamType(ParamType):
     def __init__(self, func: t.Callable[[t.Any], t.Any]) -> None:
-        self.name = func.__name__
+        self.name: str = func.__name__
         self.func = func
 
     def to_info_dict(self) -> t.Dict[str, t.Any]:
@@ -353,7 +353,11 @@ class DateTime(ParamType):
     name = "datetime"
 
     def __init__(self, formats: t.Optional[t.Sequence[str]] = None):
-        self.formats = formats or ["%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"]
+        self.formats: t.Sequence[str] = formats or [
+            "%Y-%m-%d",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+        ]
 
     def to_info_dict(self) -> t.Dict[str, t.Any]:
         info_dict = super().to_info_dict()
@@ -662,7 +666,7 @@ class File(ParamType):
     """
 
     name = "filename"
-    envvar_list_splitter = os.path.pathsep
+    envvar_list_splitter: t.ClassVar[str] = os.path.pathsep
 
     def __init__(
         self,
@@ -780,7 +784,7 @@ class Path(ParamType):
         Added the ``allow_dash`` parameter.
     """
 
-    envvar_list_splitter = os.path.pathsep
+    envvar_list_splitter: t.ClassVar[str] = os.path.pathsep
 
     def __init__(
         self,
@@ -805,7 +809,7 @@ class Path(ParamType):
         self.type = path_type
 
         if self.file_okay and not self.dir_okay:
-            self.name = _("file")
+            self.name: str = _("file")
         elif self.dir_okay and not self.file_okay:
             self.name = _("directory")
         else:
@@ -942,7 +946,7 @@ class Tuple(CompositeParamType):
     """
 
     def __init__(self, types: t.Sequence[t.Union[t.Type[t.Any], ParamType]]) -> None:
-        self.types = [convert_type(ty) for ty in types]
+        self.types: t.Sequence[ParamType] = [convert_type(ty) for ty in types]
 
     def to_info_dict(self) -> t.Dict[str, t.Any]:
         info_dict = super().to_info_dict()


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
Fix the overwhelming majority of issues identified by `pyright`. The only remaining issues are of the form:
```
click.types.File.envvar_list_splitter
  /click/src/click/types.py:658:5 - error: Ambiguous base class override
    Type declared in base class is "str | None"
    Type inferred in child class is "str"
    Inferred child class type is missing type annotation and could be inferred differently by type checkers
```
Trying to correct this issue by adding an annotation conflicts with mypy, since mypy will then raise an error:
```
src/click/types.py:658: error: Cannot override class variable (previously declared on base class "ParamType") with instance variable  [misc]
```
I've left it so mypy remains passing.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2268

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
