### PR TITLE
#2484: implement "Better error message when trying to use Optional[...] in a type parameter"

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1024,6 +1024,11 @@ def convert_type(ty: t.Optional[t.Any], default: t.Optional[t.Any] = None) -> Pa
     if guessed_type:
         return STRING
 
+    if hasattr(ty, "__origin__"):  # type is _GenericAlias
+        raise TypeError(
+            "Attempted to use a generic type such as Optional as a type parameter."
+        )
+
     if __debug__:
         try:
             if issubclass(ty, ParamType):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import os.path
 import pathlib
+import typing as t
 
 import pytest
 from conftest import symlinks_supported
@@ -128,3 +129,17 @@ def test_path_resolve_symlink(tmp_path, runner):
     rel_link.symlink_to(pathlib.Path("..") / "file")
     rel_rv = path_type.convert(os.fsdecode(rel_link), param, ctx)
     assert rel_rv == test_file_str
+
+
+def test_sensible_error_on_optional():
+    with pytest.raises(TypeError) as err:
+
+        @click.command()
+        @click.option("--f", type=t.Optional[int], default=None)
+        def cli(f):
+            click.echo(f"F:[{f}]")
+
+    assert (
+        err.value.args[0]
+        == "Attempted to use a generic type such as Optional as a type parameter."
+    )


### PR DESCRIPTION
Added handling to `types.py::convert_type` to display the following message when a `typing._GenericAlias` is discovered:

```
TypeError: Attempted to use a generic type such as Optional as a type parameter.
```

- fixes #2484

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
