### PR TITLE
Use `t.Collection` instead of `t.Sequence` in `types.Choice`

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -241,7 +241,7 @@ class Choice(ParamType):
 
     name = "choice"
 
-    def __init__(self, choices: t.Sequence[str], case_sensitive: bool = True) -> None:
+    def __init__(self, choices: t.Collection[str], case_sensitive: bool = True) -> None:
         self.choices = choices
         self.case_sensitive = case_sensitive
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Using `typing.Collection` instead of `typing.Sequence` allows sized iterables to be used as choices. One example is when using keys of a dictionnary:

```py
@click.option("--choices", type=click.Choice(my_dict.keys()))
```

Right now, mypy is complaining about it:

```sh
error: Argument 1 to "Choice" has incompatible type "dict_keys[str, Union[str, bool]]"; expected "Sequence[str]"
```

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. (no changes)
- [x] Add or update relevant docs, in the docs folder and in code. (no changes)
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs. (no changes)
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
