### PR TITLE
Updated termui.py adding timeout parameter to confirm prompt

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -2,9 +2,9 @@ import inspect
 import io
 import itertools
 import os
+import signal
 import sys
 import typing as t
-import signal
 from gettext import gettext as _
 
 from ._compat import isatty
@@ -263,7 +263,7 @@ def confirm(
             raise Abort() from None
         except TimeoutException:
             rv = default
-            echo('Y' if default else 'N')
+            echo("Y" if default else "N")
             signal.alarm(0)
             break
         if value in ("y", "yes"):

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -232,7 +232,7 @@ def confirm(
     class TimeoutException(Exception):
         pass
 
-    def interrupt(signum: int, frame) -> None:
+    def interrupt(signum: int, frame: t.Any) -> None:
         raise TimeoutException
 
     if not (timeout > 0 and default is not None):

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -63,7 +63,7 @@ def _build_prompt(
     default: t.Optional[t.Any] = None,
     show_choices: bool = True,
     type: t.Optional[ParamType] = None,
-    timeout_suffix: t.Optional[int] = 0,
+    timeout_suffix: int = 0,
 ) -> str:
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
@@ -232,7 +232,7 @@ def confirm(
     class TimeoutException(Exception):
         pass
 
-    def interrupt(signum, frame) -> None:
+    def interrupt(signum: int, frame) -> None:
         raise TimeoutException
 
     if not (timeout > 0 and default is not None):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -34,6 +34,7 @@ ALLOWED_IMPORTS = {
     "sys",
     "contextlib",
     "functools",
+    "signal",
     "stat",
     "re",
     "codecs",


### PR DESCRIPTION
added timeout parameter to confirm prompt
Implementation of timeout parameter in confirmation prompt as requested in [https://github.com/pallets/click/issues/1401](https://github.com/pallets/click/issues/1401)

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

typing test fails. same as in the original git repo