### PR TITLE
Delay evaluation of type hint imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Unreleased
         unneeded. Parsing works directly without building a separate parser.
     -   ``split_arg_string`` is moved from ``parser`` to ``shell_completion``.
 
+-   Enable deferred evaluation of annotations with
+    ``from __future__ import annotations``. :pr:`2270`
+
 
 Version 8.1.7
 -------------

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -4,6 +4,8 @@ writing command line scripts fun. Unlike other modules, it's based
 around a simple API that does not come with too much magic and is
 composable.
 """
+from __future__ import annotations
+
 from .core import Argument as Argument
 from .core import Command as Command
 from .core import CommandCollection as CommandCollection

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
 import codecs
+import collections.abc as cabc
 import io
 import os
 import re
 import sys
 import typing as t
+from types import TracebackType
 from weakref import WeakKeyDictionary
 
 CYGWIN = sys.platform.startswith("cygwin")
 WIN = sys.platform.startswith("win")
-auto_wrap_for_ansi: t.Optional[t.Callable[[t.TextIO], t.TextIO]] = None
+auto_wrap_for_ansi: t.Callable[[t.TextIO], t.TextIO] | None = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
 
 def _make_text_stream(
     stream: t.BinaryIO,
-    encoding: t.Optional[str],
-    errors: t.Optional[str],
+    encoding: str | None,
+    errors: str | None,
     force_readable: bool = False,
     force_writable: bool = False,
 ) -> t.TextIO:
@@ -55,8 +57,8 @@ class _NonClosingTextIOWrapper(io.TextIOWrapper):
     def __init__(
         self,
         stream: t.BinaryIO,
-        encoding: t.Optional[str],
-        errors: t.Optional[str],
+        encoding: str | None,
+        errors: str | None,
         force_readable: bool = False,
         force_writable: bool = False,
         **extra: t.Any,
@@ -168,7 +170,7 @@ def _is_binary_writer(stream: t.IO[t.Any], default: bool = False) -> bool:
     return True
 
 
-def _find_binary_reader(stream: t.IO[t.Any]) -> t.Optional[t.BinaryIO]:
+def _find_binary_reader(stream: t.IO[t.Any]) -> t.BinaryIO | None:
     # We need to figure out if the given stream is already binary.
     # This can happen because the official docs recommend detaching
     # the streams to get binary streams.  Some code might do this, so
@@ -186,7 +188,7 @@ def _find_binary_reader(stream: t.IO[t.Any]) -> t.Optional[t.BinaryIO]:
     return None
 
 
-def _find_binary_writer(stream: t.IO[t.Any]) -> t.Optional[t.BinaryIO]:
+def _find_binary_writer(stream: t.IO[t.Any]) -> t.BinaryIO | None:
     # We need to figure out if the given stream is already binary.
     # This can happen because the official docs recommend detaching
     # the streams to get binary streams.  Some code might do this, so
@@ -213,7 +215,7 @@ def _stream_is_misconfigured(stream: t.TextIO) -> bool:
     return is_ascii_encoding(getattr(stream, "encoding", None) or "ascii")
 
 
-def _is_compat_stream_attr(stream: t.TextIO, attr: str, value: t.Optional[str]) -> bool:
+def _is_compat_stream_attr(stream: t.TextIO, attr: str, value: str | None) -> bool:
     """A stream attribute is compatible if it is equal to the
     desired value or the desired value is unset and the attribute
     has a value.
@@ -223,7 +225,7 @@ def _is_compat_stream_attr(stream: t.TextIO, attr: str, value: t.Optional[str]) 
 
 
 def _is_compatible_text_stream(
-    stream: t.TextIO, encoding: t.Optional[str], errors: t.Optional[str]
+    stream: t.TextIO, encoding: str | None, errors: str | None
 ) -> bool:
     """Check if a stream's encoding and errors attributes are
     compatible with the desired values.
@@ -235,10 +237,10 @@ def _is_compatible_text_stream(
 
 def _force_correct_text_stream(
     text_stream: t.IO[t.Any],
-    encoding: t.Optional[str],
-    errors: t.Optional[str],
+    encoding: str | None,
+    errors: str | None,
     is_binary: t.Callable[[t.IO[t.Any], bool], bool],
-    find_binary: t.Callable[[t.IO[t.Any]], t.Optional[t.BinaryIO]],
+    find_binary: t.Callable[[t.IO[t.Any]], t.BinaryIO | None],
     force_readable: bool = False,
     force_writable: bool = False,
 ) -> t.TextIO:
@@ -281,8 +283,8 @@ def _force_correct_text_stream(
 
 def _force_correct_text_reader(
     text_reader: t.IO[t.Any],
-    encoding: t.Optional[str],
-    errors: t.Optional[str],
+    encoding: str | None,
+    errors: str | None,
     force_readable: bool = False,
 ) -> t.TextIO:
     return _force_correct_text_stream(
@@ -297,8 +299,8 @@ def _force_correct_text_reader(
 
 def _force_correct_text_writer(
     text_writer: t.IO[t.Any],
-    encoding: t.Optional[str],
-    errors: t.Optional[str],
+    encoding: str | None,
+    errors: str | None,
     force_writable: bool = False,
 ) -> t.TextIO:
     return _force_correct_text_stream(
@@ -332,27 +334,21 @@ def get_binary_stderr() -> t.BinaryIO:
     return writer
 
 
-def get_text_stdin(
-    encoding: t.Optional[str] = None, errors: t.Optional[str] = None
-) -> t.TextIO:
+def get_text_stdin(encoding: str | None = None, errors: str | None = None) -> t.TextIO:
     rv = _get_windows_console_stream(sys.stdin, encoding, errors)
     if rv is not None:
         return rv
     return _force_correct_text_reader(sys.stdin, encoding, errors, force_readable=True)
 
 
-def get_text_stdout(
-    encoding: t.Optional[str] = None, errors: t.Optional[str] = None
-) -> t.TextIO:
+def get_text_stdout(encoding: str | None = None, errors: str | None = None) -> t.TextIO:
     rv = _get_windows_console_stream(sys.stdout, encoding, errors)
     if rv is not None:
         return rv
     return _force_correct_text_writer(sys.stdout, encoding, errors, force_writable=True)
 
 
-def get_text_stderr(
-    encoding: t.Optional[str] = None, errors: t.Optional[str] = None
-) -> t.TextIO:
+def get_text_stderr(encoding: str | None = None, errors: str | None = None) -> t.TextIO:
     rv = _get_windows_console_stream(sys.stderr, encoding, errors)
     if rv is not None:
         return rv
@@ -360,10 +356,10 @@ def get_text_stderr(
 
 
 def _wrap_io_open(
-    file: t.Union[str, os.PathLike[str], int],
+    file: str | os.PathLike[str] | int,
     mode: str,
-    encoding: t.Optional[str],
-    errors: t.Optional[str],
+    encoding: str | None,
+    errors: str | None,
 ) -> t.IO[t.Any]:
     """Handles not passing ``encoding`` and ``errors`` in binary mode."""
     if "b" in mode:
@@ -373,12 +369,12 @@ def _wrap_io_open(
 
 
 def open_stream(
-    filename: t.Union[str, os.PathLike[str]],
+    filename: str | os.PathLike[str],
     mode: str = "r",
-    encoding: t.Optional[str] = None,
-    errors: t.Optional[str] = "strict",
+    encoding: str | None = None,
+    errors: str | None = "strict",
     atomic: bool = False,
-) -> t.Tuple[t.IO[t.Any], bool]:
+) -> tuple[t.IO[t.Any], bool]:
     binary = "b" in mode
     filename = os.fspath(filename)
 
@@ -418,7 +414,7 @@ def open_stream(
     import random
 
     try:
-        perm: t.Optional[int] = os.stat(filename).st_mode
+        perm: int | None = os.stat(filename).st_mode
     except OSError:
         perm = None
 
@@ -477,7 +473,12 @@ class _AtomicFile:
     def __enter__(self) -> _AtomicFile:
         return self
 
-    def __exit__(self, exc_type: t.Optional[t.Type[BaseException]], *_: t.Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         self.close(delete=exc_type is not None)
 
     def __repr__(self) -> str:
@@ -496,7 +497,7 @@ def _is_jupyter_kernel_output(stream: t.IO[t.Any]) -> bool:
 
 
 def should_strip_ansi(
-    stream: t.Optional[t.IO[t.Any]] = None, color: t.Optional[bool] = None
+    stream: t.IO[t.Any] | None = None, color: bool | None = None
 ) -> bool:
     if color is None:
         if stream is None:
@@ -516,10 +517,10 @@ if sys.platform.startswith("win") and WIN:
 
         return locale.getpreferredencoding()
 
-    _ansi_stream_wrappers: t.MutableMapping[t.TextIO, t.TextIO] = WeakKeyDictionary()
+    _ansi_stream_wrappers: cabc.MutableMapping[t.TextIO, t.TextIO] = WeakKeyDictionary()
 
     def auto_wrap_for_ansi(  # noqa: F811
-        stream: t.TextIO, color: t.Optional[bool] = None
+        stream: t.TextIO, color: bool | None = None
     ) -> t.TextIO:
         """Support ANSI color and style codes on Windows by wrapping a
         stream with colorama.
@@ -561,8 +562,8 @@ else:
         return getattr(sys.stdin, "encoding", None) or sys.getfilesystemencoding()
 
     def _get_windows_console_stream(
-        f: t.TextIO, encoding: t.Optional[str], errors: t.Optional[str]
-    ) -> t.Optional[t.TextIO]:
+        f: t.TextIO, encoding: str | None, errors: str | None
+    ) -> t.TextIO | None:
         return None
 
 
@@ -578,12 +579,12 @@ def isatty(stream: t.IO[t.Any]) -> bool:
 
 
 def _make_cached_stream_func(
-    src_func: t.Callable[[], t.Optional[t.TextIO]],
+    src_func: t.Callable[[], t.TextIO | None],
     wrapper_func: t.Callable[[], t.TextIO],
-) -> t.Callable[[], t.Optional[t.TextIO]]:
-    cache: t.MutableMapping[t.TextIO, t.TextIO] = WeakKeyDictionary()
+) -> t.Callable[[], t.TextIO | None]:
+    cache: cabc.MutableMapping[t.TextIO, t.TextIO] = WeakKeyDictionary()
 
-    def func() -> t.Optional[t.TextIO]:
+    def func() -> t.TextIO | None:
         stream = src_func()
 
         if stream is None:
