### PR TITLE
Fix return value of `shell_completion.add_completion_class` function

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -398,7 +398,7 @@ _available_shells: t.Dict[str, t.Type[ShellComplete]] = {
 
 def add_completion_class(
     cls: t.Type[ShellComplete], name: t.Optional[str] = None
-) -> None:
+) -> t.Type[ShellComplete]:
     """Register a :class:`ShellComplete` subclass under the given name.
     The name will be provided by the completion instruction environment
     variable during completion.
@@ -412,6 +412,8 @@ def add_completion_class(
         name = cls.name
 
     _available_shells[name] = cls
+
+    return cls
 
 
 def get_completion_class(shell: str) -> t.Optional[t.Type[ShellComplete]]:


### PR DESCRIPTION
Decorators should return a possibly modfiied version of the original type. Hence, `add_completion_class` should return `cls` rather than merely `None`. This conforms to Python conventions, and allows type checking to work properly.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.