### PR TITLE
signal pyreadiness for all supported Python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,11 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:


### PR DESCRIPTION
This commit marks click compatible with Python `>=3.7,<3.12`

- fixes #2399