### PR TITLE
Docs: add references for varargs and kwargs

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1480,6 +1480,7 @@ class MultiCommand(Command):
     :param result_callback: The result callback to attach to this multi
         command. This can be set or changed later with the
         :meth:`result_callback` decorator.
+    :param attrs: Other command arguments described in :class:`Command`.
     """
 
     allow_extra_args = True
@@ -1944,6 +1945,9 @@ class CommandCollection(MultiCommand):
     commands together into one.  This is a straightforward implementation
     that accepts a list of different multi commands as sources and
     provides all the commands for each of them.
+
+    See :class:`MultiCommand` and :class:`Command` for the description of
+    ``name`` and ``attrs``.
     """
 
     def __init__(
@@ -2467,6 +2471,7 @@ class Option(Parameter):
                                context.
     :param help: the help string.
     :param hidden: hide this option from help outputs.
+    :param attrs: Other command arguments described in :class:`Parameter`.
 
     .. versionchanged:: 8.1.0
         Help text indentation is cleaned here instead of only in the
@@ -2945,7 +2950,7 @@ class Argument(Parameter):
     provide fewer features than options but can have infinite ``nargs``
     and are required by default.
 
-    All parameters are passed onwards to the parameter constructor.
+    All parameters are passed onwards to the constructor of :class:`Parameter`.
     """
 
     param_type_name = "argument"

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -336,8 +336,14 @@ def argument(*param_decls: str, **attrs: t.Any) -> _Decorator[FC]:
     This is equivalent to creating an :class:`Argument` instance manually
     and attaching it to the :attr:`Command.params` list.
 
+    For the default argument class, refer to :class:`Argument` and
+    :class:`Parameter` for descriptions of parameters.
+
     :param cls: the argument class to instantiate.  This defaults to
                 :class:`Argument`.
+    :param param_decls: Passed as positional arguments to the constructor of
+        ``cls``.
+    :param attrs: Passed as keyword arguments to the constructor of ``cls``.
     """
 
     def decorator(f: FC) -> FC:
@@ -355,8 +361,14 @@ def option(*param_decls: str, **attrs: t.Any) -> _Decorator[FC]:
     This is equivalent to creating an :class:`Option` instance manually
     and attaching it to the :attr:`Command.params` list.
 
+    For the default option class, refer to :class:`Option` and
+    :class:`Parameter` for descriptions of parameters.
+
     :param cls: the option class to instantiate.  This defaults to
                 :class:`Option`.
+    :param param_decls: Passed as positional arguments to the constructor of
+        ``cls``.
+    :param attrs: Passed as keyword arguments to the constructor of ``cls``.
     """
 
     def decorator(f: FC) -> FC:


### PR DESCRIPTION
Added clickable links to references of common classes & decorators, so that the reader can find their descriptions in 2 clicks or less.

- fixes #2280

Changed docstrings:
- `core.MultiCommand`
- `core.CommandCollection`
- `core.Option`
- `core.Argument`
- `decorators.argument`
- `decorators.option`

Preview:
- **Now**: 
![image](https://user-images.githubusercontent.com/6691643/167313389-988bcce1-a2a6-44ae-82da-de3655a3eeec.png)

- Previously:
![image](https://user-images.githubusercontent.com/6691643/167313168-0199abfb-3c29-4221-87ea-2dc3ef3e4fdb.png)

---
Checklist:

- ~~[ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~~
- ~~[ ] Add or update relevant docs, in the docs folder and in code.~~
- ~~[ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.~~
- ~~[ ] Add `.. versionchanged::` entries in any relevant code docs.~~
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
