### PR TITLE
Add support for MultiCommand method based sub-Commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,5 @@
 .. currentmodule:: click
 
-Version 8.2.1
--------------
-
-Unreleased
-
--   Add support for method based commands
-    :issue:`601`
-
 
 Version 8.2.0
 -------------
@@ -25,6 +17,8 @@ Unreleased
 
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
+-   Add support for method based commands
+    :issue:`601`
 
 
 Version 8.1.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,5 @@
 .. currentmodule:: click
 
-
 Version 8.2.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: click
 
+Version 8.2.1
+-------------
+
+Unreleased
+
+-   Add support for method based commands
+    :issue:`601`
+
+
 Version 8.2.0
 -------------
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -226,12 +226,10 @@ def command(
         params = attr_params if attr_params is not None else []
 
         try:
-            decorator_params = f.__click_params__  # type: ignore
+            params.extend(reversed(f.__click_params__))  # type: ignore
+            del f.__click_params__  # type: ignore
         except AttributeError:
             pass
-        else:
-            del f.__click_params__  # type: ignore
-            params.extend(reversed(decorator_params))
 
         if attrs.get("help") is None:
             attrs["help"] = f.__doc__

--- a/tests/test_custom_classes.py
+++ b/tests/test_custom_classes.py
@@ -118,11 +118,15 @@ def test_bound_method(runner):
     methods should be registered as commands inside the __init__ so they can capture
     the reference to `self`
     """
+
     class Test(click.MultiCommand):
         def __init__(self, attribute="default"):
             super().__init__()
             self.attribute = attribute
-            self.commands = {"echo": click.command(self.echo), "shout": click.command(self.shout)}
+            self.commands = {
+                "echo": click.command(self.echo),
+                "shout": click.command(self.shout),
+            }
 
         def echo(self):
             click.echo(self.attribute)
@@ -143,9 +147,9 @@ def test_bound_method(runner):
     result = runner.invoke(cli_default, "echo")
     assert result.output == "default\n"
 
-    cli_test = Test("test")
+    cli_test = Test("tester")
     result = runner.invoke(cli_test, "echo")
-    assert result.output == "test\n"
+    assert result.output == "tester\n"
 
     result = runner.invoke(cli_test, ["shout", "testthis"])
     assert result.output == "TESTTHIS\n"


### PR DESCRIPTION
# MultiCommand Class Based methods

This PR enables `click` users to use class MultiCommand methods.
It fixes #601 where users request for a way to use commands that are also Python Object methods.

Such as:

```python

class Foo:
    @command()
    def bar(self):
        print("bar method / command")
```
Currently one might use staticmethods to create MultiCommands that use method based commands. However user might need to access object attributes in their commands.
We propose to enable users to create MultiCommands that also allow access to object attributes by setting the commands inside the __init__ method so the instance can have a reference to self while executing.

Here is example implementation of such a class:

```python
# in file example.py
class Foo(MultiCommand):
    def __init__(self, x: message):
        super().__init__()
        self.message = message
        self.commands = {"echo": click.command(self.echo)}

    # MultiCommand must implement get_command and list_commands
    def get_command(self, ctx: click.Context, cmd_name: str) -> Command:
        return self.commands.get(cmd_name)

    def list_commands(self, ctx: click.Context) -> list[str]:
        return list(self.commands.keys())

    # here is an example method  that we want to use as a click command
    # notice we have access to self and can use click.option and click.argument decorators
    @click.option("--upper", default=False)
    def echo(self, upper: bool) -> None:
        msg = self.message.upper() if upper else self.message
        click.echo(msg) 


# execute the click application
Foo("bar")

# test it using:
# python3 example.py echo --upper
```

- fixes #601

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
