### PR TITLE
Give a UserWarning when Parameter is overriden by name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,131 @@ Unreleased
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
 -   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
+-   Adds a UserWarning when multiple parameters attempt to use the same
+    name. :issue:`2396``
+
+
+Version 8.1.8
+-------------
+
+Unreleased
+
+-   Fix an issue with type hints for ``click.open_file()``. :issue:`2717`
+-   Fix issue where error message for invalid ``click.Path`` displays on
+    multiple lines. :issue:`2697`
+-   Fixed issue that prevented a default value of ``""`` from being displayed in
+    the help for an option. :issue:`2500`
+-   The test runner handles stripping color consistently on Windows.
+    :issue:`2705`
+-   Show correct value for flag default when using ``default_map``.
+    :issue:`2632`
+
+
+Version 8.1.7
+-------------
+
+Released 2023-08-17
+
+-   Fix issue with regex flags in shell completion. :issue:`2581`
+-   Bash version detection issues a warning instead of an error. :issue:`2574`
+-   Fix issue with completion script for Fish shell. :issue:`2567`
+
+
+Version 8.1.6
+-------------
+
+Released 2023-07-18
+
+-   Fix an issue with type hints for ``@click.group()``. :issue:`2558`
+
+
+Version 8.1.5
+-------------
+
+Released 2023-07-13
+
+-   Fix an issue with type hints for ``@click.command()``, ``@click.option()``, and
+    other decorators. Introduce typing tests. :issue:`2558`
+
+
+Version 8.1.4
+-------------
+
+Released 2023-07-06
+
+-   Replace all ``typing.Dict`` occurrences to ``typing.MutableMapping`` for
+    parameter hints. :issue:`2255`
+-   Improve type hinting for decorators and give all generic types parameters.
+    :issue:`2398`
+-   Fix return value and type signature of `shell_completion.add_completion_class`
+    function. :pr:`2421`
+-   Bash version detection doesn't fail on Windows. :issue:`2461`
+-   Completion works if there is a dot (``.``) in the program name. :issue:`2166`
+-   Improve type annotations for pyright type checker. :issue:`2268`
+-   Improve responsiveness of ``click.clear()``. :issue:`2284`
+-   Improve command name detection when using Shiv or PEX. :issue:`2332`
+-   Avoid showing empty lines if command help text is empty. :issue:`2368`
+-   ZSH completion script works when loaded from ``fpath``. :issue:`2344`.
+-   ``EOFError`` and ``KeyboardInterrupt`` tracebacks are not suppressed when
+    ``standalone_mode`` is disabled. :issue:`2380`
+-   ``@group.command`` does not fail if the group was created with a custom
+    ``command_class``. :issue:`2416`
+-   ``multiple=True`` is allowed for flag options again and does not require
+    setting ``default=()``. :issue:`2246, 2292, 2295`
+-   Make the decorators returned by ``@argument()`` and ``@option()`` reusable when the
+    ``cls`` parameter is used. :issue:`2294`
+-   Don't fail when writing filenames to streams with strict errors. Replace invalid
+    bytes with the replacement character (``�``). :issue:`2395`
+-   Remove unnecessary attempt to detect MSYS2 environment. :issue:`2355`
+-   Remove outdated and unnecessary detection of App Engine environment. :pr:`2554`
+-   ``echo()`` does not fail when no streams are attached, such as with ``pythonw`` on
+    Windows. :issue:`2415`
+-   Argument with ``expose_value=False`` do not cause completion to fail. :issue:`2336`
+
+-   Drop support for Python 3.7. :pr:`2588`
+-   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
+    :pr:`326`
+-   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Deprecate the ``__version__`` attribute. Use feature detection, or
+    ``importlib.metadata.version("click")``, instead. :issue:`2598`
+-   ``BaseCommand`` is deprecated. ``Command`` is the base class for all
+    commands. :issue:`2589`
+-   ``MultiCommand`` is deprecated. ``Group`` is the base class for all group
+    commands. :issue:`2590`
+-   The current parser and related classes and methods, are deprecated.
+    :issue:`2205`
+
+    -   ``OptionParser`` and the ``parser`` module, which is a modified copy of
+        ``optparse`` in the standard library.
+    -   ``Context.protected_args`` is unneeded. ``Context.args`` contains any
+        remaining arguments while parsing.
+    -   ``Parameter.add_to_parser`` (on both ``Argument`` and ``Option``) is
+        unneeded. Parsing works directly without building a separate parser.
+    -   ``split_arg_string`` is moved from ``parser`` to ``shell_completion``.
+
+-   Enable deferred evaluation of annotations with
+    ``from __future__ import annotations``. :pr:`2270`
+-   When generating a command's name from a decorated function's name, the
+    suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
+    :issue:`2322`
+-   Show the ``types.ParamType.name`` for ``types.Choice`` options within
+    ``--help`` message if ``show_choices=False`` is specified.
+    :issue:`2356`
+-   Do not display default values in prompts when ``Option.show_default`` is
+    ``False``. :pr:`2509`
+-   Add ``get_help_extra`` method on ``Option`` to fetch the generated extra
+    items used in ``get_help_record`` to render help text. :issue:`2516`
+    :pr:`2517`
+-   Keep stdout and stderr streams independent in ``CliRunner``. Always
+    collect stderr output and never raise an exception. Add a new
+    output` stream to simulate what the user sees in its terminal. Removes
+    the ``mix_stderr`` parameter in ``CliRunner``. :issue:`2522` :pr:`2523`
+-   ``Option.show_envvar`` now also shows environment variable in error messages.
+    :issue:`2695` :pr:`2696`
+-   ``Context.close`` will be called on exit. This results in all
+    ``Context.call_on_close`` callbacks and context managers added via
+    ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
+-   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,50 +5,6 @@ Version 8.2.0
 
 Unreleased
 
