### PR TITLE
Fix format_filename and other unicode issues 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Unreleased
     ``command_class``. :issue:`2416`
 -   ``multiple=True`` is allowed for flag options again and does not require
     setting ``default=()``. :issue:`2246, 2292, 2295`
+-   Fixed regression in 8.0 that caused :func:`format_filename` to stop replacing
+    undecodable bytes with the unicode REPLACEMENT CHARACTER. Systems where the stdout
+    error handler is `strict` would fail to print such strings. :issue:`2395`
 
 
 Version 8.1.3

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -124,15 +124,9 @@ File Path Arguments
 
 In the previous example, the files were opened immediately.  But what if
 we just want the filename?  The naïve way is to use the default string
-argument type.  However, remember that Click is Unicode-based, so the string
-will always be a Unicode value.  Unfortunately, filenames can be Unicode or
-bytes depending on which operating system is being used.  As such, the type
-is insufficient.
-
-Instead, you should be using the :class:`Path` type, which automatically
-handles this ambiguity.  Not only will it return either bytes or Unicode
-depending on what makes more sense, but it will also be able to do some
-basic checks for you such as existence checks.
+argument type. The :class:`Path` type has several checks available which raise nice
+errors if they fail, such as existence. Filenames in these error messages are formatted
+with :func:`format_filename`, so any undecodable bytes will be printed nicely.
 
 Example:
 

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -17,10 +17,6 @@ auto_wrap_for_ansi: t.Optional[t.Callable[[t.TextIO], t.TextIO]] = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 
 
