### PR TITLE
flush when calling `clear`, use colorama on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 -   Bash version detection doesn't fail on Windows. :issue:`2461`
 -   Completion works if there is a dot (``.``) in the program name. :issue:`2166`
 -   Improve type annotations for pyright type checker. :issue:`2268`
+-   Improve responsiveness of ``click.clear()``. :issue:`2284`
 
 
 Version 8.1.3

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -1,14 +1,12 @@
 import inspect
 import io
 import itertools
-import os
 import sys
 import typing as t
 from gettext import gettext as _
 
 from ._compat import isatty
 from ._compat import strip_ansi
-from ._compat import WIN
 from .exceptions import Abort
 from .exceptions import UsageError
 from .globals import resolve_color_default
@@ -443,10 +441,9 @@ def clear() -> None:
     """
     if not isatty(sys.stdout):
         return
-    if WIN:
-        os.system("cls")
-    else:
-        sys.stdout.write("\033[2J\033[1;1H")
+
+    # ANSI escape \033[2J clears the screen, \033[1;1H moves the cursor
+    echo("\033[2J\033[1;1H", nl=False)
 
 
 def _interpret_color(


### PR DESCRIPTION
- fixes #2284