### PR TITLE
Add EnumChoice type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 8.2.0
 
 Unreleased
 
+-   Add ``EnumChoice`` ``ParamType`` that can accept an ``enum.Enum`` type
+    and use its keys or values as choices that map back to the ``Enum``.
+    :issue:`605`
+
 
 Version 8.1.3
 -------------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -414,6 +414,85 @@ Choices should be unique after considering the effects of
 
 .. _option-prompting:
 
+.. _enum-choice-opts:
+
+Enum Choice Options
+--------------
+
+Similar to the :class:`Choice` type, the :class:`EnumChoice` type may
+be used to have the parameter be a choice of :class:`enum.Enum` names or values
+that may to `enum.Enum` objects when parsed.  It can be instantiated
+with an `enum.Enum` class.  The enum object corresponding to the passed name
+or value (depending on settings) will be returned.
+
+Example:
+
+.. click:example::
+
+    class MockEnum(Enum):
+        FOO = "foo"
+        BAR = "bar"
+        BAZ = "baz"
+
+    @click.command()
+    @click.option('--foo-opt',
+                  type=click.EnumChoice(MockEnum)
+    def handle_foo(foo_opt):
+        click.echo(foo_opt)
+
+What it looks like:
+
+.. click:run::
+
+    invoke(handle_foo, args=['--foo-opt=FOO'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=BAR'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=foo'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=other'])
+    println()
+    invoke(handle_foo, args=['--help'])
+
+Using the ``use_value`` parameter will cause the parser to use the enum
+values as choices instead of the names. All enum values must be unique. Example:
+
+.. click:example::
+
+    class MockEnum(Enum):
+        FOO = "foo"
+        BAR = "bar"
+        BAZ = "baz"
+
+    @click.command()
+    @click.option('--foo-opt',
+                  type=click.EnumChoice(MockEnum, use_value=True)
+    def handle_foo(foo_opt):
+        click.echo(foo_opt)
+
+What it looks like:
+
+.. click:run::
+
+    invoke(handle_foo, args=['--foo-opt=foo'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=bar'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=FOO'])
+    println()
+    invoke(handle_foo, args=['--foo-opt=other'])
+    println()
+    invoke(handle_foo, args=['--help'])
+
+Choices work with options that have ``multiple=True``. If a ``default``
+value is given with ``multiple=True``, it should be a list or tuple of
+valid choices.
+
+The ``case_sensitive`` parameter works identically to the :class:`Choice` type,
+operating whatever the choices derived from the enum are.
+
+.. versionadded:: 8.2
+
 Prompting
 ---------
 

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -52,6 +52,7 @@ from .termui import unstyle as unstyle
 from .types import BOOL as BOOL
 from .types import Choice as Choice
 from .types import DateTime as DateTime
+from .types import EnumChoice as EnumChoice
 from .types import File as File
 from .types import FLOAT as FLOAT
 from .types import FloatRange as FloatRange

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -331,20 +331,27 @@ class Choice(ParamType):
 
 
 class EnumChoice(Choice):
-    """The choice type allows a value to be checked against a fixed set
-    of supported values. All of these values have to be strings.
+    """The :class:`EnumChoice` type allows a value to be checked against either the
+    keys or the values of an :class:`~enum.Enum`.
 
-    You should only pass a list or tuple of choices. Other iterables
-    (like generators) may lead to surprising results.
+    If using :param:`use_value` is `True`, all enum values should be unique.
+    The inputted value will then be converted to the corresponding enum object.
 
-    The resulting value will always be one of the originally passed choices
-    regardless of ``case_sensitive`` or any ``ctx.token_normalize_func``
-    being specified.
+    The resulting value will be an instance of the Enum class corresponding
+    to the user's key or value passed in.
 
     See :ref:`choice-opts` for an example.
 
-    :param case_sensitive: Set to false to make choices case
-        insensitive. Defaults to true.
+    :param choices: `enum.Enum` type that will be used to create CLI choices.
+    :param case_sensitive: Set to `False` to make choices case
+        insensitive. Defaults to `True`.
+    :param use_value: Set to `True` to use enum values as choices instead
+        of enum keys. Defaults to `False`.
+
+    :raises ValueError: Raised when `use_value` is True but enum values are not
+        unique.
+
+    .. versionadded:: 8.2
     """
 
     name = "enum_choice"
@@ -357,6 +364,12 @@ class EnumChoice(Choice):
     ) -> None:
         self.use_value: bool = use_value
         if self.use_value:
+            try:
+                enum.unique(choices)
+            except ValueError as err:
+                raise ValueError(
+                    "All values in `choices` must be unique if `use_value` is `True`"
+                ) from err
             self.choice_to_enum = {str(enum.value): enum for enum in choices}
         else:
             self.choice_to_enum = {str(enum.name): enum for enum in choices}

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -373,14 +373,16 @@ class EnumChoice(Choice):
             self.choice_to_enum = {str(enum.value): enum for enum in choices}
         else:
             self.choice_to_enum = {str(enum.name): enum for enum in choices}
-        self.choices = list(self.choice_to_enum)
-        self.case_sensitive = case_sensitive
+        super().__init__(
+            choices=list(self.choice_to_enum),
+            case_sensitive=case_sensitive,
+        )
 
     def convert(
         self, value: t.Any, param: t.Optional["Parameter"], ctx: t.Optional["Context"]
     ) -> t.Any:
         normed_value = super().convert(value, param, ctx)
-        return self.choice_to_enum[normed_value]
+        return self.choice_to_enum.get(normed_value)
 
     def __repr__(self) -> str:
         return f"EnumChoice({list(self.choices)})"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -488,6 +488,29 @@ def test_enum_choice_argument_case_insensitive_values(runner):
     assert result.output == "MockEnum.foo\n"
 
 
+def test_enum_choice_argument_non_unique_values(runner):
+    class MockEnum(Enum):
+        foo = 1
+        bar = 2
+        baz = 2
+
+    with pytest.raises(ValueError):
+
+        @click.command()
+        @click.argument("method", type=click.EnumChoice(MockEnum, use_value=True))
+        def bad_cli(method):
+            click.echo(method)
+
+    @click.command()
+    @click.argument("method", type=click.EnumChoice(MockEnum, use_value=False))
+    def cli(method):
+        click.echo(method)
+
+    result = runner.invoke(cli, ["foo"])
+    assert not result.exception, "Values do not need to be unique if using enum names"
+    assert result.output == "MockEnum.foo\n"
+
+
 def test_datetime_option_default(runner):
     @click.command()
     @click.option("--start_date", type=click.DateTime())


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

* Add `EnumChoice` `ParamType` that inherits from the `Choice` type. It can take an `enum.Enum` and use it's keys or values as options that can then be mapped back to the enum itself.
* Allows enum keys or values to be used as the choices

Example Usage:
```py
    class MockEnum(Enum):
        foo = 1
        bar = 2
        baz = 3

    @click.argument("method", type=click.EnumChoice(MockEnum))
    def cli(method):
        click.echo(method)
```

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Fixes #605

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