-def get_filesystem_encoding() -> str:
-    return sys.getfilesystemencoding() or sys.getdefaultencoding()
-
-
 def _make_text_stream(
     stream: t.BinaryIO,
     encoding: t.Optional[str],
@@ -564,7 +560,7 @@ if sys.platform.startswith("win") and WIN:
 else:
 
     def _get_argv_encoding() -> str:
-        return getattr(sys.stdin, "encoding", None) or get_filesystem_encoding()
+        return getattr(sys.stdin, "encoding", None) or sys.getfilesystemencoding()
 
     def _get_windows_console_stream(
         f: t.TextIO, encoding: t.Optional[str], errors: t.Optional[str]

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -268,7 +268,7 @@ class FileError(ClickException):
         self.filename: t.Union[str, bytes] = filename
 
     def format_message(self) -> str:
-        return _("Could not open file {filename!r}: {message}").format(
+        return _("Could not open file '{filename}': {message}").format(
             filename=self.ui_filename, message=self.message
         )
 

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -1,10 +1,10 @@
-import os
 import typing as t
 from gettext import gettext as _
 from gettext import ngettext
 
 from ._compat import get_text_stderr
 from .utils import echo
+from .utils import format_filename
 
 if t.TYPE_CHECKING:
     from .core import Command
@@ -257,13 +257,15 @@ class BadArgumentUsage(UsageError):
 class FileError(ClickException):
     """Raised if a file cannot be opened."""
 
-    def __init__(self, filename: str, hint: t.Optional[str] = None) -> None:
+    def __init__(
+        self, filename: t.Union[str, bytes], hint: t.Optional[str] = None
+    ) -> None:
         if hint is None:
             hint = _("unknown error")
 
         super().__init__(hint)
-        self.ui_filename: str = os.fsdecode(filename)
-        self.filename = filename
+        self.ui_filename: str = format_filename(filename)
+        self.filename: t.Union[str, bytes] = filename
 
     def format_message(self) -> str:
         return _("Could not open file {filename!r}: {message}").format(

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -851,7 +851,7 @@ class Path(ParamType):
                 # until Python 3.8. Use pathlib for now.
                 import pathlib
 
-                rv = os.fsdecode(pathlib.Path(rv).resolve())
+                rv = os.fspath(pathlib.Path(os.fsdecode(rv)).resolve())
 
             try:
                 st = os.stat(rv)

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1,12 +1,12 @@
 import os
 import stat
+import sys
 import typing as t
 from datetime import datetime
 from gettext import gettext as _
 from gettext import ngettext
 
 from ._compat import _get_argv_encoding
-from ._compat import get_filesystem_encoding
 from ._compat import open_stream
 from .exceptions import BadParameter
 from .utils import LazyFile
@@ -207,7 +207,7 @@ class StringParamType(ParamType):
             try:
                 value = value.decode(enc)
             except UnicodeError:
-                fs_enc = get_filesystem_encoding()
+                fs_enc = sys.getfilesystemencoding()
                 if fs_enc != enc:
                     try:
                         value = value.decode(fs_enc)

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import stat
 import sys
 import typing as t
@@ -833,6 +834,8 @@ class Path(ParamType):
                 rv = os.fsdecode(rv)
             elif self.type is bytes:
                 rv = os.fsencode(rv)
+            elif issubclass(self.type, pathlib.PurePath):
+                rv = self.type(os.fsdecode(rv))
             else:
                 rv = self.type(rv)
 
@@ -849,8 +852,6 @@ class Path(ParamType):
             if self.resolve_path:
                 # os.path.realpath doesn't resolve symlinks on Windows
                 # until Python 3.8. Use pathlib for now.
-                import pathlib
-
                 rv = os.fspath(pathlib.Path(os.fsdecode(rv)).resolve())
 
             try:

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -11,7 +11,6 @@ from ._compat import _default_text_stdout
 from ._compat import _find_binary_writer
 from ._compat import auto_wrap_for_ansi
 from ._compat import binary_streams
-from ._compat import get_filesystem_encoding
 from ._compat import open_stream
 from ._compat import should_strip_ansi
 from ._compat import strip_ansi
@@ -48,7 +47,7 @@ def make_str(value: t.Any) -> str:
     """Converts a value into a valid string."""
     if isinstance(value, bytes):
         try:
-            return value.decode(get_filesystem_encoding())
+            return value.decode(sys.getfilesystemencoding())
         except UnicodeError:
             return value.decode("utf-8", "replace")
     return str(value)

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -412,8 +412,17 @@ def format_filename(
     """
     if shorten:
         filename = os.path.basename(filename)
+    else:
+        filename = os.fspath(filename)
 
-    return os.fsdecode(filename)
+    if isinstance(filename, bytes):
+        filename = filename.decode(sys.getfilesystemencoding(), "replace")
+    else:
+        filename = filename.encode("utf-8", "surrogateescape").decode(
+            "utf-8", "replace"
+        )
+
+    return filename
 
 
 def get_app_dir(app_name: str, roaming: bool = True, force_posix: bool = False) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import pytest
 
 from click.testing import CliRunner
@@ -9,19 +6,3 @@ from click.testing import CliRunner
 @pytest.fixture(scope="function")
 def runner(request):
     return CliRunner()
-
-
-def _check_symlinks_supported():
-    with tempfile.TemporaryDirectory(prefix="click-pytest-") as tempdir:
-        target = os.path.join(tempdir, "target")
-        open(target, "w").close()
-        link = os.path.join(tempdir, "link")
-
-        try:
-            os.symlink(target, link)
-            return True
-        except OSError:
-            return False
-
-
-symlinks_supported = _check_symlinks_supported()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,86 @@
+import os
+import tempfile
+
+import pytest
+
+IMPOSSIBLE_UTF8_BYTE = b"\xff"
+IMPOSSIBLE_UTF8_SURROGATE_STR = IMPOSSIBLE_UTF8_BYTE.decode("utf-8", "surrogateescape")
+
+
+def _check_symlinks_supported():
+    with tempfile.TemporaryDirectory(prefix="click-pytest-") as tempdir:
+        target = os.path.join(tempdir, "target")
+        open(target, "w").close()
+        link = os.path.join(tempdir, "link")
+
+        try:
+            os.symlink(target, link)
+            return True
+        except OSError:
+            return False
+
+
+def _check_non_utf8_filenames():
+    with tempfile.TemporaryDirectory(prefix="click-pytest-") as tempdir:
+        target = os.path.join(tempdir, IMPOSSIBLE_UTF8_SURROGATE_STR)
+        try:
+            f = open(target, "w")
+        except OSError:
+            return False
+        else:
+            f.close()
+            return True
+
+
+symlinks_supported = _check_symlinks_supported()
+non_utf8_filenames_supported = _check_non_utf8_filenames()
+
+
+def assert_no_surrogates(value: str) -> None:
+    """This fixture returns a function that can be used to assert that a string
+    can be printed to a stream in which errors='strict' (e.g. stdout), i.e. has no
+    surrogates.
+
+    You *must not remove this from tests*, as many (most?) systems in which our tests
+    will run are already configured with a locale which makes printing surrogates work
+    fine.
+
+    Here are some typical scenarios in which strings with surrogates wouldn't cause an
+    error:
+
+    - You're printing to stderr
+
+      Python uses the `backslashreplace` error handler for stderr.
+
+    - You're using the official Python docker image which sets LANG=C.UTF-8
+
+      Since Python 3.5, the stdin and stdour error handler is `surrogateescape` when the
+      `C` locale is used. Python 3.7 extends this to the `POSIX` locale (via PEP 540)
+      and additionally the `C.UTF-8` and `UTF-8` locales (via PEP 538).
+
+    - You're using a minimal Debian (e.g. a docker image) and don't have LANG/LC_* set.
+
+      Since Python 3.7, Python will coerce your locale to `C.UTF-8` (PEP 538), and
+      therefore changes the error handler for stdin and stdout to `surrogateescape`.
+
+    - You're on a system where the locale is explicitly `C` or `POSIX`.
+
+      As above, Python will coerce your locale to `C.UTF-8` (PEP 538).
+
+    - You're using PEP 540's UTF-8 mode explicitly via `PYTHONUTF8=1` or `-X utf8`.
+
+      PEP 540 changes the stdout and stdin error handlers to `surrogateescape`.
+
+    A typical scenario in which the `strict` error handler is used for stdin and stdout
+    is when you have a locale like `LANG=en_GB.UTF-8`. It is these systems where we need
+    to be sure we aren't printing surrogates to stdout!
+    """
+    __tracebackhide__ = True
+    assert isinstance(value, str), "this fixture is only for checking strings"
+    try:
+        value.encode("utf-8", "strict")
+    except UnicodeEncodeError as exc:
+        if exc.reason == "surrogates not allowed":
+            pytest.fail("string contains surrogates")
+        else:
+            raise

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,11 @@
+from .helpers import assert_no_surrogates
+from .helpers import IMPOSSIBLE_UTF8_SURROGATE_STR
+from click.exceptions import FileError
+
+
+def test_file_error_surrogates():
+    filename = f"/x/foo{IMPOSSIBLE_UTF8_SURROGATE_STR}.txt"
+    exc = FileError(filename=filename)
+    message = exc.format_message()
+    assert_no_surrogates(message)
+    assert message == "Could not open file '/x/foo�.txt': unknown error"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -48,6 +48,7 @@ ALLOWED_IMPORTS = {
     "typing",
     "types",
     "gettext",
+    "pathlib",
 }
 
 if WIN:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -85,23 +85,28 @@ def test_cast_multi_default(runner, nargs, multiple, default, expect):
 
 
 @pytest.mark.parametrize(
-    ("cls", "expect"),
+    ("type", "value", "expect"),
     [
-        (None, "a/b/c.txt"),
-        (str, "a/b/c.txt"),
-        (bytes, b"a/b/c.txt"),
-        (pathlib.Path, pathlib.Path("a", "b", "c.txt")),
+        (click.Path(resolve_path=True), "foo/bar", os.path.realpath("foo/bar")),
+        (click.Path(resolve_path=True), b"foo/bar", os.path.realpath("foo/bar")),
+        (
+            click.Path(resolve_path=True),
+            pathlib.Path("foo/bar"),
+            os.path.realpath("foo/bar"),
+        ),
+        (click.Path(), "foo/bar", "foo/bar"),
+        (click.Path(), b"foo/bar", b"foo/bar"),
+        (click.Path(path_type=None), "foo/bar", "foo/bar"),
+        (click.Path(path_type=None), b"foo/bar", b"foo/bar"),
+        (click.Path(path_type=str), "foo/bar", "foo/bar"),
+        (click.Path(path_type=str), b"foo/bar", "foo/bar"),
+        (click.Path(path_type=bytes), "foo/bar", b"foo/bar"),
+        (click.Path(path_type=bytes), b"foo/bar", b"foo/bar"),
+        (click.Path(path_type=pathlib.Path), "foo/bar", pathlib.Path("foo/bar")),
     ],
 )
-def test_path_type(runner, cls, expect):
-    cli = click.Command(
-        "cli",
-        params=[click.Argument(["p"], type=click.Path(path_type=cls))],
-        callback=lambda p: p,
-    )
-    result = runner.invoke(cli, ["a/b/c.txt"], standalone_mode=False)
-    assert result.exception is None
-    assert result.return_value == expect
+def test_path(type, value, expect):
+    assert type.convert(value, None, None) == expect
 
 
 @pytest.mark.skipif(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -103,6 +103,7 @@ def test_cast_multi_default(runner, nargs, multiple, default, expect):
         (click.Path(path_type=bytes), "foo/bar", b"foo/bar"),
         (click.Path(path_type=bytes), b"foo/bar", b"foo/bar"),
         (click.Path(path_type=pathlib.Path), "foo/bar", pathlib.Path("foo/bar")),
+        (click.Path(path_type=pathlib.Path), b"foo/bar", pathlib.Path("foo/bar")),
     ],
 )
 def test_path(type, value, expect):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,7 +101,12 @@ def test_filename_formatting():
 
     # filesystem encoding on windows permits this.
     if not WIN:
-        assert click.format_filename(b"/x/foo\xff.txt", shorten=True) == "foo\udcff.txt"
+        rv = click.format_filename(b"/x/foo\xff.txt", shorten=True)
+        assert rv == "foo\ufffd.txt"
+
+        # We want format_filename to produce a string that can be printed to
+        # stdout even in errors="strict" mode, check that here.
+        assert rv.encode("utf-8", "strict") == b"foo\xef\xbf\xbd.txt"
 
 
 def test_prompts(runner):


### PR DESCRIPTION
In some environments, the stdout error handler is `surrogateescape` (see [PEP 538](https://peps.python.org/pep-0538/) and [PEP 540](https://peps.python.org/pep-0540/#relationship-with-the-locale-coercion-pep-538)). In others, the stdout error handler defaults to `strict`. `format_filename` should allow invalid unicode to be printed (with replacement characters) to avoid `UnicodeEncodeError`s.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2395

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