--   Drop support for Python 3.7. :pr:`2588`
--   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
-    :pr:`326`
--   Use ``flit_core`` instead of ``setuptools`` as build backend.
--   Deprecate the ``__version__`` attribute. Use feature detection, or
-    ``importlib.metadata.version("click")``, instead. :issue:`2598`
--   ``BaseCommand`` is deprecated. ``Command`` is the base class for all
-    commands. :issue:`2589`
--   ``MultiCommand`` is deprecated. ``Group`` is the base class for all group
-    commands. :issue:`2590`
--   The current parser and related classes and methods, are deprecated.
-    :issue:`2205`
-
-    -   ``OptionParser`` and the ``parser`` module, which is a modified copy of
-        ``optparse`` in the standard library.
-    -   ``Context.protected_args`` is unneeded. ``Context.args`` contains any
-        remaining arguments while parsing.
-    -   ``Parameter.add_to_parser`` (on both ``Argument`` and ``Option``) is
-        unneeded. Parsing works directly without building a separate parser.
-    -   ``split_arg_string`` is moved from ``parser`` to ``shell_completion``.
-
--   Enable deferred evaluation of annotations with
-    ``from __future__ import annotations``. :pr:`2270`
--   When generating a command's name from a decorated function's name, the
-    suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
-    :issue:`2322`
--   Show the ``types.ParamType.name`` for ``types.Choice`` options within
-    ``--help`` message if ``show_choices=False`` is specified.
-    :issue:`2356`
--   Do not display default values in prompts when ``Option.show_default`` is
-    ``False``. :pr:`2509`
--   Add ``get_help_extra`` method on ``Option`` to fetch the generated extra
-    items used in ``get_help_record`` to render help text. :issue:`2516`
-    :pr:`2517`
--   Keep stdout and stderr streams independent in ``CliRunner``. Always
-    collect stderr output and never raise an exception. Add a new
-    output` stream to simulate what the user sees in its terminal. Removes
-    the ``mix_stderr`` parameter in ``CliRunner``. :issue:`2522` :pr:`2523`
--   ``Option.show_envvar`` now also shows environment variable in error messages.
-    :issue:`2695` :pr:`2696`
--   ``Context.close`` will be called on exit. This results in all
-    ``Context.call_on_close`` callbacks and context managers added via
-    ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
--   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
 -   Adds a UserWarning when multiple parameters attempt to use the same
     name. :issue:`2396``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,8 +49,8 @@ Unreleased
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
 -   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
--   Adds a UserWarning when multiple parameters attempt to use the same
-    name. :issue:`2396``
+-   A ``UserWarning`` will be shown when multiple parameters attempt to use the
+    same name. :issue:`2396``
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,87 +5,6 @@ Version 8.2.0
 
 Unreleased
 
