### PR TITLE
Show empty default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Unreleased
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
 -   Fix return value and type signature of `shell_completion.add_completion_class` function. :pr:`2421`
--   Display empty string defaults. :issue:`2500`
+-   Display empty string defaults for options. :issue:`2500`
 
 
 Version 8.1.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Unreleased
 
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
-
+-   Display empty string defaults for options.
+    :issue:`2500`
 
 Version 8.1.3
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Unreleased
 -   Improve type hinting for decorators and give all generic types parameters.
     :issue:`2398`
 -   Fix return value and type signature of `shell_completion.add_completion_class` function. :pr:`2421`
--   Display empty string defaults for options. :issue:`2500`
+-   Display empty string defaults. :issue:`2500`
 
 
 Version 8.1.3

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2774,6 +2774,7 @@ class Option(Parameter):
             show_default = ctx.show_default
 
         if show_default_is_str or (show_default and (default_value is not None)):
+            default_string = None
             if show_default_is_str:
                 default_string = f"({self.show_default})"
             elif isinstance(default_value, (list, tuple)):
@@ -2787,11 +2788,11 @@ class Option(Parameter):
                     (self.opts if self.default else self.secondary_opts)[0]
                 )[1]
             elif self.is_bool_flag and not self.secondary_opts and not default_value:
-                default_string = ""
+                default_string = None
             else:
                 default_string = str(default_value)
 
-            if default_string:
+            if default_string is not None:
                 extra.append(_("default: {default}").format(default=default_string))
 
         if (

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -745,6 +745,20 @@ def test_show_default_boolean_flag_name(runner, default, expect):
     assert f"[default: {expect}]" in message
 
 
+@pytest.mark.parametrize(("default", "expect"), [("", ""), ("value", "value")])
+def test_show_default_empty_string(runner, default, expect):
+    """When an empty string is set as a default value it will show the default value."""
+    opt = click.Option(
+        ("--string-option",),
+        type=str,
+        default=default,
+        show_default=True,
+    )
+    ctx = click.Context(click.Command("test"))
+    message = opt.get_help_record(ctx)[1]
+    assert f"[default: {expect}]" in message
+
+
 def test_show_true_default_boolean_flag_value(runner):
     """When a boolean flag only has one opt and its default is True,
     it will show the default value, not the opt name.


### PR DESCRIPTION
Use `None` instead of `""` to indicate that `default_string` is unset to allow for empty string defaults. 

https://github.com/pallets/click/issues/2500
- fixes #2500

New behavior:
<img width="643" alt="image" src="https://user-images.githubusercontent.com/53453358/235231361-893e9a47-fd85-4865-8ec1-285f6c79ddd6.png">


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
