### PR TITLE
Fix return value and type signature of `shell_completion.add_completion_class` function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
+-   Fix return value and type signature of `shell_completion.add_completion_class` function. :pr:`2421`
 
 
 Version 8.1.3

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -389,6 +389,9 @@ class FishComplete(ShellComplete):
         return f"{item.type},{item.value}"
 
 
+ShellCompleteType = t.TypeVar("ShellCompleteType", bound=t.Type[ShellComplete])
+
+
 _available_shells: t.Dict[str, t.Type[ShellComplete]] = {
     "bash": BashComplete,
     "fish": FishComplete,
@@ -397,8 +400,8 @@ _available_shells: t.Dict[str, t.Type[ShellComplete]] = {
 
 
 def add_completion_class(
-    cls: t.Type[ShellComplete], name: t.Optional[str] = None
-) -> None:
+    cls: ShellCompleteType, name: t.Optional[str] = None
+) -> ShellCompleteType:
     """Register a :class:`ShellComplete` subclass under the given name.
     The name will be provided by the completion instruction environment
     variable during completion.
@@ -412,6 +415,8 @@ def add_completion_class(
         name = cls.name
 
     _available_shells[name] = cls
+
+    return cls
 
 
 def get_completion_class(shell: str) -> t.Optional[t.Type[ShellComplete]]:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -4,10 +4,10 @@ from click.core import Argument
 from click.core import Command
 from click.core import Group
 from click.core import Option
+from click.shell_completion import _available_shells
+from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
 from click.shell_completion import ShellComplete
-from click.shell_completion import add_completion_class
-from click.shell_completion import _available_shells
 from click.types import Choice
 from click.types import File
 from click.types import Path

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -6,6 +6,8 @@ from click.core import Group
 from click.core import Option
 from click.shell_completion import CompletionItem
 from click.shell_completion import ShellComplete
+from click.shell_completion import add_completion_class
+from click.shell_completion import _available_shells
 from click.types import Choice
 from click.types import File
 from click.types import Path
@@ -342,3 +344,25 @@ def test_choice_case_sensitive(value, expect):
     )
     completions = _get_words(cli, ["-a"], "a")
     assert completions == expect
+
+
+def test_add_completion_class():
+    _available_shells.clear()
+
+    class MyshComplete(ShellComplete):
+        name = "mysh"
+        source_template = "dummy source"
+
+    assert add_completion_class(MyshComplete) is MyshComplete
+    assert _available_shells[MyshComplete.name] is MyshComplete
+
+
+def test_add_completion_class_decorator():
+    _available_shells.clear()
+
+    @add_completion_class
+    class MyshComplete(ShellComplete):
+        name = "mysh"
+        source_template = "dummy source"
+
+    assert _available_shells[MyshComplete.name] is MyshComplete

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,10 +1,10 @@
 import pytest
 
+import click.shell_completion
 from click.core import Argument
 from click.core import Command
 from click.core import Group
 from click.core import Option
-import click.shell_completion
 from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
 from click.shell_completion import ShellComplete

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -357,19 +357,34 @@ def _restore_available_shells(tmpdir):
 
 @pytest.mark.usefixtures("_restore_available_shells")
 def test_add_completion_class():
+    # At first, "mysh" is not in available shells
+    assert "mysh" not in click.shell_completion._available_shells
+
     class MyshComplete(ShellComplete):
         name = "mysh"
         source_template = "dummy source"
 
+    # "mysh" still not in available shells because it is not registered
+    assert "mysh" not in click.shell_completion._available_shells
+
+    # Adding a completion class should return that class
     assert add_completion_class(MyshComplete) is MyshComplete
-    assert click.shell_completion._available_shells[MyshComplete.name] is MyshComplete
+
+    # Now, "mysh" is finally in available shells
+    assert "mysh" in click.shell_completion._available_shells
+    assert click.shell_completion._available_shells["mysh"] is MyshComplete
 
 
 @pytest.mark.usefixtures("_restore_available_shells")
 def test_add_completion_class_decorator():
+    # At first, "mysh" is not in available shells
+    assert "mysh" not in click.shell_completion._available_shells
+
     @add_completion_class
     class MyshComplete(ShellComplete):
         name = "mysh"
         source_template = "dummy source"
 
-    assert click.shell_completion._available_shells[MyshComplete.name] is MyshComplete
+    # Using `add_completion_class` as a decorator adds the new shell immediately
+    assert "mysh" in click.shell_completion._available_shells
+    assert click.shell_completion._available_shells["mysh"] is MyshComplete

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -348,9 +348,11 @@ def test_choice_case_sensitive(value, expect):
 
 @pytest.fixture()
 def _restore_available_shells(tmpdir):
-    prev_available_shells = click.shell_completion._available_shells
+    prev_available_shells = click.shell_completion._available_shells.copy()
+    click.shell_completion._available_shells.clear()
     yield
-    click.shell_completion._available_shells = prev_available_shells
+    click.shell_completion._available_shells.clear()
+    click.shell_completion._available_shells.update(prev_available_shells)
 
 
 @pytest.mark.usefixtures("_restore_available_shells")

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -376,6 +376,32 @@ def test_add_completion_class():
 
 
 @pytest.mark.usefixtures("_restore_available_shells")
+def test_add_completion_class_with_name():
+    # At first, "mysh" is not in available shells
+    assert "mysh" not in click.shell_completion._available_shells
+    assert "not_mysh" not in click.shell_completion._available_shells
+
+    class MyshComplete(ShellComplete):
+        name = "not_mysh"
+        source_template = "dummy source"
+
+    # "mysh" and "not_mysh" are still not in available shells because
+    # it is not registered yet
+    assert "mysh" not in click.shell_completion._available_shells
+    assert "not_mysh" not in click.shell_completion._available_shells
+
+    # Adding a completion class should return that class.
+    # Because we are using the "name" parameter, the name isn't taken
+    # from the class.
+    assert add_completion_class(MyshComplete, name="mysh") is MyshComplete
+
+    # Now, "mysh" is finally in available shells
+    assert "mysh" in click.shell_completion._available_shells
+    assert "not_mysh" not in click.shell_completion._available_shells
+    assert click.shell_completion._available_shells["mysh"] is MyshComplete
+
+
+@pytest.mark.usefixtures("_restore_available_shells")
 def test_add_completion_class_decorator():
     # At first, "mysh" is not in available shells
     assert "mysh" not in click.shell_completion._available_shells

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -4,7 +4,7 @@ from click.core import Argument
 from click.core import Command
 from click.core import Group
 from click.core import Option
-from click.shell_completion import _available_shells
+import click.shell_completion
 from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
 from click.shell_completion import ShellComplete
@@ -346,23 +346,28 @@ def test_choice_case_sensitive(value, expect):
     assert completions == expect
 
 
-def test_add_completion_class():
-    _available_shells.clear()
+@pytest.fixture()
+def _restore_available_shells(tmpdir):
+    prev_available_shells = click.shell_completion._available_shells
+    yield
+    click.shell_completion._available_shells = prev_available_shells
 
+
+@pytest.mark.usefixtures("_restore_available_shells")
+def test_add_completion_class():
     class MyshComplete(ShellComplete):
         name = "mysh"
         source_template = "dummy source"
 
     assert add_completion_class(MyshComplete) is MyshComplete
-    assert _available_shells[MyshComplete.name] is MyshComplete
+    assert click.shell_completion._available_shells[MyshComplete.name] is MyshComplete
 
 
+@pytest.mark.usefixtures("_restore_available_shells")
 def test_add_completion_class_decorator():
-    _available_shells.clear()
-
     @add_completion_class
     class MyshComplete(ShellComplete):
         name = "mysh"
         source_template = "dummy source"
 
-    assert _available_shells[MyshComplete.name] is MyshComplete
+    assert click.shell_completion._available_shells[MyshComplete.name] is MyshComplete


### PR DESCRIPTION
Decorators should return a possibly modfiied version of the original type. Hence, add_completion_class should return cls rather than merely None. This conforms to Python conventions, and allows type checking to work properly.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.