--   Adds a UserWarning when multiple parameters attempt to use the same
-    name. :issue:`2396``
-
-
-Version 8.1.8
--------------
-
-Unreleased
-
--   Fix an issue with type hints for ``click.open_file()``. :issue:`2717`
--   Fix issue where error message for invalid ``click.Path`` displays on
-    multiple lines. :issue:`2697`
--   Fixed issue that prevented a default value of ``""`` from being displayed in
-    the help for an option. :issue:`2500`
--   The test runner handles stripping color consistently on Windows.
-    :issue:`2705`
--   Show correct value for flag default when using ``default_map``.
-    :issue:`2632`
-
-
-Version 8.1.7
--------------
-
-Released 2023-08-17
-
--   Fix issue with regex flags in shell completion. :issue:`2581`
--   Bash version detection issues a warning instead of an error. :issue:`2574`
--   Fix issue with completion script for Fish shell. :issue:`2567`
-
-
-Version 8.1.6
--------------
-
-Released 2023-07-18
-
--   Fix an issue with type hints for ``@click.group()``. :issue:`2558`
-
-
-Version 8.1.5
--------------
-
-Released 2023-07-13
-
--   Fix an issue with type hints for ``@click.command()``, ``@click.option()``, and
-    other decorators. Introduce typing tests. :issue:`2558`
-
-
-Version 8.1.4
--------------
-
-Released 2023-07-06
-
--   Replace all ``typing.Dict`` occurrences to ``typing.MutableMapping`` for
-    parameter hints. :issue:`2255`
--   Improve type hinting for decorators and give all generic types parameters.
-    :issue:`2398`
--   Fix return value and type signature of `shell_completion.add_completion_class`
-    function. :pr:`2421`
--   Bash version detection doesn't fail on Windows. :issue:`2461`
--   Completion works if there is a dot (``.``) in the program name. :issue:`2166`
--   Improve type annotations for pyright type checker. :issue:`2268`
--   Improve responsiveness of ``click.clear()``. :issue:`2284`
--   Improve command name detection when using Shiv or PEX. :issue:`2332`
--   Avoid showing empty lines if command help text is empty. :issue:`2368`
--   ZSH completion script works when loaded from ``fpath``. :issue:`2344`.
--   ``EOFError`` and ``KeyboardInterrupt`` tracebacks are not suppressed when
-    ``standalone_mode`` is disabled. :issue:`2380`
--   ``@group.command`` does not fail if the group was created with a custom
-    ``command_class``. :issue:`2416`
--   ``multiple=True`` is allowed for flag options again and does not require
-    setting ``default=()``. :issue:`2246, 2292, 2295`
--   Make the decorators returned by ``@argument()`` and ``@option()`` reusable when the
-    ``cls`` parameter is used. :issue:`2294`
--   Don't fail when writing filenames to streams with strict errors. Replace invalid
-    bytes with the replacement character (``�``). :issue:`2395`
--   Remove unnecessary attempt to detect MSYS2 environment. :issue:`2355`
--   Remove outdated and unnecessary detection of App Engine environment. :pr:`2554`
--   ``echo()`` does not fail when no streams are attached, such as with ``pythonw`` on
-    Windows. :issue:`2415`
--   Argument with ``expose_value=False`` do not cause completion to fail. :issue:`2336`
-
 -   Drop support for Python 3.7. :pr:`2588`
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`326`
@@ -130,6 +49,8 @@ Released 2023-07-06
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
 -   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
+-   Adds a UserWarning when multiple parameters attempt to use the same
+    name. :issue:`2396``
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -974,8 +974,8 @@ class Command:
             for duplicate_opt in duplicate_opts:
                 warnings.warn(
                     (
-                        f"The option {duplicate_opt} is used more than once. "
-                        "Remove it as an option should be unique."
+                        f"The parameter {duplicate_opt} is used more than once. "
+                        "Remove its duplicate as parameters should be unique."
                     ),
                     stacklevel=3,
                 )

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1990,6 +1990,10 @@ class Parameter:
         of :class:`~click.shell_completion.CompletionItem` or a list of
         strings.
 
+    .. versionchanged:: 8.2
+        Adding duplicate parameter names to a :class:`~click.core.Command` will
+        result in a ``UserWarning`` being shown.
+
     .. versionchanged:: 8.0
         ``process_value`` validates required parameters and bounded
         ``nargs``, and invokes the parameter callback before returning

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2991,7 +2991,7 @@ class Argument(Parameter):
         else:
             raise TypeError(
                 "Arguments take exactly one parameter declaration, got"
-                f" {len(decls)}."
+                f" {len(decls)}: {decls}."
             )
         return name, [arg], []
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -319,7 +319,7 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
             f.__click_params__ = []  # type: ignore
         else:
             for opt in param.opts:
-                for preexisting_param in f.__click_params__:
+                for preexisting_param in f.__click_params__:  # type: ignore
                     if opt in preexisting_param.opts:
 
                         from warnings import warn