@@ -610,15 +611,13 @@ _default_text_stdout = _make_cached_stream_func(lambda: sys.stdout, get_text_std
 _default_text_stderr = _make_cached_stream_func(lambda: sys.stderr, get_text_stderr)
 
 
-binary_streams: t.Mapping[str, t.Callable[[], t.BinaryIO]] = {
+binary_streams: cabc.Mapping[str, t.Callable[[], t.BinaryIO]] = {
     "stdin": get_binary_stdin,
     "stdout": get_binary_stdout,
     "stderr": get_binary_stderr,
 }
 
-text_streams: t.Mapping[
-    str, t.Callable[[t.Optional[str], t.Optional[str]], t.TextIO]
-] = {
+text_streams: cabc.Mapping[str, t.Callable[[str | None, str | None], t.TextIO]] = {
     "stdin": get_text_stdin,
     "stdout": get_text_stdout,
     "stderr": get_text_stderr,

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 import io
 import os
@@ -358,7 +360,7 @@ def get_text_stderr(
 
 
 def _wrap_io_open(
-    file: t.Union[str, "os.PathLike[str]", int],
+    file: t.Union[str, os.PathLike[str], int],
     mode: str,
     encoding: t.Optional[str],
     errors: t.Optional[str],
@@ -371,7 +373,7 @@ def _wrap_io_open(
 
 
 def open_stream(
-    filename: "t.Union[str, os.PathLike[str]]",
+    filename: t.Union[str, os.PathLike[str]],
     mode: str = "r",
     encoding: t.Optional[str] = None,
     errors: t.Optional[str] = "strict",
@@ -472,7 +474,7 @@ class _AtomicFile:
     def __getattr__(self, name: str) -> t.Any:
         return getattr(self._f, name)
 
-    def __enter__(self) -> "_AtomicFile":
+    def __enter__(self) -> _AtomicFile:
         return self
 
     def __exit__(self, exc_type: t.Optional[t.Type[BaseException]], *_: t.Any) -> None:

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -3,6 +3,8 @@ This module contains implementations for the termui module. To keep the
 import time of Click down, some infrequently used functionality is
 placed in this module and only imported as needed.
 """
+from __future__ import annotations
+
 import contextlib
 import math
 import os
@@ -104,7 +106,7 @@ class ProgressBar(t.Generic[V]):
         self.is_hidden: bool = not isatty(self.file)
         self._last_line: t.Optional[str] = None
 
-    def __enter__(self) -> "ProgressBar[V]":
+    def __enter__(self) -> ProgressBar[V]:
         self.entered = True
         self.render_progress()
         return self

--- a/src/click/_textwrap.py
+++ b/src/click/_textwrap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 import typing as t
 from contextlib import contextmanager

--- a/src/click/_textwrap.py
+++ b/src/click/_textwrap.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import textwrap
-import typing as t
 from contextlib import contextmanager
 
 
 class TextWrapper(textwrap.TextWrapper):
     def _handle_long_word(
         self,
-        reversed_chunks: t.List[str],
-        cur_line: t.List[str],
+        reversed_chunks: list[str],
+        cur_line: list[str],
         cur_len: int,
         width: int,
     ) -> None:
@@ -25,7 +25,7 @@ class TextWrapper(textwrap.TextWrapper):
             cur_line.append(reversed_chunks.pop())
 
     @contextmanager
-    def extra_indent(self, indent: str) -> t.Iterator[None]:
+    def extra_indent(self, indent: str) -> cabc.Iterator[None]:
         old_initial_indent = self.initial_indent
         old_subsequent_indent = self.subsequent_indent
         self.initial_indent += indent

--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -6,6 +6,8 @@
 # compared to the original patches as we do not need to patch
 # the entire interpreter but just work in our little world of
 # echo and prompt.
+from __future__ import annotations
+
 import io
 import sys
 import time

--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -8,6 +8,7 @@
 # echo and prompt.
 from __future__ import annotations
 
+import collections.abc as cabc
 import io
 import sys
 import time
@@ -198,7 +199,7 @@ class ConsoleStream:
             pass
         return self.buffer.write(x)
 
-    def writelines(self, lines: t.Iterable[t.AnyStr]) -> None:
+    def writelines(self, lines: cabc.Iterable[t.AnyStr]) -> None:
         for line in lines:
             self.write(line)
 
@@ -242,7 +243,7 @@ def _get_text_stderr(buffer_stream: t.BinaryIO) -> t.TextIO:
     return t.cast(t.TextIO, ConsoleStream(text_stream, buffer_stream))
 
 
-_stream_factories: t.Mapping[int, t.Callable[[t.BinaryIO], t.TextIO]] = {
+_stream_factories: cabc.Mapping[int, t.Callable[[t.BinaryIO], t.TextIO]] = {
     0: _get_text_stdin,
     1: _get_text_stdout,
     2: _get_text_stderr,
@@ -263,8 +264,8 @@ def _is_console(f: t.TextIO) -> bool:
 
 
 def _get_windows_console_stream(
-    f: t.TextIO, encoding: t.Optional[str], errors: t.Optional[str]
-) -> t.Optional[t.TextIO]:
+    f: t.TextIO, encoding: str | None, errors: str | None
+) -> t.TextIO | None:
     if (
         get_buffer is not None
         and encoding in {"utf-16-le", None}

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import errno
 import inspect
@@ -46,8 +48,8 @@ V = t.TypeVar("V")
 
 
 def _complete_visible_commands(
-    ctx: "Context", incomplete: str
-) -> t.Iterator[t.Tuple[str, "Command"]]:
+    ctx: Context, incomplete: str
+) -> t.Iterator[t.Tuple[str, Command]]:
     """List all the subcommands of a group that start with the
     incomplete value and aren't hidden.
 
@@ -65,7 +67,7 @@ def _complete_visible_commands(
 
 
 def _check_nested_chain(
-    base_command: "Group", cmd_name: str, cmd: "Command", register: bool = False
+    base_command: Group, cmd_name: str, cmd: Command, register: bool = False
 ) -> None:
     if not base_command.chain or not isinstance(cmd, Group):
         return
@@ -90,7 +92,7 @@ def batch(iterable: t.Iterable[V], batch_size: int) -> t.List[t.Tuple[V, ...]]:
 
 @contextmanager
 def augment_usage_errors(
-    ctx: "Context", param: t.Optional["Parameter"] = None
+    ctx: Context, param: t.Optional[Parameter] = None
 ) -> t.Iterator[None]:
     """Context manager that attaches extra information to exceptions."""
     try:
@@ -108,15 +110,15 @@ def augment_usage_errors(
 
 
 def iter_params_for_processing(
-    invocation_order: t.Sequence["Parameter"],
-    declaration_order: t.Sequence["Parameter"],
-) -> t.List["Parameter"]:
+    invocation_order: t.Sequence[Parameter],
+    declaration_order: t.Sequence[Parameter],
+) -> t.List[Parameter]:
     """Given a sequence of parameters in the order as should be considered
     for processing and an iterable of parameters that exist, this returns
     a list in the correct order as they should be processed.
     """
 
-    def sort_key(item: "Parameter") -> t.Tuple[bool, float]:
+    def sort_key(item: Parameter) -> t.Tuple[bool, float]:
         try:
             idx: float = invocation_order.index(item)
         except ValueError:
@@ -255,12 +257,12 @@ class Context:
     #: The formatter class to create with :meth:`make_formatter`.
     #:
     #: .. versionadded:: 8.0
-    formatter_class: t.Type["HelpFormatter"] = HelpFormatter
+    formatter_class: t.Type[HelpFormatter] = HelpFormatter
 
     def __init__(
         self,
-        command: "Command",
-        parent: t.Optional["Context"] = None,
+        command: Command,
+        parent: t.Optional[Context] = None,
         info_name: t.Optional[str] = None,
         obj: t.Optional[t.Any] = None,
         auto_envvar_prefix: t.Optional[str] = None,
@@ -462,7 +464,7 @@ class Context:
             "auto_envvar_prefix": self.auto_envvar_prefix,
         }
 
-    def __enter__(self) -> "Context":
+    def __enter__(self) -> Context:
         self._depth += 1
         push_context(self)
         return self
@@ -479,7 +481,7 @@ class Context:
         pop_context()
 
     @contextmanager
-    def scope(self, cleanup: bool = True) -> t.Iterator["Context"]:
+    def scope(self, cleanup: bool = True) -> t.Iterator[Context]:
         """This helper method can be used with the context object to promote
         it to the current thread local (see :func:`get_current_context`).
         The default behavior of this is to invoke the cleanup functions which
@@ -627,7 +629,7 @@ class Context:
             rv = f"{' '.join(parent_command_path)} {rv}"
         return rv.lstrip()
 
-    def find_root(self) -> "Context":
+    def find_root(self) -> Context:
         """Finds the outermost context."""
         node = self
         while node.parent is not None:
@@ -636,7 +638,7 @@ class Context:
 
     def find_object(self, object_type: t.Type[V]) -> t.Optional[V]:
         """Finds the closest object of a given type."""
-        node: t.Optional["Context"] = self
+        node: t.Optional[Context] = self
 
         while node is not None:
             if isinstance(node.obj, object_type):
@@ -657,13 +659,13 @@ class Context:
 
     @t.overload
     def lookup_default(
-        self, name: str, call: "te.Literal[True]" = True
+        self, name: str, call: te.Literal[True] = True
     ) -> t.Optional[t.Any]:
         ...
 
     @t.overload
     def lookup_default(
-        self, name: str, call: "te.Literal[False]" = ...
+        self, name: str, call: te.Literal[False] = ...
     ) -> t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]]:
         ...
 
@@ -687,7 +689,7 @@ class Context:
 
         return None
 
-    def fail(self, message: str) -> "te.NoReturn":
+    def fail(self, message: str) -> te.NoReturn:
         """Aborts the execution of the program with a specific error
         message.
 
@@ -695,11 +697,11 @@ class Context:
         """
         raise UsageError(message, self)
 
-    def abort(self) -> "te.NoReturn":
+    def abort(self) -> te.NoReturn:
         """Aborts the script."""
         raise Abort()
 
-    def exit(self, code: int = 0) -> "te.NoReturn":
+    def exit(self, code: int = 0) -> te.NoReturn:
         """Exits the application with a given exit code."""
         raise Exit(code)
 
@@ -715,7 +717,7 @@ class Context:
         """
         return self.command.get_help(self)
 
-    def _make_sub_context(self, command: "Command") -> "Context":
+    def _make_sub_context(self, command: Command) -> Context:
         """Create a new context of the same type as this context, but
         for a new command.
 
@@ -726,7 +728,7 @@ class Context:
     @t.overload
     def invoke(
         __self,  # noqa: B902
-        __callback: "t.Callable[..., V]",
+        __callback: t.Callable[..., V],
         *args: t.Any,
         **kwargs: t.Any,
     ) -> V:
@@ -735,7 +737,7 @@ class Context:
     @t.overload
     def invoke(
         __self,  # noqa: B902
-        __callback: "Command",
+        __callback: Command,
         *args: t.Any,
         **kwargs: t.Any,
     ) -> t.Any:
@@ -743,7 +745,7 @@ class Context:
 
     def invoke(
         __self,  # noqa: B902
-        __callback: t.Union["Command", "t.Callable[..., V]"],
+        __callback: t.Union[Command, t.Callable[..., V]],
         *args: t.Any,
         **kwargs: t.Any,
     ) -> t.Union[t.Any, V]:
@@ -795,7 +797,7 @@ class Context:
                 return __callback(*args, **kwargs)
 
     def forward(
-        __self, __cmd: "Command", *args: t.Any, **kwargs: t.Any  # noqa: B902
+        __self, __cmd: Command, *args: t.Any, **kwargs: t.Any  # noqa: B902
     ) -> t.Any:
         """Similar to :meth:`invoke` but fills in default keyword
         arguments from the current context if the other command expects
@@ -907,7 +909,7 @@ class Command:
         name: t.Optional[str],
         context_settings: t.Optional[t.MutableMapping[str, t.Any]] = None,
         callback: t.Optional[t.Callable[..., t.Any]] = None,
-        params: t.Optional[t.List["Parameter"]] = None,
+        params: t.Optional[t.List[Parameter]] = None,
         help: t.Optional[str] = None,
         epilog: t.Optional[str] = None,
         short_help: t.Optional[str] = None,
@@ -935,7 +937,7 @@ class Command:
         #: the list of parameters for this command in the order they
         #: should show up in the help page and execute.  Eager parameters
         #: will automatically be handled before non eager ones.
-        self.params: t.List["Parameter"] = params or []
+        self.params: t.List[Parameter] = params or []
         self.help = help
         self.epilog = epilog
         self.options_metavar = options_metavar
@@ -968,7 +970,7 @@ class Command:
         self.format_usage(ctx, formatter)
         return formatter.getvalue().rstrip("\n")
 
-    def get_params(self, ctx: Context) -> t.List["Parameter"]:
+    def get_params(self, ctx: Context) -> t.List[Parameter]:
         rv = self.params
         help_option = self.get_help_option(ctx)
 
@@ -1004,14 +1006,14 @@ class Command:
             all_names.difference_update(param.secondary_opts)
         return list(all_names)
 
-    def get_help_option(self, ctx: Context) -> t.Optional["Option"]:
+    def get_help_option(self, ctx: Context) -> t.Optional[Option]:
         """Returns the help option object."""
         help_options = self.get_help_option_names(ctx)
 
         if not help_options or not self.add_help_option:
             return None
 
-        def show_help(ctx: Context, param: "Parameter", value: str) -> None:
+        def show_help(ctx: Context, param: Parameter, value: str) -> None:
             if value and not ctx.resilient_parsing:
                 echo(ctx.get_help(), color=ctx.color)
                 ctx.exit()
@@ -1186,7 +1188,7 @@ class Command:
         if self.callback is not None:
             return ctx.invoke(self.callback, **ctx.params)
 
-    def shell_complete(self, ctx: Context, incomplete: str) -> t.List["CompletionItem"]:
+    def shell_complete(self, ctx: Context, incomplete: str) -> t.List[CompletionItem]:
         """Return a list of completions for the incomplete value. Looks
         at the names of options and chained multi-commands.
 
@@ -1200,7 +1202,7 @@ class Command:
         """
         from click.shell_completion import CompletionItem
 
-        results: t.List["CompletionItem"] = []
+        results: t.List[CompletionItem] = []
 
         if incomplete and not incomplete[0].isalnum():
             for param in self.get_params(ctx):
@@ -1239,9 +1241,9 @@ class Command:
         args: t.Optional[t.Sequence[str]] = None,
         prog_name: t.Optional[str] = None,
         complete_var: t.Optional[str] = None,
-        standalone_mode: "te.Literal[True]" = True,
+        standalone_mode: t.Literal[True] = True,
         **extra: t.Any,
-    ) -> "te.NoReturn":
+    ) -> t.NoReturn:
         ...
 
     @t.overload
@@ -1470,7 +1472,7 @@ class Group(Command):
     #: custom groups.
     #:
     #: .. versionadded:: 8.0
-    group_class: t.Optional[t.Union[t.Type["Group"], t.Type[type]]] = None
+    group_class: t.Optional[t.Union[t.Type[Group], t.Type[type]]] = None
     # Literal[type] isn't valid, so use Type[type]
 
     def __init__(
@@ -1601,18 +1603,18 @@ class Group(Command):
         return decorator
 
     @t.overload
-    def group(self, __func: t.Callable[..., t.Any]) -> "Group":
+    def group(self, __func: t.Callable[..., t.Any]) -> Group:
         ...
 
     @t.overload
     def group(
         self, *args: t.Any, **kwargs: t.Any
-    ) -> t.Callable[[t.Callable[..., t.Any]], "Group"]:
+    ) -> t.Callable[[t.Callable[..., t.Any]], Group]:
         ...
 
     def group(
         self, *args: t.Any, **kwargs: t.Any
-    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], "Group"], "Group"]:
+    ) -> t.Union[t.Callable[[t.Callable[..., t.Any]], Group], Group]:
         """A shortcut decorator for declaring and attaching a group to
         the group. This takes the same arguments as :func:`group` and
         immediately registers the created group with this group by
@@ -1644,7 +1646,7 @@ class Group(Command):
             else:
                 kwargs["cls"] = self.group_class
 
-        def decorator(f: t.Callable[..., t.Any]) -> "Group":
+        def decorator(f: t.Callable[..., t.Any]) -> Group:
             cmd: Group = group(*args, **kwargs)(f)
             self.add_command(cmd)
             return cmd
@@ -1856,7 +1858,7 @@ class Group(Command):
             ctx.fail(_("No such command {name!r}.").format(name=original_cmd_name))
         return cmd_name if cmd else None, cmd, args[1:]
 
-    def shell_complete(self, ctx: Context, incomplete: str) -> t.List["CompletionItem"]:
+    def shell_complete(self, ctx: Context, incomplete: str) -> t.List[CompletionItem]:
         """Return a list of completions for the incomplete value. Looks
         at the names of options, subcommands, and chained
         multi-commands.
@@ -2031,7 +2033,7 @@ class Parameter:
         type: t.Optional[t.Union[types.ParamType, t.Any]] = None,
         required: bool = False,
         default: t.Optional[t.Union[t.Any, t.Callable[[], t.Any]]] = None,
-        callback: t.Optional[t.Callable[[Context, "Parameter", t.Any], t.Any]] = None,
+        callback: t.Optional[t.Callable[[Context, Parameter, t.Any], t.Any]] = None,
         nargs: t.Optional[int] = None,
         multiple: bool = False,
         metavar: t.Optional[str] = None,
@@ -2040,8 +2042,8 @@ class Parameter:
         envvar: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         shell_complete: t.Optional[
             t.Callable[
-                [Context, "Parameter", str],
-                t.Union[t.List["CompletionItem"], t.List[str]],
+                [Context, Parameter, str],
+                t.Union[t.List[CompletionItem], t.List[str]],
             ]
         ] = None,
     ) -> None:
@@ -2166,7 +2168,7 @@ class Parameter:
 
     @t.overload
     def get_default(
-        self, ctx: Context, call: "te.Literal[True]" = True
+        self, ctx: Context, call: te.Literal[True] = True
     ) -> t.Optional[t.Any]:
         ...
 
@@ -2362,7 +2364,7 @@ class Parameter:
         hint_list = self.opts or [self.human_readable_name]
         return " / ".join(f"'{x}'" for x in hint_list)
 
-    def shell_complete(self, ctx: Context, incomplete: str) -> t.List["CompletionItem"]:
+    def shell_complete(self, ctx: Context, incomplete: str) -> t.List[CompletionItem]:
         """Return a list of completions for the incomplete value. If a
         ``shell_complete`` function was given during init, it is used.
         Otherwise, the :attr:`type`
@@ -2781,7 +2783,7 @@ class Option(Parameter):
 
     @t.overload
     def get_default(
-        self, ctx: Context, call: "te.Literal[True]" = True
+        self, ctx: Context, call: te.Literal[True] = True
     ) -> t.Optional[t.Any]:
         ...
 
@@ -2869,7 +2871,7 @@ class Option(Parameter):
         return rv
 
     def consume_value(
-        self, ctx: Context, opts: t.Mapping[str, "Parameter"]
+        self, ctx: Context, opts: t.Mapping[str, Parameter]
     ) -> t.Tuple[t.Any, ParameterSource]:
         value, source = super().consume_value(ctx, opts)
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import typing as t
 from functools import update_wrapper
@@ -23,24 +25,24 @@ _AnyCallable = t.Callable[..., t.Any]
 FC = t.TypeVar("FC", bound=t.Union[_AnyCallable, Command])
 
 
-def pass_context(f: "t.Callable[te.Concatenate[Context, P], R]") -> "t.Callable[P, R]":
+def pass_context(f: t.Callable[te.Concatenate[Context, P], R]) -> t.Callable[P, R]:
     """Marks a callback as wanting to receive the current context
     object as first argument.
     """
 
-    def new_func(*args: "P.args", **kwargs: "P.kwargs") -> "R":
+    def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
         return f(get_current_context(), *args, **kwargs)
 
     return update_wrapper(new_func, f)
 
 
-def pass_obj(f: "t.Callable[te.Concatenate[t.Any, P], R]") -> "t.Callable[P, R]":
+def pass_obj(f: t.Callable[te.Concatenate[t.Any, P], R]) -> t.Callable[P, R]:
     """Similar to :func:`pass_context`, but only pass the object on the
     context onwards (:attr:`Context.obj`).  This is useful if that object
     represents the state of a nested system.
     """
 
-    def new_func(*args: "P.args", **kwargs: "P.kwargs") -> "R":
+    def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
         return f(get_current_context().obj, *args, **kwargs)
 
     return update_wrapper(new_func, f)
@@ -48,7 +50,7 @@ def pass_obj(f: "t.Callable[te.Concatenate[t.Any, P], R]") -> "t.Callable[P, R]"
 
 def make_pass_decorator(
     object_type: t.Type[T], ensure: bool = False
-) -> t.Callable[["t.Callable[te.Concatenate[T, P], R]"], "t.Callable[P, R]"]:
+) -> t.Callable[[t.Callable[te.Concatenate[T, P], R]], t.Callable[P, R]]:
     """Given an object type this creates a decorator that will work
     similar to :func:`pass_obj` but instead of passing the object of the
     current context, it will find the innermost context of type
@@ -71,8 +73,8 @@ def make_pass_decorator(
                    remembered on the context if it's not there yet.
     """
 
-    def decorator(f: "t.Callable[te.Concatenate[T, P], R]") -> "t.Callable[P, R]":
-        def new_func(*args: "P.args", **kwargs: "P.kwargs") -> "R":
+    def decorator(f: t.Callable[te.Concatenate[T, P], R]) -> t.Callable[P, R]:
+        def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
             ctx = get_current_context()
 
             obj: t.Optional[T]
@@ -97,7 +99,7 @@ def make_pass_decorator(
 
 def pass_meta_key(
     key: str, *, doc_description: t.Optional[str] = None
-) -> "t.Callable[[t.Callable[te.Concatenate[t.Any, P], R]], t.Callable[P, R]]":
+) -> t.Callable[[t.Callable[te.Concatenate[t.Any, P], R]], t.Callable[P, R]]:
     """Create a decorator that passes a key from
     :attr:`click.Context.meta` as the first argument to the decorated
     function.
@@ -110,8 +112,8 @@ def pass_meta_key(
     .. versionadded:: 8.0
     """
 
-    def decorator(f: "t.Callable[te.Concatenate[t.Any, P], R]") -> "t.Callable[P, R]":
-        def new_func(*args: "P.args", **kwargs: "P.kwargs") -> R:
+    def decorator(f: t.Callable[te.Concatenate[t.Any, P], R]) -> t.Callable[P, R]:
+        def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
             ctx = get_current_context()
             obj = ctx.meta[key]
             return ctx.invoke(f, obj, *args, **kwargs)

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -22,7 +22,7 @@ if t.TYPE_CHECKING:
 R = t.TypeVar("R")
 T = t.TypeVar("T")
 _AnyCallable = t.Callable[..., t.Any]
-FC = t.TypeVar("FC", bound=t.Union[_AnyCallable, Command])
+FC = t.TypeVar("FC", bound="_AnyCallable | Command")
 
 
 def pass_context(f: t.Callable[te.Concatenate[Context, P], R]) -> t.Callable[P, R]:
@@ -36,7 +36,7 @@ def pass_context(f: t.Callable[te.Concatenate[Context, P], R]) -> t.Callable[P, 
     return update_wrapper(new_func, f)
 
 
-def pass_obj(f: t.Callable[te.Concatenate[t.Any, P], R]) -> t.Callable[P, R]:
+def pass_obj(f: t.Callable[te.Concatenate[T, P], R]) -> t.Callable[P, R]:
     """Similar to :func:`pass_context`, but only pass the object on the
     context onwards (:attr:`Context.obj`).  This is useful if that object
     represents the state of a nested system.
@@ -49,7 +49,7 @@ def pass_obj(f: t.Callable[te.Concatenate[t.Any, P], R]) -> t.Callable[P, R]:
 
 
 def make_pass_decorator(
-    object_type: t.Type[T], ensure: bool = False
+    object_type: type[T], ensure: bool = False
 ) -> t.Callable[[t.Callable[te.Concatenate[T, P], R]], t.Callable[P, R]]:
     """Given an object type this creates a decorator that will work
     similar to :func:`pass_obj` but instead of passing the object of the
@@ -77,7 +77,7 @@ def make_pass_decorator(
         def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
             ctx = get_current_context()
 
-            obj: t.Optional[T]
+            obj: T | None
             if ensure:
                 obj = ctx.ensure_object(object_type)
             else:
@@ -98,8 +98,8 @@ def make_pass_decorator(
 
 
 def pass_meta_key(
-    key: str, *, doc_description: t.Optional[str] = None
-) -> t.Callable[[t.Callable[te.Concatenate[t.Any, P], R]], t.Callable[P, R]]:
+    key: str, *, doc_description: str | None = None
+) -> t.Callable[[t.Callable[te.Concatenate[T, P], R]], t.Callable[P, R]]:
     """Create a decorator that passes a key from
     :attr:`click.Context.meta` as the first argument to the decorated
     function.
@@ -112,7 +112,7 @@ def pass_meta_key(
     .. versionadded:: 8.0
     """
 
-    def decorator(f: t.Callable[te.Concatenate[t.Any, P], R]) -> t.Callable[P, R]:
+    def decorator(f: t.Callable[te.Concatenate[T, P], R]) -> t.Callable[P, R]:
         def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
             ctx = get_current_context()
             obj = ctx.meta[key]
@@ -143,8 +143,8 @@ def command(name: _AnyCallable) -> Command:
 # @command(namearg, CommandCls, ...) or @command(namearg, cls=CommandCls, ...)
 @t.overload
 def command(
-    name: t.Optional[str],
-    cls: t.Type[CmdType],
+    name: str | None,
+    cls: type[CmdType],
     **attrs: t.Any,
 ) -> t.Callable[[_AnyCallable], CmdType]:
     ...
@@ -155,7 +155,7 @@ def command(
 def command(
     name: None = None,
     *,
-    cls: t.Type[CmdType],
+    cls: type[CmdType],
     **attrs: t.Any,
 ) -> t.Callable[[_AnyCallable], CmdType]:
     ...
@@ -164,16 +164,16 @@ def command(
 # variant: with optional string name, no cls argument provided.
 @t.overload
 def command(
-    name: t.Optional[str] = ..., cls: None = None, **attrs: t.Any
+    name: str | None = ..., cls: None = None, **attrs: t.Any
 ) -> t.Callable[[_AnyCallable], Command]:
     ...
 
 
 def command(
-    name: t.Union[t.Optional[str], _AnyCallable] = None,
-    cls: t.Optional[t.Type[CmdType]] = None,
+    name: str | _AnyCallable | None = None,
+    cls: type[CmdType] | None = None,
     **attrs: t.Any,
-) -> t.Union[Command, t.Callable[[_AnyCallable], t.Union[Command, CmdType]]]:
+) -> Command | t.Callable[[_AnyCallable], Command | CmdType]:
     r"""Creates a new :class:`Command` and uses the decorated function as
     callback.  This will also automatically attach all decorated
     :func:`option`\s and :func:`argument`\s as parameters to the command.
@@ -203,7 +203,7 @@ def command(
         appended to the end of the list.
     """
 
-    func: t.Optional[t.Callable[[_AnyCallable], t.Any]] = None
+    func: t.Callable[[_AnyCallable], t.Any] | None = None
 
     if callable(name):
         func = name
@@ -212,7 +212,7 @@ def command(
         assert not attrs, "Use 'command(**kwargs)(callable)' to provide arguments."
 
     if cls is None:
-        cls = t.cast(t.Type[CmdType], Command)
+        cls = t.cast("type[CmdType]", Command)
 
     def decorator(f: _AnyCallable) -> CmdType:
         if isinstance(f, Command):
@@ -264,8 +264,8 @@ def group(name: _AnyCallable) -> Group:
 # @group(namearg, GroupCls, ...) or @group(namearg, cls=GroupCls, ...)
 @t.overload
 def group(
-    name: t.Optional[str],
-    cls: t.Type[GrpType],
+    name: str | None,
+    cls: type[GrpType],
     **attrs: t.Any,
 ) -> t.Callable[[_AnyCallable], GrpType]:
     ...
@@ -276,7 +276,7 @@ def group(
 def group(
     name: None = None,
     *,
-    cls: t.Type[GrpType],
+    cls: type[GrpType],
     **attrs: t.Any,
 ) -> t.Callable[[_AnyCallable], GrpType]:
     ...
@@ -285,16 +285,16 @@ def group(
 # variant: with optional string name, no cls argument provided.
 @t.overload
 def group(
-    name: t.Optional[str] = ..., cls: None = None, **attrs: t.Any
+    name: str | None = ..., cls: None = None, **attrs: t.Any
 ) -> t.Callable[[_AnyCallable], Group]:
     ...
 
 
 def group(
-    name: t.Union[str, _AnyCallable, None] = None,
-    cls: t.Optional[t.Type[GrpType]] = None,
+    name: str | _AnyCallable | None = None,
+    cls: type[GrpType] | None = None,
     **attrs: t.Any,
-) -> t.Union[Group, t.Callable[[_AnyCallable], t.Union[Group, GrpType]]]:
+) -> Group | t.Callable[[_AnyCallable], Group | GrpType]:
     """Creates a new :class:`Group` with a function as callback.  This
     works otherwise the same as :func:`command` just that the `cls`
     parameter is set to :class:`Group`.
@@ -303,7 +303,7 @@ def group(
         This decorator can be applied without parentheses.
     """
     if cls is None:
-        cls = t.cast(t.Type[GrpType], Group)
+        cls = t.cast("type[GrpType]", Group)
 
     if callable(name):
         return command(cls=cls, **attrs)(name)
@@ -322,7 +322,7 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
 
 
 def argument(
-    *param_decls: str, cls: t.Optional[t.Type[Argument]] = None, **attrs: t.Any
+    *param_decls: str, cls: type[Argument] | None = None, **attrs: t.Any
 ) -> t.Callable[[FC], FC]:
     """Attaches an argument to the command.  All positional arguments are
     passed as parameter declarations to :class:`Argument`; all keyword
@@ -350,7 +350,7 @@ def argument(
 
 
 def option(
-    *param_decls: str, cls: t.Optional[t.Type[Option]] = None, **attrs: t.Any
+    *param_decls: str, cls: type[Option] | None = None, **attrs: t.Any
 ) -> t.Callable[[FC], FC]:
     """Attaches an option to the command.  All positional arguments are
     passed as parameter declarations to :class:`Option`; all keyword
@@ -419,11 +419,11 @@ def password_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
 
 
 def version_option(
-    version: t.Optional[str] = None,
+    version: str | None = None,
     *param_decls: str,
-    package_name: t.Optional[str] = None,
-    prog_name: t.Optional[str] = None,
-    message: t.Optional[str] = None,
+    package_name: str | None = None,
+    prog_name: str | None = None,
+    message: str | None = None,
     **kwargs: t.Any,
 ) -> t.Callable[[FC], FC]:
     """Add a ``--version`` option which immediately prints the version

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from gettext import gettext as _
 from gettext import ngettext
@@ -55,10 +57,10 @@ class UsageError(ClickException):
 
     exit_code = 2
 
-    def __init__(self, message: str, ctx: t.Optional["Context"] = None) -> None:
+    def __init__(self, message: str, ctx: t.Optional[Context] = None) -> None:
         super().__init__(message)
         self.ctx = ctx
-        self.cmd: t.Optional["Command"] = self.ctx.command if self.ctx else None
+        self.cmd: t.Optional[Command] = self.ctx.command if self.ctx else None
 
     def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
         if file is None:
@@ -104,8 +106,8 @@ class BadParameter(UsageError):
     def __init__(
         self,
         message: str,
-        ctx: t.Optional["Context"] = None,
-        param: t.Optional["Parameter"] = None,
+        ctx: t.Optional[Context] = None,
+        param: t.Optional[Parameter] = None,
         param_hint: t.Optional[str] = None,
     ) -> None:
         super().__init__(message, ctx)
@@ -140,8 +142,8 @@ class MissingParameter(BadParameter):
     def __init__(
         self,
         message: t.Optional[str] = None,
-        ctx: t.Optional["Context"] = None,
-        param: t.Optional["Parameter"] = None,
+        ctx: t.Optional[Context] = None,
+        param: t.Optional[Parameter] = None,
         param_hint: t.Optional[str] = None,
         param_type: t.Optional[str] = None,
     ) -> None:
@@ -206,7 +208,7 @@ class NoSuchOption(UsageError):
         option_name: str,
         message: t.Optional[str] = None,
         possibilities: t.Optional[t.Sequence[str]] = None,
-        ctx: t.Optional["Context"] = None,
+        ctx: t.Optional[Context] = None,
     ) -> None:
         if message is None:
             message = _("No such option: {name}").format(name=option_name)
@@ -239,7 +241,7 @@ class BadOptionUsage(UsageError):
     """
 
     def __init__(
-        self, option_name: str, message: str, ctx: t.Optional["Context"] = None
+        self, option_name: str, message: str, ctx: t.Optional[Context] = None
     ) -> None:
         super().__init__(message, ctx)
         self.option_name = option_name

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as t
 from gettext import gettext as _
 from gettext import ngettext
@@ -14,9 +15,7 @@ if t.TYPE_CHECKING:
     from .core import Parameter
 
 
-def _join_param_hints(
-    param_hint: t.Optional[t.Union[t.Sequence[str], str]]
-) -> t.Optional[str]:
+def _join_param_hints(param_hint: cabc.Sequence[str] | str | None) -> str | None:
     if param_hint is not None and not isinstance(param_hint, str):
         return " / ".join(repr(x) for x in param_hint)
 
@@ -39,7 +38,7 @@ class ClickException(Exception):
     def __str__(self) -> str:
         return self.message
 
-    def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
+    def show(self, file: t.IO[t.Any] | None = None) -> None:
         if file is None:
             file = get_text_stderr()
 
@@ -57,12 +56,12 @@ class UsageError(ClickException):
 
     exit_code = 2
 
-    def __init__(self, message: str, ctx: t.Optional[Context] = None) -> None:
+    def __init__(self, message: str, ctx: Context | None = None) -> None:
         super().__init__(message)
         self.ctx = ctx
-        self.cmd: t.Optional[Command] = self.ctx.command if self.ctx else None
+        self.cmd: Command | None = self.ctx.command if self.ctx else None
 
-    def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
+    def show(self, file: t.IO[t.Any] | None = None) -> None:
         if file is None:
             file = get_text_stderr()
         color = None
@@ -106,9 +105,9 @@ class BadParameter(UsageError):
     def __init__(
         self,
         message: str,
-        ctx: t.Optional[Context] = None,
-        param: t.Optional[Parameter] = None,
-        param_hint: t.Optional[str] = None,
+        ctx: Context | None = None,
+        param: Parameter | None = None,
+        param_hint: str | None = None,
     ) -> None:
         super().__init__(message, ctx)
         self.param = param
@@ -141,18 +140,18 @@ class MissingParameter(BadParameter):
 
     def __init__(
         self,
-        message: t.Optional[str] = None,
-        ctx: t.Optional[Context] = None,
-        param: t.Optional[Parameter] = None,
-        param_hint: t.Optional[str] = None,
-        param_type: t.Optional[str] = None,
+        message: str | None = None,
+        ctx: Context | None = None,
+        param: Parameter | None = None,
+        param_hint: str | None = None,
+        param_type: str | None = None,
     ) -> None:
         super().__init__(message or "", ctx, param, param_hint)
         self.param_type = param_type
 
     def format_message(self) -> str:
         if self.param_hint is not None:
-            param_hint: t.Optional[str] = self.param_hint
+            param_hint: str | None = self.param_hint
         elif self.param is not None:
             param_hint = self.param.get_error_hint(self.ctx)  # type: ignore
         else:
@@ -206,9 +205,9 @@ class NoSuchOption(UsageError):
     def __init__(
         self,
         option_name: str,
-        message: t.Optional[str] = None,
-        possibilities: t.Optional[t.Sequence[str]] = None,
-        ctx: t.Optional[Context] = None,
+        message: str | None = None,
+        possibilities: cabc.Sequence[str] | None = None,
+        ctx: Context | None = None,
     ) -> None:
         if message is None:
             message = _("No such option: {name}").format(name=option_name)
@@ -241,7 +240,7 @@ class BadOptionUsage(UsageError):
     """
 
     def __init__(
-        self, option_name: str, message: str, ctx: t.Optional[Context] = None
+        self, option_name: str, message: str, ctx: Context | None = None
     ) -> None:
         super().__init__(message, ctx)
         self.option_name = option_name
@@ -259,7 +258,7 @@ class BadArgumentUsage(UsageError):
 class FileError(ClickException):
     """Raised if a file cannot be opened."""
 
-    def __init__(self, filename: str, hint: t.Optional[str] = None) -> None:
+    def __init__(self, filename: str, hint: str | None = None) -> None:
         if hint is None:
             hint = _("unknown error")
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from contextlib import contextmanager
 from gettext import gettext as _

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import typing as t
+import collections.abc as cabc
 from contextlib import contextmanager
 from gettext import gettext as _
 
@@ -8,11 +8,11 @@ from ._compat import term_len
 from .parser import _split_opt
 
 # Can force a width.  This is used by the test system
-FORCED_WIDTH: t.Optional[int] = None
+FORCED_WIDTH: int | None = None
 
 
-def measure_table(rows: t.Iterable[t.Tuple[str, str]]) -> t.Tuple[int, ...]:
-    widths: t.Dict[int, int] = {}
+def measure_table(rows: cabc.Iterable[tuple[str, str]]) -> tuple[int, ...]:
+    widths: dict[int, int] = {}
 
     for row in rows:
         for idx, col in enumerate(row):
@@ -22,8 +22,8 @@ def measure_table(rows: t.Iterable[t.Tuple[str, str]]) -> t.Tuple[int, ...]:
 
 
 def iter_rows(
-    rows: t.Iterable[t.Tuple[str, str]], col_count: int
-) -> t.Iterator[t.Tuple[str, ...]]:
+    rows: cabc.Iterable[tuple[str, str]], col_count: int
+) -> cabc.Iterator[tuple[str, ...]]:
     for row in rows:
         yield row + ("",) * (col_count - len(row))
 
@@ -65,8 +65,8 @@ def wrap_text(
     if not preserve_paragraphs:
         return wrapper.fill(text)
 
-    p: t.List[t.Tuple[int, bool, str]] = []
-    buf: t.List[str] = []
+    p: list[tuple[int, bool, str]] = []
+    buf: list[str] = []
     indent = None
 
     def _flush_par() -> None:
@@ -116,8 +116,8 @@ class HelpFormatter:
     def __init__(
         self,
         indent_increment: int = 2,
-        width: t.Optional[int] = None,
-        max_width: t.Optional[int] = None,
+        width: int | None = None,
+        max_width: int | None = None,
     ) -> None:
         import shutil
 
@@ -130,7 +130,7 @@ class HelpFormatter:
                 width = max(min(shutil.get_terminal_size().columns, max_width) - 2, 50)
         self.width = width
         self.current_indent = 0
-        self.buffer: t.List[str] = []
+        self.buffer: list[str] = []
 
     def write(self, string: str) -> None:
         """Writes a unicode string into the internal buffer."""
@@ -144,9 +144,7 @@ class HelpFormatter:
         """Decreases the indentation."""
         self.current_indent -= self.indent_increment
 
-    def write_usage(
-        self, prog: str, args: str = "", prefix: t.Optional[str] = None
-    ) -> None:
+    def write_usage(self, prog: str, args: str = "", prefix: str | None = None) -> None:
         """Writes a usage line into the buffer.
 
         :param prog: the program name.
@@ -211,7 +209,7 @@ class HelpFormatter:
 
     def write_dl(
         self,
-        rows: t.Sequence[t.Tuple[str, str]],
+        rows: cabc.Sequence[tuple[str, str]],
         col_max: int = 30,
         col_spacing: int = 2,
     ) -> None:
@@ -254,7 +252,7 @@ class HelpFormatter:
                 self.write("\n")
 
     @contextmanager
-    def section(self, name: str) -> t.Iterator[None]:
+    def section(self, name: str) -> cabc.Iterator[None]:
         """Helpful context manager that writes a paragraph, a heading,
         and the indents.
 
@@ -269,7 +267,7 @@ class HelpFormatter:
             self.dedent()
 
     @contextmanager
-    def indentation(self) -> t.Iterator[None]:
+    def indentation(self) -> cabc.Iterator[None]:
         """A context manager that increases the indentation."""
         self.indent()
         try:
@@ -282,7 +280,7 @@ class HelpFormatter:
         return "".join(self.buffer)
 
 
-def join_options(options: t.Sequence[str]) -> t.Tuple[str, bool]:
+def join_options(options: cabc.Sequence[str]) -> tuple[str, bool]:
     """Given a list of option strings this joins them in the most appropriate
     way and returns them in the form ``(formatted_string,
     any_prefix_is_slash)`` where the second item in the tuple is a flag that

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from threading import local
 
@@ -9,16 +11,16 @@ _local = local()
 
 
 @t.overload
-def get_current_context(silent: "te.Literal[False]" = False) -> "Context":
+def get_current_context(silent: te.Literal[False] = False) -> Context:
     ...
 
 
 @t.overload
-def get_current_context(silent: bool = ...) -> t.Optional["Context"]:
+def get_current_context(silent: bool = ...) -> t.Optional[Context]:
     ...
 
 
-def get_current_context(silent: bool = False) -> t.Optional["Context"]:
+def get_current_context(silent: bool = False) -> t.Optional[Context]:
     """Returns the current click context.  This can be used as a way to
     access the current context object from anywhere.  This is a more implicit
     alternative to the :func:`pass_context` decorator.  This function is
@@ -42,7 +44,7 @@ def get_current_context(silent: bool = False) -> t.Optional["Context"]:
     return None
 
 
-def push_context(ctx: "Context") -> None:
+def push_context(ctx: Context) -> None:
     """Pushes a new context to the current stack."""
     _local.__dict__.setdefault("stack", []).append(ctx)
 

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -4,23 +4,22 @@ import typing as t
 from threading import local
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
     from .core import Context
 
 _local = local()
 
 
 @t.overload
-def get_current_context(silent: te.Literal[False] = False) -> Context:
+def get_current_context(silent: t.Literal[False] = False) -> Context:
     ...
 
 
 @t.overload
-def get_current_context(silent: bool = ...) -> t.Optional[Context]:
+def get_current_context(silent: bool = ...) -> Context | None:
     ...
 
 
-def get_current_context(silent: bool = False) -> t.Optional[Context]:
+def get_current_context(silent: bool = False) -> Context | None:
     """Returns the current click context.  This can be used as a way to
     access the current context object from anywhere.  This is a more implicit
     alternative to the :func:`pass_context` decorator.  This function is
@@ -54,7 +53,7 @@ def pop_context() -> None:
     _local.stack.pop()
 
 
-def resolve_color_default(color: t.Optional[bool] = None) -> t.Optional[bool]:
+def resolve_color_default(color: bool | None = None) -> bool | None:
     """Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
     the current context.

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -23,6 +23,7 @@ Copyright 2002-2006 Python Software Foundation. All rights reserved.
 # Copyright 2002-2006 Python Software Foundation
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as t
 from collections import deque
 from gettext import gettext as _
@@ -34,7 +35,6 @@ from .exceptions import NoSuchOption
 from .exceptions import UsageError
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
     from .core import Argument as CoreArgument
     from .core import Context
     from .core import Option as CoreOption
@@ -49,8 +49,8 @@ _flag_needs_value = object()
 
 
 def _unpack_args(
-    args: t.Sequence[str], nargs_spec: t.Sequence[int]
-) -> t.Tuple[t.Sequence[t.Union[str, t.Sequence[t.Optional[str]], None]], t.List[str]]:
+    args: cabc.Sequence[str], nargs_spec: cabc.Sequence[int]
+) -> tuple[cabc.Sequence[str | cabc.Sequence[str | None] | None], list[str]]:
     """Given an iterable of arguments and an iterable of nargs specifications,
     it returns a tuple with all the unpacked arguments at the first index
     and all remaining arguments as the second.
@@ -62,10 +62,10 @@ def _unpack_args(
     """
     args = deque(args)
     nargs_spec = deque(nargs_spec)
-    rv: t.List[t.Union[str, t.Tuple[t.Optional[str], ...], None]] = []
-    spos: t.Optional[int] = None
+    rv: list[str | tuple[str | None, ...] | None] = []
+    spos: int | None = None
 
-    def _fetch(c: te.Deque[V]) -> t.Optional[V]:
+    def _fetch(c: deque[V]) -> V | None:
         try:
             if spos is None:
                 return c.popleft()
@@ -108,7 +108,7 @@ def _unpack_args(
     return tuple(rv), list(args)
 
 
-def _split_opt(opt: str) -> t.Tuple[str, str]:
+def _split_opt(opt: str) -> tuple[str, str]:
     first = opt[:1]
     if first.isalnum():
         return "", opt
@@ -117,7 +117,7 @@ def _split_opt(opt: str) -> t.Tuple[str, str]:
     return first, opt[1:]
 
 
-def _normalize_opt(opt: str, ctx: t.Optional[Context]) -> str:
+def _normalize_opt(opt: str, ctx: Context | None) -> str:
     if ctx is None or ctx.token_normalize_func is None:
         return opt
     prefix, opt = _split_opt(opt)
@@ -128,15 +128,15 @@ class _Option:
     def __init__(
         self,
         obj: CoreOption,
-        opts: t.Sequence[str],
-        dest: t.Optional[str],
-        action: t.Optional[str] = None,
+        opts: cabc.Sequence[str],
+        dest: str | None,
+        action: str | None = None,
         nargs: int = 1,
-        const: t.Optional[t.Any] = None,
+        const: t.Any | None = None,
     ):
         self._short_opts = []
         self._long_opts = []
-        self.prefixes: t.Set[str] = set()
+        self.prefixes: set[str] = set()
 
         for opt in opts:
             prefix, value = _split_opt(opt)
@@ -179,14 +179,14 @@ class _Option:
 
 
 class _Argument:
-    def __init__(self, obj: CoreArgument, dest: t.Optional[str], nargs: int = 1):
+    def __init__(self, obj: CoreArgument, dest: str | None, nargs: int = 1):
         self.dest = dest
         self.nargs = nargs
         self.obj = obj
 
     def process(
         self,
-        value: t.Union[t.Optional[str], t.Sequence[t.Optional[str]]],
+        value: str | cabc.Sequence[str | None] | None,
         state: _ParsingState,
     ) -> None:
         if self.nargs > 1:
@@ -211,11 +211,11 @@ class _Argument:
 
 
 class _ParsingState:
-    def __init__(self, rargs: t.List[str]) -> None:
-        self.opts: t.Dict[str, t.Any] = {}
-        self.largs: t.List[str] = []
+    def __init__(self, rargs: list[str]) -> None:
+        self.opts: dict[str, t.Any] = {}
+        self.largs: list[str] = []
         self.rargs = rargs
-        self.order: t.List[CoreParameter] = []
+        self.order: list[CoreParameter] = []
 
 
 class _OptionParser:
@@ -235,7 +235,7 @@ class _OptionParser:
         Will be removed in Click 9.0.
     """
 
-    def __init__(self, ctx: t.Optional[Context] = None) -> None:
+    def __init__(self, ctx: Context | None = None) -> None:
         #: The :class:`~click.Context` for this parser.  This might be
         #: `None` for some advanced use cases.
         self.ctx = ctx
@@ -254,19 +254,19 @@ class _OptionParser:
             self.allow_interspersed_args = ctx.allow_interspersed_args
             self.ignore_unknown_options = ctx.ignore_unknown_options
 
-        self._short_opt: t.Dict[str, _Option] = {}
-        self._long_opt: t.Dict[str, _Option] = {}
+        self._short_opt: dict[str, _Option] = {}
+        self._long_opt: dict[str, _Option] = {}
         self._opt_prefixes = {"-", "--"}
-        self._args: t.List[_Argument] = []
+        self._args: list[_Argument] = []
 
     def add_option(
         self,
         obj: CoreOption,
-        opts: t.Sequence[str],
-        dest: t.Optional[str],
-        action: t.Optional[str] = None,
+        opts: cabc.Sequence[str],
+        dest: str | None,
+        action: str | None = None,
         nargs: int = 1,
-        const: t.Optional[t.Any] = None,
+        const: t.Any | None = None,
     ) -> None:
         """Adds a new option named `dest` to the parser.  The destination
         is not inferred (unlike with optparse) and needs to be explicitly
@@ -284,9 +284,7 @@ class _OptionParser:
         for opt in option._long_opts:
             self._long_opt[opt] = option
 
-    def add_argument(
-        self, obj: CoreArgument, dest: t.Optional[str], nargs: int = 1
-    ) -> None:
+    def add_argument(self, obj: CoreArgument, dest: str | None, nargs: int = 1) -> None:
         """Adds a positional argument named `dest` to the parser.
 
         The `obj` can be used to identify the option in the order list
@@ -295,8 +293,8 @@ class _OptionParser:
         self._args.append(_Argument(obj, dest=dest, nargs=nargs))
 
     def parse_args(
-        self, args: t.List[str]
-    ) -> t.Tuple[t.Dict[str, t.Any], t.List[str], t.List[CoreParameter]]:
+        self, args: list[str]
+    ) -> tuple[dict[str, t.Any], list[str], list[CoreParameter]]:
         """Parses positional arguments and returns ``(values, args, order)``
         for the parsed options and arguments as well as the leftover
         arguments if there are any.  The order is a list of objects as they
@@ -360,7 +358,7 @@ class _OptionParser:
         # not a very interesting subset!
 
     def _match_long_opt(
-        self, opt: str, explicit_value: t.Optional[str], state: _ParsingState
+        self, opt: str, explicit_value: str | None, state: _ParsingState
     ) -> None:
         if opt not in self._long_opt:
             from difflib import get_close_matches

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -21,6 +21,8 @@ Copyright 2002-2006 Python Software Foundation. All rights reserved.
 # maintained by the Python Software Foundation.
 # Copyright 2001-2006 Gregory P. Ward
 # Copyright 2002-2006 Python Software Foundation
+from __future__ import annotations
+
 import typing as t
 from collections import deque
 from gettext import gettext as _
@@ -63,7 +65,7 @@ def _unpack_args(
     rv: t.List[t.Union[str, t.Tuple[t.Optional[str], ...], None]] = []
     spos: t.Optional[int] = None
 
-    def _fetch(c: "te.Deque[V]") -> t.Optional[V]:
+    def _fetch(c: te.Deque[V]) -> t.Optional[V]:
         try:
             if spos is None:
                 return c.popleft()
@@ -115,7 +117,7 @@ def _split_opt(opt: str) -> t.Tuple[str, str]:
     return first, opt[1:]
 
 
-def _normalize_opt(opt: str, ctx: t.Optional["Context"]) -> str:
+def _normalize_opt(opt: str, ctx: t.Optional[Context]) -> str:
     if ctx is None or ctx.token_normalize_func is None:
         return opt
     prefix, opt = _split_opt(opt)
@@ -125,7 +127,7 @@ def _normalize_opt(opt: str, ctx: t.Optional["Context"]) -> str:
 class _Option:
     def __init__(
         self,
-        obj: "CoreOption",
+        obj: CoreOption,
         opts: t.Sequence[str],
         dest: t.Optional[str],
         action: t.Optional[str] = None,
@@ -160,7 +162,7 @@ class _Option:
     def takes_value(self) -> bool:
         return self.action in ("store", "append")
 
-    def process(self, value: t.Any, state: "_ParsingState") -> None:
+    def process(self, value: t.Any, state: _ParsingState) -> None:
         if self.action == "store":
             state.opts[self.dest] = value  # type: ignore
         elif self.action == "store_const":
@@ -177,7 +179,7 @@ class _Option:
 
 
 class _Argument:
-    def __init__(self, obj: "CoreArgument", dest: t.Optional[str], nargs: int = 1):
+    def __init__(self, obj: CoreArgument, dest: t.Optional[str], nargs: int = 1):
         self.dest = dest
         self.nargs = nargs
         self.obj = obj
@@ -185,7 +187,7 @@ class _Argument:
     def process(
         self,
         value: t.Union[t.Optional[str], t.Sequence[t.Optional[str]]],
-        state: "_ParsingState",
+        state: _ParsingState,
     ) -> None:
         if self.nargs > 1:
             assert value is not None
@@ -213,7 +215,7 @@ class _ParsingState:
         self.opts: t.Dict[str, t.Any] = {}
         self.largs: t.List[str] = []
         self.rargs = rargs
-        self.order: t.List["CoreParameter"] = []
+        self.order: t.List[CoreParameter] = []
 
 
 class _OptionParser:
@@ -233,7 +235,7 @@ class _OptionParser:
         Will be removed in Click 9.0.
     """
 
-    def __init__(self, ctx: t.Optional["Context"] = None) -> None:
+    def __init__(self, ctx: t.Optional[Context] = None) -> None:
         #: The :class:`~click.Context` for this parser.  This might be
         #: `None` for some advanced use cases.
         self.ctx = ctx
@@ -259,7 +261,7 @@ class _OptionParser:
 
     def add_option(
         self,
-        obj: "CoreOption",
+        obj: CoreOption,
         opts: t.Sequence[str],
         dest: t.Optional[str],
         action: t.Optional[str] = None,
@@ -283,7 +285,7 @@ class _OptionParser:
             self._long_opt[opt] = option
 
     def add_argument(
-        self, obj: "CoreArgument", dest: t.Optional[str], nargs: int = 1
+        self, obj: CoreArgument, dest: t.Optional[str], nargs: int = 1
     ) -> None:
         """Adds a positional argument named `dest` to the parser.
 
@@ -294,7 +296,7 @@ class _OptionParser:
 
     def parse_args(
         self, args: t.List[str]
-    ) -> t.Tuple[t.Dict[str, t.Any], t.List[str], t.List["CoreParameter"]]:
+    ) -> t.Tuple[t.Dict[str, t.Any], t.List[str], t.List[CoreParameter]]:
         """Parses positional arguments and returns ``(values, args, order)``
         for the parsed options and arguments as well as the leftover
         arguments if there are any.  The order is a list of objects as they

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import typing as t

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import io
 import itertools
@@ -296,7 +298,7 @@ def progressbar(
     file: t.Optional[t.TextIO] = None,
     color: t.Optional[bool] = None,
     update_min_steps: int = 1,
-) -> "ProgressBar[V]":
+) -> ProgressBar[V]:
     """This function creates an iterable context manager that can be used
     to iterate over something while showing a progress bar.  It will
     either iterate over the `iterable` or `length` items (that are counted

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import io
 import os
@@ -103,7 +105,7 @@ class Result:
 
     def __init__(
         self,
-        runner: "CliRunner",
+        runner: CliRunner,
         stdout_bytes: bytes,
         stderr_bytes: t.Optional[bytes],
         return_value: t.Any,
@@ -187,7 +189,7 @@ class CliRunner:
         self.echo_stdin = echo_stdin
         self.mix_stderr = mix_stderr
 
-    def get_default_prog_name(self, cli: "Command") -> str:
+    def get_default_prog_name(self, cli: Command) -> str:
         """Given a command object it will return the default program name
         for it.  The default is the `name` attribute or ``"root"`` if not
         set.
@@ -348,7 +350,7 @@ class CliRunner:
 
     def invoke(
         self,
-        cli: "Command",
+        cli: Command,
         args: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         input: t.Optional[t.Union[str, bytes, t.IO[t.Any]]] = None,
         env: t.Optional[t.Mapping[str, t.Optional[str]]] = None,
@@ -449,7 +451,7 @@ class CliRunner:
 
     @contextlib.contextmanager
     def isolated_filesystem(
-        self, temp_dir: t.Optional[t.Union[str, "os.PathLike[str]"]] = None
+        self, temp_dir: t.Optional[t.Union[str, os.PathLike[str]]] = None
     ) -> t.Iterator[str]:
         """A context manager that creates a temporary directory and
         changes the current working directory to it. This isolates tests

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import contextlib
 import io
 import os
@@ -43,10 +44,10 @@ class EchoingStdin:
     def readline(self, n: int = -1) -> bytes:
         return self._echo(self._input.readline(n))
 
-    def readlines(self) -> t.List[bytes]:
+    def readlines(self) -> list[bytes]:
         return [self._echo(x) for x in self._input.readlines()]
 
-    def __iter__(self) -> t.Iterator[bytes]:
+    def __iter__(self) -> cabc.Iterator[bytes]:
         return iter(self._echo(x) for x in self._input)
 
     def __repr__(self) -> str:
@@ -54,7 +55,7 @@ class EchoingStdin:
 
 
 @contextlib.contextmanager
-def _pause_echo(stream: t.Optional[EchoingStdin]) -> t.Iterator[None]:
+def _pause_echo(stream: EchoingStdin | None) -> cabc.Iterator[None]:
     if stream is None:
         yield
     else:
@@ -81,11 +82,11 @@ class _NamedTextIOWrapper(io.TextIOWrapper):
 
 
 def make_input_stream(
-    input: t.Optional[t.Union[str, bytes, t.IO[t.Any]]], charset: str
+    input: str | bytes | t.IO[t.Any] | None, charset: str
 ) -> t.BinaryIO:
     # Is already an input stream.
     if hasattr(input, "read"):
-        rv = _find_binary_reader(t.cast(t.IO[t.Any], input))
+        rv = _find_binary_reader(t.cast("t.IO[t.Any]", input))
 
         if rv is not None:
             return rv
@@ -107,13 +108,12 @@ class Result:
         self,
         runner: CliRunner,
         stdout_bytes: bytes,
-        stderr_bytes: t.Optional[bytes],
+        stderr_bytes: bytes | None,
         return_value: t.Any,
         exit_code: int,
-        exception: t.Optional[BaseException],
-        exc_info: t.Optional[
-            t.Tuple[t.Type[BaseException], BaseException, TracebackType]
-        ] = None,
+        exception: BaseException | None,
+        exc_info: tuple[type[BaseException], BaseException, TracebackType]
+        | None = None,
     ):
         #: The runner that created the result
         self.runner = runner
@@ -180,12 +180,12 @@ class CliRunner:
     def __init__(
         self,
         charset: str = "utf-8",
-        env: t.Optional[t.Mapping[str, t.Optional[str]]] = None,
+        env: cabc.Mapping[str, str | None] | None = None,
         echo_stdin: bool = False,
         mix_stderr: bool = True,
     ) -> None:
         self.charset = charset
-        self.env: t.Mapping[str, t.Optional[str]] = env or {}
+        self.env: cabc.Mapping[str, str | None] = env or {}
         self.echo_stdin = echo_stdin
         self.mix_stderr = mix_stderr
 
@@ -197,8 +197,8 @@ class CliRunner:
         return cli.name or "root"
 
     def make_env(
-        self, overrides: t.Optional[t.Mapping[str, t.Optional[str]]] = None
-    ) -> t.Mapping[str, t.Optional[str]]:
+        self, overrides: cabc.Mapping[str, str | None] | None = None
+    ) -> cabc.Mapping[str, str | None]:
         """Returns the environment overrides for invoking a script."""
         rv = dict(self.env)
         if overrides:
@@ -208,10 +208,10 @@ class CliRunner:
     @contextlib.contextmanager
     def isolation(
         self,
-        input: t.Optional[t.Union[str, bytes, t.IO[t.Any]]] = None,
-        env: t.Optional[t.Mapping[str, t.Optional[str]]] = None,
+        input: str | bytes | t.IO[t.Any] | None = None,
+        env: cabc.Mapping[str, str | None] | None = None,
         color: bool = False,
-    ) -> t.Iterator[t.Tuple[io.BytesIO, t.Optional[io.BytesIO]]]:
+    ) -> cabc.Iterator[tuple[io.BytesIO, io.BytesIO | None]]:
         """A context manager that sets up the isolation for invoking of a
         command line tool.  This sets up stdin with the given input data
         and `os.environ` with the overrides from the given dictionary.
@@ -277,7 +277,7 @@ class CliRunner:
             )
 
         @_pause_echo(echo_input)  # type: ignore
-        def visible_input(prompt: t.Optional[str] = None) -> str:
+        def visible_input(prompt: str | None = None) -> str:
             sys.stdout.write(prompt or "")
             val = text_input.readline().rstrip("\r\n")
             sys.stdout.write(f"{val}\n")
@@ -285,7 +285,7 @@ class CliRunner:
             return val
 
         @_pause_echo(echo_input)  # type: ignore
-        def hidden_input(prompt: t.Optional[str] = None) -> str:
+        def hidden_input(prompt: str | None = None) -> str:
             sys.stdout.write(f"{prompt or ''}\n")
             sys.stdout.flush()
             return text_input.readline().rstrip("\r\n")
@@ -303,7 +303,7 @@ class CliRunner:
         default_color = color
 
         def should_strip_ansi(
-            stream: t.Optional[t.IO[t.Any]] = None, color: t.Optional[bool] = None
+            stream: t.IO[t.Any] | None = None, color: bool | None = None
         ) -> bool:
             if color is None:
                 return not default_color
@@ -351,9 +351,9 @@ class CliRunner:
     def invoke(
         self,
         cli: Command,
-        args: t.Optional[t.Union[str, t.Sequence[str]]] = None,
-        input: t.Optional[t.Union[str, bytes, t.IO[t.Any]]] = None,
-        env: t.Optional[t.Mapping[str, t.Optional[str]]] = None,
+        args: str | cabc.Sequence[str] | None = None,
+        input: str | bytes | t.IO[t.Any] | None = None,
+        env: cabc.Mapping[str, str | None] | None = None,
         catch_exceptions: bool = True,
         color: bool = False,
         **extra: t.Any,
@@ -395,7 +395,7 @@ class CliRunner:
         exc_info = None
         with self.isolation(input=input, env=env, color=color) as outstreams:
             return_value = None
-            exception: t.Optional[BaseException] = None
+            exception: BaseException | None = None
             exit_code = 0
 
             if isinstance(args, str):
@@ -410,7 +410,7 @@ class CliRunner:
                 return_value = cli.main(args=args or (), prog_name=prog_name, **extra)
             except SystemExit as e:
                 exc_info = sys.exc_info()
-                e_code = t.cast(t.Optional[t.Union[int, t.Any]], e.code)
+                e_code = t.cast("int | t.Any | None", e.code)
 
                 if e_code is None:
                     e_code = 0
@@ -451,8 +451,8 @@ class CliRunner:
 
     @contextlib.contextmanager
     def isolated_filesystem(
-        self, temp_dir: t.Optional[t.Union[str, os.PathLike[str]]] = None
-    ) -> t.Iterator[str]:
+        self, temp_dir: str | os.PathLike[str] | None = None
+    ) -> cabc.Iterator[str]:
         """A context manager that creates a temporary directory and
         changes the current working directory to it. This isolates tests
         that affect the contents of the CWD to prevent them from

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import stat
 import sys
@@ -76,16 +78,16 @@ class ParamType:
     def __call__(
         self,
         value: t.Any,
-        param: t.Optional["Parameter"] = None,
-        ctx: t.Optional["Context"] = None,
+        param: t.Optional[Parameter] = None,
+        ctx: t.Optional[Context] = None,
     ) -> t.Any:
         if value is not None:
             return self.convert(value, param, ctx)
 
-    def get_metavar(self, param: "Parameter") -> t.Optional[str]:
+    def get_metavar(self, param: Parameter) -> t.Optional[str]:
         """Returns the metavar default for this param if it provides one."""
 
-    def get_missing_message(self, param: "Parameter") -> t.Optional[str]:
+    def get_missing_message(self, param: Parameter) -> t.Optional[str]:
         """Optionally might return extra information about a missing
         parameter.
 
@@ -93,7 +95,7 @@ class ParamType:
         """
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         """Convert the value to the correct type. This is not called if
         the value is ``None`` (the missing value).
@@ -129,15 +131,15 @@ class ParamType:
     def fail(
         self,
         message: str,
-        param: t.Optional["Parameter"] = None,
-        ctx: t.Optional["Context"] = None,
-    ) -> "t.NoReturn":
+        param: t.Optional[Parameter] = None,
+        ctx: t.Optional[Context] = None,
+    ) -> t.NoReturn:
         """Helper method to fail with an invalid value message."""
         raise BadParameter(message, ctx=ctx, param=param)
 
     def shell_complete(
-        self, ctx: "Context", param: "Parameter", incomplete: str
-    ) -> t.List["CompletionItem"]:
+        self, ctx: Context, param: Parameter, incomplete: str
+    ) -> t.List[CompletionItem]:
         """Return a list of
         :class:`~click.shell_completion.CompletionItem` objects for the
         incomplete value. Most types do not provide completions, but
@@ -172,7 +174,7 @@ class FuncParamType(ParamType):
         return info_dict
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         try:
             return self.func(value)
@@ -189,7 +191,7 @@ class UnprocessedParamType(ParamType):
     name = "text"
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         return value
 
@@ -201,7 +203,7 @@ class StringParamType(ParamType):
     name = "text"
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         if isinstance(value, bytes):
             enc = _get_argv_encoding()
@@ -252,7 +254,7 @@ class Choice(ParamType):
         info_dict["case_sensitive"] = self.case_sensitive
         return info_dict
 
-    def get_metavar(self, param: "Parameter") -> str:
+    def get_metavar(self, param: Parameter) -> str:
         choices_str = "|".join(self.choices)
 
         # Use curly braces to indicate a required argument.
@@ -262,11 +264,11 @@ class Choice(ParamType):
         # Use square braces to indicate an option or optional argument.
         return f"[{choices_str}]"
 
-    def get_missing_message(self, param: "Parameter") -> str:
+    def get_missing_message(self, param: Parameter) -> str:
         return _("Choose from:\n\t{choices}").format(choices=",\n\t".join(self.choices))
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         # Match through normalization and case sensitivity
         # first do token_normalize_func, then lowercase
@@ -307,8 +309,8 @@ class Choice(ParamType):
         return f"Choice({list(self.choices)})"
 
     def shell_complete(
-        self, ctx: "Context", param: "Parameter", incomplete: str
-    ) -> t.List["CompletionItem"]:
+        self, ctx: Context, param: Parameter, incomplete: str
+    ) -> t.List[CompletionItem]:
         """Complete choices that start with the incomplete value.
 
         :param ctx: Invocation context for this command.
@@ -365,7 +367,7 @@ class DateTime(ParamType):
         info_dict["formats"] = self.formats
         return info_dict
 
-    def get_metavar(self, param: "Parameter") -> str:
+    def get_metavar(self, param: Parameter) -> str:
         return f"[{'|'.join(self.formats)}]"
 
     def _try_to_convert_date(self, value: t.Any, format: str) -> t.Optional[datetime]:
@@ -375,7 +377,7 @@ class DateTime(ParamType):
             return None
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         if isinstance(value, datetime):
             return value
@@ -405,7 +407,7 @@ class _NumberParamTypeBase(ParamType):
     _number_class: t.ClassVar[t.Type[t.Any]]
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         try:
             return self._number_class(value)
@@ -446,7 +448,7 @@ class _NumberRangeBase(_NumberParamTypeBase):
         return info_dict
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         import operator
 
@@ -476,7 +478,7 @@ class _NumberRangeBase(_NumberParamTypeBase):
 
         return rv
 
-    def _clamp(self, bound: float, dir: "te.Literal[1, -1]", open: bool) -> float:
+    def _clamp(self, bound: float, dir: te.Literal[1, -1], open: bool) -> float:
         """Find the valid value to clamp to bound in the given
         direction.
 
@@ -531,7 +533,7 @@ class IntRange(_NumberRangeBase, IntParamType):
     name = "integer range"
 
     def _clamp(  # type: ignore
-        self, bound: int, dir: "te.Literal[1, -1]", open: bool
+        self, bound: int, dir: te.Literal[1, -1], open: bool
     ) -> int:
         if not open:
             return bound
@@ -580,7 +582,7 @@ class FloatRange(_NumberRangeBase, FloatParamType):
         if (min_open or max_open) and clamp:
             raise TypeError("Clamping is not supported for open bounds.")
 
-    def _clamp(self, bound: float, dir: "te.Literal[1, -1]", open: bool) -> float:
+    def _clamp(self, bound: float, dir: te.Literal[1, -1], open: bool) -> float:
         if not open:
             return bound
 
@@ -594,7 +596,7 @@ class BoolParamType(ParamType):
     name = "boolean"
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         if value in {False, True}:
             return bool(value)
@@ -619,7 +621,7 @@ class UUIDParameterType(ParamType):
     name = "uuid"
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         import uuid
 
@@ -688,7 +690,7 @@ class File(ParamType):
         info_dict.update(mode=self.mode, encoding=self.encoding)
         return info_dict
 
-    def resolve_lazy_flag(self, value: "t.Union[str, os.PathLike[str]]") -> bool:
+    def resolve_lazy_flag(self, value: t.Union[str, os.PathLike[str]]) -> bool:
         if self.lazy is not None:
             return self.lazy
         if os.fspath(value) == "-":
@@ -699,9 +701,9 @@ class File(ParamType):
 
     def convert(
         self,
-        value: t.Union[str, "os.PathLike[str]", t.IO[t.Any]],
-        param: t.Optional["Parameter"],
-        ctx: t.Optional["Context"],
+        value: t.Union[str, os.PathLike[str], t.IO[t.Any]],
+        param: t.Optional[Parameter],
+        ctx: t.Optional[Context],
     ) -> t.IO[t.Any]:
         if _is_file_like(value):
             return value
@@ -741,8 +743,8 @@ class File(ParamType):
             self.fail(f"'{format_filename(value)}': {e.strerror}", param, ctx)
 
     def shell_complete(
-        self, ctx: "Context", param: "Parameter", incomplete: str
-    ) -> t.List["CompletionItem"]:
+        self, ctx: Context, param: Parameter, incomplete: str
+    ) -> t.List[CompletionItem]:
         """Return a special completion marker that tells the completion
         system to use the shell to provide file path completions.
 
@@ -757,7 +759,7 @@ class File(ParamType):
         return [CompletionItem(incomplete, type="file")]
 
 
-def _is_file_like(value: t.Any) -> "te.TypeGuard[t.IO[t.Any]]":
+def _is_file_like(value: t.Any) -> te.TypeGuard[t.IO[t.Any]]:
     return hasattr(value, "read") or hasattr(value, "write")
 
 
@@ -838,8 +840,8 @@ class Path(ParamType):
         return info_dict
 
     def coerce_path_result(
-        self, value: "t.Union[str, os.PathLike[str]]"
-    ) -> "t.Union[str, bytes, os.PathLike[str]]":
+        self, value: t.Union[str, os.PathLike[str]]
+    ) -> t.Union[str, bytes, os.PathLike[str]]:
         if self.type is not None and not isinstance(value, self.type):
             if self.type is str:
                 return os.fsdecode(value)
@@ -852,10 +854,10 @@ class Path(ParamType):
 
     def convert(
         self,
-        value: "t.Union[str, os.PathLike[str]]",
-        param: t.Optional["Parameter"],
-        ctx: t.Optional["Context"],
-    ) -> "t.Union[str, bytes, os.PathLike[str]]":
+        value: t.Union[str, os.PathLike[str]],
+        param: t.Optional[Parameter],
+        ctx: t.Optional[Context],
+    ) -> t.Union[str, bytes, os.PathLike[str]]:
         rv = value
 
         is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
@@ -924,8 +926,8 @@ class Path(ParamType):
         return self.coerce_path_result(rv)
 
     def shell_complete(
-        self, ctx: "Context", param: "Parameter", incomplete: str
-    ) -> t.List["CompletionItem"]:
+        self, ctx: Context, param: Parameter, incomplete: str
+    ) -> t.List[CompletionItem]:
         """Return a special completion marker that tells the completion
         system to use the shell to provide path completions for only
         directories or any paths.
@@ -973,7 +975,7 @@ class Tuple(CompositeParamType):
         return len(self.types)
 
     def convert(
-        self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
+        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
     ) -> t.Any:
         len_type = len(self.types)
         len_value = len(value)

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import os
 import stat
 import sys
@@ -52,9 +53,9 @@ class ParamType:
     #: whitespace splits them up.  The exception are paths and files which
     #: are split by ``os.path.pathsep`` by default (":" on Unix and ";" on
     #: Windows).
-    envvar_list_splitter: t.ClassVar[t.Optional[str]] = None
+    envvar_list_splitter: t.ClassVar[str | None] = None
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         """Gather information that could be useful for a tool generating
         user-facing documentation.
 
@@ -78,16 +79,16 @@ class ParamType:
     def __call__(
         self,
         value: t.Any,
-        param: t.Optional[Parameter] = None,
-        ctx: t.Optional[Context] = None,
+        param: Parameter | None = None,
+        ctx: Context | None = None,
     ) -> t.Any:
         if value is not None:
             return self.convert(value, param, ctx)
 
-    def get_metavar(self, param: Parameter) -> t.Optional[str]:
+    def get_metavar(self, param: Parameter) -> str | None:
         """Returns the metavar default for this param if it provides one."""
 
-    def get_missing_message(self, param: Parameter) -> t.Optional[str]:
+    def get_missing_message(self, param: Parameter) -> str | None:
         """Optionally might return extra information about a missing
         parameter.
 
@@ -95,7 +96,7 @@ class ParamType:
         """
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         """Convert the value to the correct type. This is not called if
         the value is ``None`` (the missing value).
@@ -118,7 +119,7 @@ class ParamType:
         """
         return value
 
-    def split_envvar_value(self, rv: str) -> t.Sequence[str]:
+    def split_envvar_value(self, rv: str) -> cabc.Sequence[str]:
         """Given a value from an environment variable this splits it up
         into small chunks depending on the defined envvar list splitter.
 
@@ -131,15 +132,15 @@ class ParamType:
     def fail(
         self,
         message: str,
-        param: t.Optional[Parameter] = None,
-        ctx: t.Optional[Context] = None,
+        param: Parameter | None = None,
+        ctx: Context | None = None,
     ) -> t.NoReturn:
         """Helper method to fail with an invalid value message."""
         raise BadParameter(message, ctx=ctx, param=param)
 
     def shell_complete(
         self, ctx: Context, param: Parameter, incomplete: str
-    ) -> t.List[CompletionItem]:
+    ) -> list[CompletionItem]:
         """Return a list of
         :class:`~click.shell_completion.CompletionItem` objects for the
         incomplete value. Most types do not provide completions, but
@@ -168,13 +169,13 @@ class FuncParamType(ParamType):
         self.name: str = func.__name__
         self.func = func
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict["func"] = self.func
         return info_dict
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         try:
             return self.func(value)
@@ -191,7 +192,7 @@ class UnprocessedParamType(ParamType):
     name = "text"
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         return value
 
@@ -203,7 +204,7 @@ class StringParamType(ParamType):
     name = "text"
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         if isinstance(value, bytes):
             enc = _get_argv_encoding()
@@ -244,11 +245,13 @@ class Choice(ParamType):
 
     name = "choice"
 
-    def __init__(self, choices: t.Sequence[str], case_sensitive: bool = True) -> None:
+    def __init__(
+        self, choices: cabc.Sequence[str], case_sensitive: bool = True
+    ) -> None:
         self.choices = choices
         self.case_sensitive = case_sensitive
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict["choices"] = self.choices
         info_dict["case_sensitive"] = self.case_sensitive
@@ -268,7 +271,7 @@ class Choice(ParamType):
         return _("Choose from:\n\t{choices}").format(choices=",\n\t".join(self.choices))
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         # Match through normalization and case sensitivity
         # first do token_normalize_func, then lowercase
@@ -310,7 +313,7 @@ class Choice(ParamType):
 
     def shell_complete(
         self, ctx: Context, param: Parameter, incomplete: str
-    ) -> t.List[CompletionItem]:
+    ) -> list[CompletionItem]:
         """Complete choices that start with the incomplete value.
 
         :param ctx: Invocation context for this command.
@@ -355,14 +358,14 @@ class DateTime(ParamType):
 
     name = "datetime"
 
-    def __init__(self, formats: t.Optional[t.Sequence[str]] = None):
-        self.formats: t.Sequence[str] = formats or [
+    def __init__(self, formats: cabc.Sequence[str] | None = None):
+        self.formats: cabc.Sequence[str] = formats or [
             "%Y-%m-%d",
             "%Y-%m-%dT%H:%M:%S",
             "%Y-%m-%d %H:%M:%S",
         ]
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict["formats"] = self.formats
         return info_dict
@@ -370,14 +373,14 @@ class DateTime(ParamType):
     def get_metavar(self, param: Parameter) -> str:
         return f"[{'|'.join(self.formats)}]"
 
-    def _try_to_convert_date(self, value: t.Any, format: str) -> t.Optional[datetime]:
+    def _try_to_convert_date(self, value: t.Any, format: str) -> datetime | None:
         try:
             return datetime.strptime(value, format)
         except ValueError:
             return None
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         if isinstance(value, datetime):
             return value
@@ -404,10 +407,10 @@ class DateTime(ParamType):
 
 
 class _NumberParamTypeBase(ParamType):
-    _number_class: t.ClassVar[t.Type[t.Any]]
+    _number_class: t.ClassVar[type[t.Any]]
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         try:
             return self._number_class(value)
@@ -424,8 +427,8 @@ class _NumberParamTypeBase(ParamType):
 class _NumberRangeBase(_NumberParamTypeBase):
     def __init__(
         self,
-        min: t.Optional[float] = None,
-        max: t.Optional[float] = None,
+        min: float | None = None,
+        max: float | None = None,
         min_open: bool = False,
         max_open: bool = False,
         clamp: bool = False,
@@ -436,7 +439,7 @@ class _NumberRangeBase(_NumberParamTypeBase):
         self.max_open = max_open
         self.clamp = clamp
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict.update(
             min=self.min,
@@ -448,7 +451,7 @@ class _NumberRangeBase(_NumberParamTypeBase):
         return info_dict
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         import operator
 
@@ -478,7 +481,7 @@ class _NumberRangeBase(_NumberParamTypeBase):
 
         return rv
 
-    def _clamp(self, bound: float, dir: te.Literal[1, -1], open: bool) -> float:
+    def _clamp(self, bound: float, dir: t.Literal[1, -1], open: bool) -> float:
         """Find the valid value to clamp to bound in the given
         direction.
 
@@ -533,7 +536,7 @@ class IntRange(_NumberRangeBase, IntParamType):
     name = "integer range"
 
     def _clamp(  # type: ignore
-        self, bound: int, dir: te.Literal[1, -1], open: bool
+        self, bound: int, dir: t.Literal[1, -1], open: bool
     ) -> int:
         if not open:
             return bound
@@ -569,8 +572,8 @@ class FloatRange(_NumberRangeBase, FloatParamType):
 
     def __init__(
         self,
-        min: t.Optional[float] = None,
-        max: t.Optional[float] = None,
+        min: float | None = None,
+        max: float | None = None,
         min_open: bool = False,
         max_open: bool = False,
         clamp: bool = False,
@@ -582,7 +585,7 @@ class FloatRange(_NumberRangeBase, FloatParamType):
         if (min_open or max_open) and clamp:
             raise TypeError("Clamping is not supported for open bounds.")
 
-    def _clamp(self, bound: float, dir: te.Literal[1, -1], open: bool) -> float:
+    def _clamp(self, bound: float, dir: t.Literal[1, -1], open: bool) -> float:
         if not open:
             return bound
 
@@ -596,7 +599,7 @@ class BoolParamType(ParamType):
     name = "boolean"
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         if value in {False, True}:
             return bool(value)
@@ -621,7 +624,7 @@ class UUIDParameterType(ParamType):
     name = "uuid"
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         import uuid
 
@@ -674,9 +677,9 @@ class File(ParamType):
     def __init__(
         self,
         mode: str = "r",
-        encoding: t.Optional[str] = None,
-        errors: t.Optional[str] = "strict",
-        lazy: t.Optional[bool] = None,
+        encoding: str | None = None,
+        errors: str | None = "strict",
+        lazy: bool | None = None,
         atomic: bool = False,
     ) -> None:
         self.mode = mode
@@ -685,12 +688,12 @@ class File(ParamType):
         self.lazy = lazy
         self.atomic = atomic
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict.update(mode=self.mode, encoding=self.encoding)
         return info_dict
 
-    def resolve_lazy_flag(self, value: t.Union[str, os.PathLike[str]]) -> bool:
+    def resolve_lazy_flag(self, value: str | os.PathLike[str]) -> bool:
         if self.lazy is not None:
             return self.lazy
         if os.fspath(value) == "-":
@@ -701,14 +704,14 @@ class File(ParamType):
 
     def convert(
         self,
-        value: t.Union[str, os.PathLike[str], t.IO[t.Any]],
-        param: t.Optional[Parameter],
-        ctx: t.Optional[Context],
+        value: str | os.PathLike[str] | t.IO[t.Any],
+        param: Parameter | None,
+        ctx: Context | None,
     ) -> t.IO[t.Any]:
         if _is_file_like(value):
             return value
 
-        value = t.cast("t.Union[str, os.PathLike[str]]", value)
+        value = t.cast("str | os.PathLike[str]", value)
 
         try:
             lazy = self.resolve_lazy_flag(value)
@@ -721,7 +724,7 @@ class File(ParamType):
                 if ctx is not None:
                     ctx.call_on_close(lf.close_intelligently)
 
-                return t.cast(t.IO[t.Any], lf)
+                return t.cast("t.IO[t.Any]", lf)
 
             f, should_close = open_stream(
                 value, self.mode, self.encoding, self.errors, atomic=self.atomic
@@ -744,7 +747,7 @@ class File(ParamType):
 
     def shell_complete(
         self, ctx: Context, param: Parameter, incomplete: str
-    ) -> t.List[CompletionItem]:
+    ) -> list[CompletionItem]:
         """Return a special completion marker that tells the completion
         system to use the shell to provide file path completions.
 
@@ -807,7 +810,7 @@ class Path(ParamType):
         readable: bool = True,
         resolve_path: bool = False,
         allow_dash: bool = False,
-        path_type: t.Optional[t.Type[t.Any]] = None,
+        path_type: type[t.Any] | None = None,
         executable: bool = False,
     ):
         self.exists = exists
@@ -827,7 +830,7 @@ class Path(ParamType):
         else:
             self.name = _("path")
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict.update(
             exists=self.exists,
@@ -840,8 +843,8 @@ class Path(ParamType):
         return info_dict
 
     def coerce_path_result(
-        self, value: t.Union[str, os.PathLike[str]]
-    ) -> t.Union[str, bytes, os.PathLike[str]]:
+        self, value: str | os.PathLike[str]
+    ) -> str | bytes | os.PathLike[str]:
         if self.type is not None and not isinstance(value, self.type):
             if self.type is str:
                 return os.fsdecode(value)
@@ -854,10 +857,10 @@ class Path(ParamType):
 
     def convert(
         self,
-        value: t.Union[str, os.PathLike[str]],
-        param: t.Optional[Parameter],
-        ctx: t.Optional[Context],
-    ) -> t.Union[str, bytes, os.PathLike[str]]:
+        value: str | os.PathLike[str],
+        param: Parameter | None,
+        ctx: Context | None,
+    ) -> str | bytes | os.PathLike[str]:
         rv = value
 
         is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
@@ -927,7 +930,7 @@ class Path(ParamType):
 
     def shell_complete(
         self, ctx: Context, param: Parameter, incomplete: str
-    ) -> t.List[CompletionItem]:
+    ) -> list[CompletionItem]:
         """Return a special completion marker that tells the completion
         system to use the shell to provide path completions for only
         directories or any paths.
@@ -958,10 +961,10 @@ class Tuple(CompositeParamType):
     :param types: a list of types that should be used for the tuple items.
     """
 
-    def __init__(self, types: t.Sequence[t.Union[t.Type[t.Any], ParamType]]) -> None:
-        self.types: t.Sequence[ParamType] = [convert_type(ty) for ty in types]
+    def __init__(self, types: cabc.Sequence[type[t.Any] | ParamType]) -> None:
+        self.types: cabc.Sequence[ParamType] = [convert_type(ty) for ty in types]
 
-    def to_info_dict(self) -> t.Dict[str, t.Any]:
+    def to_info_dict(self) -> dict[str, t.Any]:
         info_dict = super().to_info_dict()
         info_dict["types"] = [t.to_info_dict() for t in self.types]
         return info_dict
@@ -975,7 +978,7 @@ class Tuple(CompositeParamType):
         return len(self.types)
 
     def convert(
-        self, value: t.Any, param: t.Optional[Parameter], ctx: t.Optional[Context]
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
     ) -> t.Any:
         len_type = len(self.types)
         len_value = len(value)
@@ -994,7 +997,7 @@ class Tuple(CompositeParamType):
         return tuple(ty(x, param, ctx) for ty, x in zip(self.types, value))
 
 
-def convert_type(ty: t.Optional[t.Any], default: t.Optional[t.Any] = None) -> ParamType:
+def convert_type(ty: t.Any | None, default: t.Any | None = None) -> ParamType:
     """Find the most appropriate :class:`ParamType` for the given Python
     type. If the type isn't provided, it can be inferred from a default
     value.

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys
@@ -30,10 +32,10 @@ def _posixify(name: str) -> str:
     return "-".join(name.split()).lower()
 
 
-def safecall(func: "t.Callable[P, R]") -> "t.Callable[P, t.Optional[R]]":
+def safecall(func: t.Callable[P, R]) -> t.Callable[P, t.Optional[R]]:
     """Wraps a function so that it swallows exceptions."""
 
-    def wrapper(*args: "P.args", **kwargs: "P.kwargs") -> t.Optional[R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> t.Optional[R]:
         try:
             return func(*args, **kwargs)
         except Exception:
@@ -112,7 +114,7 @@ class LazyFile:
 
     def __init__(
         self,
-        filename: t.Union[str, "os.PathLike[str]"],
+        filename: t.Union[str, os.PathLike[str]],
         mode: str = "r",
         encoding: t.Optional[str] = None,
         errors: t.Optional[str] = "strict",
@@ -175,7 +177,7 @@ class LazyFile:
         if self.should_close:
             self.close()
 
-    def __enter__(self) -> "LazyFile":
+    def __enter__(self) -> LazyFile:
         return self
 
     def __exit__(
@@ -198,7 +200,7 @@ class KeepOpenFile:
     def __getattr__(self, name: str) -> t.Any:
         return getattr(self._file, name)
 
-    def __enter__(self) -> "KeepOpenFile":
+    def __enter__(self) -> KeepOpenFile:
         return self
 
     def __exit__(
@@ -319,7 +321,7 @@ def echo(
     file.flush()
 
 
-def get_binary_stream(name: "te.Literal['stdin', 'stdout', 'stderr']") -> t.BinaryIO:
+def get_binary_stream(name: te.Literal["stdin", "stdout", "stderr"]) -> t.BinaryIO:
     """Returns a system stream for byte processing.
 
     :param name: the name of the stream to open.  Valid names are ``'stdin'``,
@@ -332,7 +334,7 @@ def get_binary_stream(name: "te.Literal['stdin', 'stdout', 'stderr']") -> t.Bina
 
 
 def get_text_stream(
-    name: "te.Literal['stdin', 'stdout', 'stderr']",
+    name: te.Literal["stdin", "stdout", "stderr"],
     encoding: t.Optional[str] = None,
     errors: t.Optional[str] = "strict",
 ) -> t.TextIO:
@@ -402,7 +404,7 @@ def open_file(
 
 
 def format_filename(
-    filename: "t.Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]",
+    filename: t.Union[str, bytes, os.PathLike[str], os.PathLike[bytes]],
     shorten: bool = False,
 ) -> str:
     """Format a filename as a string for display. Ensures the filename can be

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import os
 import re
 import sys
@@ -32,10 +33,10 @@ def _posixify(name: str) -> str:
     return "-".join(name.split()).lower()
 
 
-def safecall(func: t.Callable[P, R]) -> t.Callable[P, t.Optional[R]]:
+def safecall(func: t.Callable[P, R]) -> t.Callable[P, R | None]:
     """Wraps a function so that it swallows exceptions."""
 
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> t.Optional[R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | None:
         try:
             return func(*args, **kwargs)
         except Exception:
@@ -114,10 +115,10 @@ class LazyFile:
 
     def __init__(
         self,
-        filename: t.Union[str, os.PathLike[str]],
+        filename: str | os.PathLike[str],
         mode: str = "r",
-        encoding: t.Optional[str] = None,
-        errors: t.Optional[str] = "strict",
+        encoding: str | None = None,
+        errors: str | None = "strict",
         atomic: bool = False,
     ):
         self.name: str = os.fspath(filename)
@@ -125,7 +126,7 @@ class LazyFile:
         self.encoding = encoding
         self.errors = errors
         self.atomic = atomic
-        self._f: t.Optional[t.IO[t.Any]]
+        self._f: t.IO[t.Any] | None
         self.should_close: bool
 
         if self.name == "-":
@@ -182,13 +183,13 @@ class LazyFile:
 
     def __exit__(
         self,
-        exc_type: t.Optional[t.Type[BaseException]],
-        exc_value: t.Optional[BaseException],
-        tb: t.Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         self.close_intelligently()
 
-    def __iter__(self) -> t.Iterator[t.AnyStr]:
+    def __iter__(self) -> cabc.Iterator[t.AnyStr]:
         self.open()
         return iter(self._f)  # type: ignore
 
@@ -205,25 +206,25 @@ class KeepOpenFile:
 
     def __exit__(
         self,
-        exc_type: t.Optional[t.Type[BaseException]],
-        exc_value: t.Optional[BaseException],
-        tb: t.Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
     ) -> None:
         pass
 
     def __repr__(self) -> str:
         return repr(self._file)
 
-    def __iter__(self) -> t.Iterator[t.AnyStr]:
+    def __iter__(self) -> cabc.Iterator[t.AnyStr]:
         return iter(self._file)
 
 
 def echo(
-    message: t.Optional[t.Any] = None,
-    file: t.Optional[t.IO[t.Any]] = None,
+    message: t.Any | None = None,
+    file: t.IO[t.Any] | None = None,
     nl: bool = True,
     err: bool = False,
-    color: t.Optional[bool] = None,
+    color: bool | None = None,
 ) -> None:
     """Print a message and newline to stdout or a file. This should be
     used instead of :func:`print` because it provides better support
@@ -276,7 +277,7 @@ def echo(
 
     # Convert non bytes/text into the native string type.
     if message is not None and not isinstance(message, (str, bytes, bytearray)):
-        out: t.Optional[t.Union[str, bytes]] = str(message)
+        out: str | bytes | None = str(message)
     else:
         out = message
 
@@ -321,7 +322,7 @@ def echo(
     file.flush()
 
 
-def get_binary_stream(name: te.Literal["stdin", "stdout", "stderr"]) -> t.BinaryIO:
+def get_binary_stream(name: t.Literal["stdin", "stdout", "stderr"]) -> t.BinaryIO:
     """Returns a system stream for byte processing.
 
     :param name: the name of the stream to open.  Valid names are ``'stdin'``,
@@ -334,9 +335,9 @@ def get_binary_stream(name: te.Literal["stdin", "stdout", "stderr"]) -> t.Binary
 
 
 def get_text_stream(
-    name: te.Literal["stdin", "stdout", "stderr"],
-    encoding: t.Optional[str] = None,
-    errors: t.Optional[str] = "strict",
+    name: t.Literal["stdin", "stdout", "stderr"],
+    encoding: str | None = None,
+    errors: str | None = "strict",
 ) -> t.TextIO:
     """Returns a system stream for text processing.  This usually returns
     a wrapped stream around a binary stream returned from
@@ -357,8 +358,8 @@ def get_text_stream(
 def open_file(
     filename: str,
     mode: str = "r",
-    encoding: t.Optional[str] = None,
-    errors: t.Optional[str] = "strict",
+    encoding: str | None = None,
+    errors: str | None = "strict",
     lazy: bool = False,
     atomic: bool = False,
 ) -> t.IO[t.Any]:
@@ -392,19 +393,19 @@ def open_file(
     """
     if lazy:
         return t.cast(
-            t.IO[t.Any], LazyFile(filename, mode, encoding, errors, atomic=atomic)
+            "t.IO[t.Any]", LazyFile(filename, mode, encoding, errors, atomic=atomic)
         )
 
     f, should_close = open_stream(filename, mode, encoding, errors, atomic=atomic)
 
     if not should_close:
-        f = t.cast(t.IO[t.Any], KeepOpenFile(f))
+        f = t.cast("t.IO[t.Any]", KeepOpenFile(f))
 
     return f
 
 
 def format_filename(
-    filename: t.Union[str, bytes, os.PathLike[str], os.PathLike[bytes]],
+    filename: str | bytes | os.PathLike[str] | os.PathLike[bytes],
     shorten: bool = False,
 ) -> str:
     """Format a filename as a string for display. Ensures the filename can be
@@ -520,7 +521,7 @@ class PacifyFlushWrapper:
 
 
 def _detect_program_name(
-    path: t.Optional[str] = None, _main: t.Optional[ModuleType] = None
+    path: str | None = None, _main: ModuleType | None = None
 ) -> str:
     """Determine the command used to run the program, for use in help
     text. If a file or entry point was executed, the file name is
@@ -575,12 +576,12 @@ def _detect_program_name(
 
 
 def _expand_args(
-    args: t.Iterable[str],
+    args: cabc.Iterable[str],
     *,
     user: bool = True,
     env: bool = True,
     glob_recursive: bool = True,
-) -> t.List[str]:
+) -> list[str]:
     """Simulate Unix shell expansion with Python functions.
 
     See :func:`glob.glob`, :func:`os.path.expanduser`, and

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -27,6 +27,7 @@ click.echo(json.dumps(rv))
 """
 
 ALLOWED_IMPORTS = {
+    "__future__",
     "weakref",
     "os",
     "struct",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -32,6 +32,7 @@ ALLOWED_IMPORTS = {
     "os",
     "struct",
     "collections",
+    "collections.abc",
     "sys",
     "contextlib",
     "functools",


### PR DESCRIPTION
This PR reduces the time at startup that is taken at import time. This is achieved by delaying the evaluation of type imports.

- https://github.com/pallets/click/issues/2267

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
