### PR TITLE
Fix metavar for Choice options when show_choices=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Unreleased
 -   When generating a command's name from a decorated function's name, the
     suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
     :issue:`2322`
+-   Show the ``types.ParamType.name`` for ``types.Choice`` options within
+    ``--help`` message if ``show_choices=False`` is specified.
+    :issue:`2356`
 
 
 Version 8.1.8

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -259,23 +259,13 @@ class Choice(ParamType):
         return info_dict
 
     def get_metavar(self, param: Parameter) -> str:
-        # Use choice ParamTypes if choices are hidden.
         if param.param_type_name == "option" and not param.show_choices:  # type: ignore
-            _choices = [
+            choice_metavars = [
                 convert_type(type(choice)).name.upper() for choice in self.choices
             ]
+            choices_str = "|".join([*dict.fromkeys(choice_metavars)])
         else:
-            _choices = [str(i) for i in self.choices]
-
-        # Dedupe choices
-        _choices = [*dict.fromkeys(_choices)]
-
-        # Create choices_str
-        choices_str = "|".join(_choices)
-
-        # Use no braces if single choice
-        if len(_choices) < 2:
-            return choices_str
+            choices_str = "|".join([str(i) for i in self.choices])
 
         # Use curly braces to indicate a required argument.
         if param.required and param.param_type_name == "argument":

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -260,9 +260,10 @@ class Choice(ParamType):
 
     def get_metavar(self, param: Parameter) -> str:
         if param.param_type_name == "option" and not param.show_choices:
-            choices_str = "|".join(
-                {convert_type(type(choice)).name.upper() for choice in self.choices}
-            )
+            choice_metavars = [
+                convert_type(type(choice)).name.upper() for choice in self.choices
+            ]
+            choices_str = "|".join([*dict.fromkeys(choice_metavars)])
         else:
             choices_str = "|".join([str(i) for i in self.choices])
 

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -259,7 +259,12 @@ class Choice(ParamType):
         return info_dict
 
     def get_metavar(self, param: Parameter) -> str:
-        choices_str = "|".join(self.choices)
+        if param.param_type_name == "option" and not param.show_choices:
+            choices_str = "|".join(
+                {convert_type(type(choice)).name.upper() for choice in self.choices}
+            )
+        else:
+            choices_str = "|".join([str(i) for i in self.choices])
 
         # Use curly braces to indicate a required argument.
         if param.required and param.param_type_name == "argument":

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -259,13 +259,23 @@ class Choice(ParamType):
         return info_dict
 
     def get_metavar(self, param: Parameter) -> str:
+        # Use choice ParamTypes if choices are hidden.
         if param.param_type_name == "option" and not param.show_choices:  # type: ignore
-            choice_metavars = [
+            _choices = [
                 convert_type(type(choice)).name.upper() for choice in self.choices
             ]
-            choices_str = "|".join([*dict.fromkeys(choice_metavars)])
         else:
-            choices_str = "|".join([str(i) for i in self.choices])
+            _choices = [str(i) for i in self.choices]
+
+        # Dedupe choices
+        _choices = [*dict.fromkeys(_choices)]
+
+        # Create choices_str
+        choices_str = "|".join(_choices)
+
+        # Use no braces if single choice
+        if len(_choices) < 2:
+            return choices_str
 
         # Use curly braces to indicate a required argument.
         if param.required and param.param_type_name == "argument":

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -259,7 +259,7 @@ class Choice(ParamType):
         return info_dict
 
     def get_metavar(self, param: Parameter) -> str:
-        if param.param_type_name == "option" and not param.show_choices:
+        if param.param_type_name == "option" and not param.show_choices:  # type: ignore
             choice_metavars = [
                 convert_type(type(choice)).name.upper() for choice in self.choices
             ]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -931,10 +931,10 @@ def test_invalid_flag_combinations(runner, kwargs, message):
 @pytest.mark.parametrize(
     ("choices", "metavars"),
     [
-        pytest.param(["foo", "bar"], "TEXT", id="text choices"),
-        pytest.param([1, 2], "INTEGER", id="int choices"),
-        pytest.param([1.0, 2.0], "FLOAT", id="float choices"),
-        pytest.param([True, False], "BOOLEAN", id="bool choices"),
+        pytest.param(["foo", "bar"], "[TEXT]", id="text choices"),
+        pytest.param([1, 2], "[INTEGER]", id="int choices"),
+        pytest.param([1.0, 2.0], "[FLOAT]", id="float choices"),
+        pytest.param([True, False], "[BOOLEAN]", id="bool choices"),
         pytest.param(["foo", 1], "[TEXT|INTEGER]", id="text/int choices"),
     ],
 )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -931,10 +931,10 @@ def test_invalid_flag_combinations(runner, kwargs, message):
 @pytest.mark.parametrize(
     ("choices", "metavars"),
     [
-        pytest.param(["foo", "bar"], "[TEXT]", id="text choices"),
-        pytest.param([1, 2], "[INTEGER]", id="int choices"),
-        pytest.param([1.0, 2.0], "[FLOAT]", id="float choices"),
-        pytest.param([True, False], "[BOOLEAN]", id="bool choices"),
+        pytest.param(["foo", "bar"], "TEXT", id="text choices"),
+        pytest.param([1, 2], "INTEGER", id="int choices"),
+        pytest.param([1.0, 2.0], "FLOAT", id="float choices"),
+        pytest.param([True, False], "BOOLEAN", id="bool choices"),
         pytest.param(["foo", 1], "[TEXT|INTEGER]", id="text/int choices"),
     ],
 )


### PR DESCRIPTION
The `show_choices` parameter is intended to suppress choices from being displayed inline when `click.prompt()` is used. It's available to `click.option()` because an option can act like a prompt if the `prompt=True` parameter  is used. However, this parameter does not prevent the choices from being used to create the `Choice` metavar displayed within the `--help` message.

This change addresses this issue by creating the metavar string using the ParamTypes of the choices instead of the values themselves.

Example script:
```python
import click

@click.command()
@click.option(
    '-s', 
    '--string', 
    type=click.Choice(['hello', 'world']), 
    show_choices=False, 
    prompt=True, 
    help="This value echoed back to stdout."
)
def demoecho(string):
    click.echo(string)

if __name__ == "__main__":
    demoecho()
```
Output when `show_choices=True`:
```bash
$ demoecho --help         
Usage: demoecho [OPTIONS]

Options:
  -s, --string [hello|world]   This value echoed back to stdout.
  --help                       Show this message and exit.
```

Output when `show_choices=False`:
```bash
$ demoecho --help         
Usage: demoecho [OPTIONS]

Options:
  -s, --string [TEXT]    This value echoed back to stdout.
  --help                 Show this message and exit.
```

- fixes #2356

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
