### PR TITLE
improvements for fish completion function

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -161,29 +161,25 @@ compdef %(complete_func)s %(prog_name)s;
 """
 
 _SOURCE_FISH = """\
-function %(complete_func)s;
-    set -l response;
+function %(complete_func)s
+    set -l response (env %(complete_var)s=fish_complete COMP_WORDS=(commandline -cp) \
+COMP_CWORD=(commandline -t) %(prog_name)s)
 
-    for value in (env %(complete_var)s=fish_complete COMP_WORDS=(commandline -cp) \
-COMP_CWORD=(commandline -t) %(prog_name)s);
-        set response $response $value;
-    end;
+    for completion in $response
+        set -l metadata (string split "," $completion)
 
-    for completion in $response;
-        set -l metadata (string split "," $completion);
-
-        if test $metadata[1] = "dir";
-            __fish_complete_directories $metadata[2];
-        else if test $metadata[1] = "file";
-            __fish_complete_path $metadata[2];
-        else if test $metadata[1] = "plain";
-            echo $metadata[2];
-        end;
-    end;
-end;
+        if test $metadata[1] = "dir"
+            __fish_complete_directories $metadata[2]
+        else if test $metadata[1] = "file"
+            __fish_complete_path $metadata[2]
+        else if test $metadata[1] = "plain"
+            echo $metadata[2]
+        end
+    end
+end
 
 complete --no-files --command %(prog_name)s --arguments \
-"(%(complete_func)s)";
+"(%(complete_func)s)"
 """
 
 


### PR DESCRIPTION
This PR improves the auto-completion function for fish-shell.

- `for` loop not necessary, `set` variable already works as expected (simplification)
- ending lines with ; is not idiomatic (style)

Since this is not a real bug or feature request, I did not open an issue beforehand. I hope this is fine in such a case.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
    - skipped, no functional change
- [ ] Add or update relevant docs, in the docs folder and in code.
    - skipped, no functional change that needs docs
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
    - skipped, not an important change but if you also do this for small changes, I can do this of course
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
    - skipped, did not change an interface
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
    - actually tests failed, but this was also the case prior to my change, so not related
