### PR TITLE
Fix help output for Shiv and PEX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 -   Completion works if there is a dot (``.``) in the program name. :issue:`2166`
 -   Improve type annotations for pyright type checker. :issue:`2268`
 -   Improve responsiveness of ``click.clear()``. :issue:`2284`
+-   Improve command name detection when using Shiv or PEX. :issue:`2332`
 
 
 Version 8.1.3

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -523,7 +523,8 @@ def _detect_program_name(
     # The value of __package__ indicates how Python was called. It may
     # not exist if a setuptools script is installed as an egg. It may be
     # set incorrectly for entry points created with pip on Windows.
-    if getattr(_main, "__package__", None) is None or (
+    # It is set to "" inside a Shiv or PEX zipapp.
+    if getattr(_main, "__package__", None) in {None, ""} or (
         os.name == "nt"
         and _main.__package__ == ""
         and not os.path.exists(path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -446,6 +446,7 @@ class MockMain:
         ("example", None, "example"),
         (str(pathlib.Path("example/__main__.py")), "example", "python -m example"),
         (str(pathlib.Path("example/cli.py")), "example", "python -m example.cli"),
+        (str(pathlib.Path("./example")), "", "example"),
     ],
 )
 def test_detect_program_name(path, main, expected):


### PR DESCRIPTION
This change ensures that "Usage" help output is correctly displayed when Click scripts are run inside Shiv or PEX zipapps, where `__package__` is set to the empty string rather than `None`.

- fixes #2332
- Problem introduced by #1609

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
