### PR TITLE
Update dependencies using pip-compile-multi

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,13 +5,13 @@
 #
 #    pip-compile-multi
 #
-build==0.9.0
-    # via -r requirements/build.in
-packaging==23.0
+build==0.10.0
+    # via -r requirements\build.in
+colorama==0.4.6
     # via build
-pep517==0.13.0
+packaging==23.1
+    # via build
+pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
+    # via build

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,9 @@
 -r docs.txt
 -r tests.txt
 -r typing.txt
-build==0.9.0
+build==0.10.0
     # via pip-tools
-cachetools==5.2.0
+cachetools==5.3.0
     # via tox
 cfgv==3.3.1
     # via pre-commit
@@ -20,43 +20,41 @@ click==8.1.3
     # via
     #   pip-compile-multi
     #   pip-tools
-colorama==0.4.6
-    # via tox
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-identify==2.5.11
+identify==2.5.23
     # via pre-commit
 nodeenv==1.7.0
     # via pre-commit
-pep517==0.13.0
-    # via build
-pip-compile-multi==2.6.1
-    # via -r requirements/dev.in
-pip-tools==6.12.1
+pip-compile-multi==2.6.2
+    # via -r requirements\dev.in
+pip-tools==6.13.0
     # via pip-compile-multi
-platformdirs==2.6.2
+platformdirs==3.5.0
     # via
     #   tox
     #   virtualenv
-pre-commit==2.21.0
-    # via -r requirements/dev.in
-pyproject-api==1.2.1
+pre-commit==3.3.1
+    # via -r requirements\dev.in
+pyproject-api==1.5.1
     # via tox
+pyproject-hooks==1.0.0
+    # via build
 pyyaml==6.0
     # via pre-commit
-toposort==1.7
+toposort==1.10
     # via pip-compile-multi
-tox==4.1.0
-    # via -r requirements/dev.in
-virtualenv==20.17.1
+tox==4.5.1
+    # via -r requirements\dev.in
+virtualenv==20.23.0
     # via
     #   pre-commit
     #   tox
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,14 +5,16 @@
 #
 #    pip-compile-multi
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-babel==2.11.0
+babel==2.12.1
     # via sphinx
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
+colorama==0.4.6
+    # via sphinx
 docutils==0.18.1
     # via
     #   sphinx
@@ -23,48 +25,46 @@ imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
-packaging==22.0
+packaging==23.1
     # via
     #   pallets-sphinx-themes
     #   sphinx
-pallets-sphinx-themes==2.0.3
-    # via -r requirements/docs.in
-pygments==2.13.0
+pallets-sphinx-themes==2.1.0
+    # via -r requirements\docs.in
+pygments==2.15.1
     # via
     #   sphinx
     #   sphinx-tabs
-pytz==2022.7
-    # via babel
-requests==2.28.1
+requests==2.29.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.0.0
+sphinx==7.0.0
     # via
-    #   -r requirements/docs.in
+    #   -r requirements\docs.in
     #   pallets-sphinx-themes
     #   sphinx-issues
     #   sphinx-tabs
     #   sphinxcontrib-log-cabinet
 sphinx-issues==3.0.1
-    # via -r requirements/docs.in
+    # via -r requirements\docs.in
 sphinx-tabs==3.4.1
-    # via -r requirements/docs.in
-sphinxcontrib-applehelp==1.0.2
+    # via -r requirements\docs.in
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-log-cabinet==1.0.1
-    # via -r requirements/docs.in
+    # via -r requirements\docs.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.13
+urllib3==1.26.15
     # via requests

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,17 +5,17 @@
 #
 #    pip-compile-multi
 #
-attrs==22.2.0
+colorama==0.4.6
     # via pytest
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-packaging==22.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-pytest==7.2.0
-    # via -r requirements/tests.in
+pytest==7.3.1
+    # via -r requirements\tests.in
 tomli==2.0.1
     # via pytest

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -5,11 +5,11 @@
 #
 #    pip-compile-multi
 #
-mypy==1.2.0
-    # via -r requirements\typing.in
-mypy-extensions==1.0.0
+mypy==0.991
+    # via -r requirements/typing.in
+mypy-extensions==0.4.3
     # via mypy
 tomli==2.0.1
     # via mypy
-typing-extensions==4.5.0
+typing-extensions==4.4.0
     # via mypy

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -5,11 +5,11 @@
 #
 #    pip-compile-multi
 #
-mypy==0.991
-    # via -r requirements/typing.in
-mypy-extensions==0.4.3
+mypy==1.2.0
+    # via -r requirements\typing.in
+mypy-extensions==1.0.0
     # via mypy
 tomli==2.0.1
     # via mypy
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via mypy

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,4 +1,5 @@
 import sys
+from unittest import mock
 
 import pytest
 
@@ -86,9 +87,12 @@ def test_bytes_args(runner, monkeypatch):
         ), "UTF-8 encoded argument should be implicitly converted to Unicode"
 
     # Simulate empty locale environment variables
-    monkeypatch.setattr(sys.stdin, "encoding", "utf-8")
     monkeypatch.setattr(sys, "getfilesystemencoding", lambda: "utf-8")
     monkeypatch.setattr(sys, "getdefaultencoding", lambda: "utf-8")
+    # sys.stdin.encoding is readonly, needs some extra effort to patch.
+    stdin = mock.Mock(wraps=sys.stdin)
+    stdin.encoding = "utf-8"
+    monkeypatch.setattr(sys, "stdin", stdin)
 
     runner.invoke(
         from_bytes,


### PR DESCRIPTION
Description
========
At the moment, tests are failing in Python 3.12-dev due to DeprecationWarning. Updated versions using `pip-compile-multi` in order to fix to problem

Fixes #2489

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
