### PR TITLE
Default catch_exceptions in CliRunner to False

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -352,7 +352,7 @@ class CliRunner:
         args: t.Optional[t.Union[str, t.Sequence[str]]] = None,
         input: t.Optional[t.Union[str, bytes, t.IO]] = None,
         env: t.Optional[t.Mapping[str, t.Optional[str]]] = None,
-        catch_exceptions: bool = True,
+        catch_exceptions: bool = False,
         color: bool = False,
         **extra: t.Any,
     ) -> Result:


### PR DESCRIPTION
Currently, exceptions are silently caught by CliRunner.invoke, and the only way to know about these is through the documentation. By defaulting catch_exceptions to False, exceptions will be re-raised automatically, and developers will have to explicitly opt-in to populate the .exception field of CliRunner