### PR TITLE
Allow is_flag=True, multiple=True with non-bool flag_value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Unreleased
     ``standalone_mode`` is disabled. :issue:`2380`
 -   ``@group.command`` does not fail if the group was created with a custom
     ``command_class``. :issue:`2416`
+-   Do not raise an exception when attempting to create an option with
+    ``multiple=True, is_flag=True`` if ``flag_value`` is not a ``bool``.
+    :issue:`2292`
 
 
 Version 8.1.3

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2622,8 +2622,11 @@ class Option(Parameter):
                 if self.is_flag:
                     raise TypeError("'count' is not valid with 'is_flag'.")
 
-            if self.multiple and self.is_flag:
-                raise TypeError("'multiple' is not valid with 'is_flag', use 'count'.")
+            if self.multiple and self.is_flag and isinstance(self.flag_value, bool):
+                raise TypeError(
+                    "'multiple' is not valid with 'is_flag' and a bool 'flag_value';"
+                    " use 'count' or set 'flag_value' to a non-bool value."
+                )
 
     def to_info_dict(self) -> t.Dict[str, t.Any]:
         info_dict = super().to_info_dict()


### PR DESCRIPTION
Allow creating options with is_flag=True and multiple=True if
flag_value is also set to a non-bool value.

Fixes #2292

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
