### PR TITLE
Introduce Parameter.deprecated + Command.deprecated message customization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,10 @@ Unreleased
         allows the user to search for future output of the generator when
         using less and then aborting the program using ctrl-c.
 
+-   Show deprecation warning message running ``--help`` Option
+    for ``@click.option``. :issue:`2263`
+
+
 Version 8.1.8
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,8 +79,9 @@ Unreleased
         allows the user to search for future output of the generator when
         using less and then aborting the program using ctrl-c.
 
--   Show deprecation warning message running ``--help`` Option
-    for ``@click.option``. :issue:`2263`
+-   Parameters can now be deprecated using ``deprecated=True``. These cannot be
+    required nor prompted and are highlighted in usage output. Using them
+    will result in a warning being printed. :issue:`2263` :pr:`2271`
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,8 +79,8 @@ Unreleased
         allows the user to search for future output of the generator when
         using less and then aborting the program using ctrl-c.
 
--   Parameters can now be deprecated using ``deprecated=True``. These cannot be
-    required nor prompted and are highlighted in usage output. Using them
+-   Parameters can now be deprecated using ``deprecated: bool | str``. These cannot
+    be required nor prompted and are highlighted in usage output. Using them
     will result in a warning being printed. :issue:`2263` :pr:`2271`
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,9 +79,14 @@ Unreleased
         allows the user to search for future output of the generator when
         using less and then aborting the program using ctrl-c.
 
--   Parameters can now be deprecated using ``deprecated: bool | str``. These cannot
-    be required nor prompted and are highlighted in usage output. Using them
-    will result in a warning being printed. :issue:`2263` :pr:`2271`
+-   ``deprecated: bool | str`` can now be used on options and arguments. This
+    previously was only available for ``Command``. The message can now also be
+    customised by using a ``str`` instead of a ``bool``. :issue:`2263` :pr:`2271`
+
+    -   ``Command.deprecated`` formatting in ``--help`` changed from
+        ``(Deprecated) help`` to ``help (DEPRECATED)``.
+    -   Parameters cannot be required nor prompted or an error is raised.
+    -   A warning will be printed when something deprecated is used.
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2428,6 +2428,8 @@ class Option(Parameter):
     :param help: the help string.
     :param hidden: hide this option from help outputs.
     :param attrs: Other command arguments described in :class:`Parameter`.
+    :param deprecated: issues a message indicating that
+                             the command is deprecated.
 
     .. versionchanged:: 8.2
         ``envvar`` used with ``flag_value`` will always use the ``flag_value``,
@@ -2469,6 +2471,7 @@ class Option(Parameter):
         hidden: bool = False,
         show_choices: bool = True,
         show_envvar: bool = False,
+        deprecated: bool = False,
         **attrs: t.Any,
     ) -> None:
         if help:
@@ -2486,6 +2489,9 @@ class Option(Parameter):
             prompt_text = None
         else:
             prompt_text = prompt
+
+        if deprecated:
+            help = help + "(DEPRECATED)" if help is not None else "(DEPRECATED)"
 
         self.prompt = prompt_text
         self.confirmation_prompt = confirmation_prompt

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2429,7 +2429,11 @@ class Option(Parameter):
     :param hidden: hide this option from help outputs.
     :param attrs: Other command arguments described in :class:`Parameter`.
     :param deprecated: issues a message indicating that
-                             the command is deprecated.
+                       the command is deprecated showing help
+
+    .. versionchanged:: 8.2.0
+        Show deprecation warning message running ``--help`` Option
+        for ``@click.option``. :issue:`2263`
 
     .. versionchanged:: 8.2
         ``envvar`` used with ``flag_value`` will always use the ``flag_value``,

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -275,6 +275,40 @@ def test_implicit_non_required(runner):
     assert result.output == "test\n"
 
 
+def test_deprecated_usage(runner):
+    @click.command()
+    @click.argument("f", required=False, deprecated=True)
+    def cli(f):
+        click.echo(f)
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "[F!]" in result.output
+
+
+def test_deprecated_warning(runner):
+    @click.command()
+    @click.argument(
+        "my-argument", required=False, deprecated=True, default="default argument"
+    )
+    def cli(my_argument: str):
+        click.echo(f"{my_argument}")
+
+    # defaults should not give a deprecated warning
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0, result.output
+    assert "is deprecated" not in result.output
+
+    result = runner.invoke(cli, ["hello"])
+    assert result.exit_code == 0, result.output
+    assert "argument 'MY_ARGUMENT' is deprecated" in result.output
+
+
+def test_deprecated_required(runner):
+    with pytest.raises(ValueError, match="is deprecated and still required"):
+        click.Argument(["a"], required=True, deprecated=True)
+
+
 def test_eat_options(runner):
     @click.command()
     @click.option("-f")

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -286,10 +286,11 @@ def test_deprecated_usage(runner):
     assert "[F!]" in result.output
 
 