@@ -327,9 +327,9 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
                         warn(
                             (
                                 "Duplicate option added to command."
-                                + " The following option appears more than once:\n"
-                                + f"{opt} (used for {param.human_readable_name}"
-                                + f" and {preexisting_param.human_readable_name})"
+                                " The following option appears more than once:\n"
+                                f"{opt} (used for {param.human_readable_name}"
+                                f" and {preexisting_param.human_readable_name})"
                             ),
                             stacklevel=3,
                         )

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -321,7 +321,6 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
             for opt in param.opts:
                 for preexisting_param in f.__click_params__:  # type: ignore
                     if opt in preexisting_param.opts:
-
                         from warnings import warn
 
                         warn(

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -317,6 +317,22 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
     else:
         if not hasattr(f, "__click_params__"):
             f.__click_params__ = []  # type: ignore
+        else:
+            for opt in param.opts:
+                for preexisting_param in f.__click_params__:
+                    if opt in preexisting_param.opts:
+
+                        from warnings import warn
+
+                        warn(
+                            (
+                                "Duplicate option added to command."
+                                + " The following option appears more than once:\n"
+                                + f"{opt} (used for {param.human_readable_name}"
+                                + f" and {preexisting_param.human_readable_name})"
+                            ),
+                            stacklevel=3,
+                        )
 
         f.__click_params__.append(param)  # type: ignore
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -317,21 +317,6 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
     else:
         if not hasattr(f, "__click_params__"):
             f.__click_params__ = []  # type: ignore
-        else:
-            for opt in param.opts:
-                for preexisting_param in f.__click_params__:  # type: ignore
-                    if opt in preexisting_param.opts:
-                        from warnings import warn
-
-                        warn(
-                            (
-                                "Duplicate option added to command."
-                                " The following option appears more than once:\n"
-                                f"{opt} (used for {param.human_readable_name}"
-                                f" and {preexisting_param.human_readable_name})"
-                            ),
-                            stacklevel=3,
-                        )
 
         f.__click_params__.append(param)  # type: ignore
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -401,3 +401,23 @@ def test_when_argument_decorator_is_used_multiple_times_cls_is_preserved():
 
     assert isinstance(foo.params[0], CustomArgument)
     assert isinstance(bar.params[0], CustomArgument)
+
+
+@pytest.mark.parametrize(
+    "args_one,args_two",
+    [
+        (
+            ("aardvark",),
+            ("aardvark",),
+        ),
+    ],
+)
+def test_duplicate_names_warning(runner, args_one, args_two):
+    @click.command()
+    @click.argument(*args_one)
+    @click.argument(*args_two)
+    def cli(one, two):
+        pass
+
+    with pytest.warns(UserWarning):
+        runner.invoke(cli, [])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -992,10 +992,11 @@ def test_usage_show_choices(runner, choices, metavars):
 
 
 def test_overridden_option_triggers_warning(runner):
-    with pytest.warns(UserWarning):
+    @click.command()
+    @click.option("-a", "--aardvark")
+    @click.option("-a", "--avocado")
+    def cli(aardvark, avocado):
+        pass
 
-        @click.command()
-        @click.option("-a", "--aardvark")
-        @click.option("-a", "--avocado")
-        def cli(aardvark, avocado):
-            pass
+    with pytest.warns(UserWarning):
+        runner.invoke(cli, [])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -989,3 +989,13 @@ def test_usage_show_choices(runner, choices, metavars):
 
     result = runner.invoke(cli_without_choices, ["--help"])
     assert metavars in result.output
+
+
+def test_overridden_option_triggers_warning(runner):
+    with pytest.warns(UserWarning):
+
+        @click.command()
+        @click.option("-a", "--aardvark")
+        @click.option("-a", "--avocado")
+        def cli(aardvark, avocado):
+            pass

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -991,11 +991,26 @@ def test_usage_show_choices(runner, choices, metavars):
     assert metavars in result.output
 
 
-def test_overridden_option_triggers_warning(runner):
+@pytest.mark.parametrize(
+    "opts_one,opts_two",
+    [
+        # No duplicate shortnames
+        (
+            ("-a", "--aardvark"),
+            ("-a", "--avocado"),
+        ),
+        # No duplicate long names
+        (
+            ("-a", "--aardvark"),
+            ("-b", "--aardvark"),
+        ),
+    ],
+)
+def test_duplicate_names_warning(runner, opts_one, opts_two):
     @click.command()
-    @click.option("-a", "--aardvark")
-    @click.option("-a", "--avocado")
-    def cli(aardvark, avocado):
+    @click.option(*opts_one)
+    @click.option(*opts_two)
+    def cli(one, two):
         pass
 
     with pytest.warns(UserWarning):


### PR DESCRIPTION
This adds a UserWarning when two parameters on one command have a name conflict. Very interested in thoughts and feedback.

- fixes #2396 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