-def test_deprecated_warning(runner):
+@pytest.mark.parametrize("deprecated", [True, "USE B INSTEAD"])
+def test_deprecated_warning(runner, deprecated):
     @click.command()
     @click.argument(
-        "my-argument", required=False, deprecated=True, default="default argument"
+        "my-argument", required=False, deprecated=deprecated, default="default argument"
     )
     def cli(my_argument: str):
         click.echo(f"{my_argument}")
@@ -302,6 +303,9 @@ def test_deprecated_warning(runner):
     result = runner.invoke(cli, ["hello"])
     assert result.exit_code == 0, result.output
     assert "argument 'MY_ARGUMENT' is deprecated" in result.output
+
+    if isinstance(deprecated, str):
+        assert deprecated in result.output
 
 
 def test_deprecated_required(runner):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -318,22 +318,30 @@ def test_unprocessed_options(runner):
 
 
 @pytest.mark.parametrize("doc", ["CLI HELP", None])
-def test_deprecated_in_help_messages(runner, doc):
-    @click.command(deprecated=True, help=doc)
+@pytest.mark.parametrize("deprecated", [True, "USE OTHER COMMAND INSTEAD"])
+def test_deprecated_in_help_messages(runner, doc, deprecated):
+    @click.command(deprecated=deprecated, help=doc)
     def cli():
         pass
 
     result = runner.invoke(cli, ["--help"])
-    assert "(Deprecated)" in result.output
+    assert "(DEPRECATED" in result.output
+
+    if isinstance(deprecated, str):
+        assert deprecated in result.output
 
 
-def test_deprecated_in_invocation(runner):
-    @click.command(deprecated=True)
+@pytest.mark.parametrize("deprecated", [True, "USE OTHER COMMAND INSTEAD"])
+def test_deprecated_in_invocation(runner, deprecated):
+    @click.command(deprecated=deprecated)
     def deprecated_cmd():
         pass
 
     result = runner.invoke(deprecated_cmd)
     assert "DeprecationWarning:" in result.output
+
+    if isinstance(deprecated, str):
+        assert deprecated in result.output
 
 
 def test_command_parse_args_collects_option_prefixes():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -33,19 +33,26 @@ def test_invalid_option(runner):
     assert "'--foo'" in message
 
 
-def test_deprecated_usage(runner):
+@pytest.mark.parametrize("deprecated", [True, "USE B INSTEAD"])
+def test_deprecated_usage(runner, deprecated):
     @click.command()
-    @click.option("--foo", default="bar", deprecated=True)
+    @click.option("--foo", default="bar", deprecated=deprecated)
     def cmd(foo):
         click.echo(foo)
 
     result = runner.invoke(cmd, ["--help"])
-    assert re.search("(DEPRECATED)", result.output)
+    assert "(DEPRECATED" in result.output
+
+    if isinstance(deprecated, str):
+        assert deprecated in result.output
 
 
-def test_deprecated_warning(runner):
+@pytest.mark.parametrize("deprecated", [True, "USE B INSTEAD"])
+def test_deprecated_warning(runner, deprecated):
     @click.command()
-    @click.option("--my-option", required=False, deprecated=True)
+    @click.option(
+        "--my-option", required=False, deprecated=deprecated, default="default option"
+    )
     def cli(my_option: str):
         click.echo(f"{my_option}")
 
@@ -57,6 +64,9 @@ def test_deprecated_warning(runner):
     result = runner.invoke(cli, ["--my-option", "hello"])
     assert result.exit_code == 0, result.output
     assert "option 'my_option' is deprecated" in result.output
+
+    if isinstance(deprecated, str):
+        assert deprecated in result.output
 
 
 def test_deprecated_required(runner):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -33,6 +33,16 @@ def test_invalid_option(runner):
     assert "'--foo'" in message
 
 
+def test_deprecated_option(runner):
+    @click.command()
+    @click.option("--foo", default="bar", deprecated=True)
+    def cmd(foo):
+        click.echo(foo)
+
+    result = runner.invoke(cmd, ["--help"])
+    assert re.search("(DEPRECATED)", result.output)
+
+
 def test_invalid_nargs(runner):
     with pytest.raises(TypeError, match="nargs=-1"):
 


### PR DESCRIPTION
Implement of #2263, Showing deprecation message with `--help` for `@click.option`

- fixes #2263 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
