### PR TITLE
Hide default value when show_default is False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Unreleased
 -   Show the ``types.ParamType.name`` for ``types.Choice`` options within
     ``--help`` message if ``show_choices=False`` is specified.
     :issue:`2356`
+-   Do not display values in prompts when `show_default=False` on Options
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ Unreleased
 -   Show the ``types.ParamType.name`` for ``types.Choice`` options within
     ``--help`` message if ``show_choices=False`` is specified.
     :issue:`2356`
--   Do not display values in prompts when `show_default=False` on Options
+-   Do not display default values in prompts when `show_default=False` on options
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,8 @@ Unreleased
 -   Show the ``types.ParamType.name`` for ``types.Choice`` options within
     ``--help`` message if ``show_choices=False`` is specified.
     :issue:`2356`
--   Do not display default values in prompts when `show_default=False` on options
+-   Do not display default values in prompts when ``Option.show_default`` is
+    ``False``. :pr:`2509`
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2803,6 +2803,7 @@ class Option(Parameter):
             show_choices=self.show_choices,
             confirmation_prompt=self.confirmation_prompt,
             value_proc=lambda x: self.process_value(ctx, x),
+            show_default=(False if self.show_default is False else True),
         )
 
     def resolve_envvar_value(self, ctx: Context) -> str | None:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2795,6 +2795,12 @@ class Option(Parameter):
         if self.is_bool_flag:
             return confirm(self.prompt, default)
 
+        # If show_default is set to True/False, provide this to `prompt` as well. For
+        # non-bool values of `show_default`, we use `prompt`'s default behavior
+        prompt_kwargs: t.Any = {}
+        if type(self.show_default) is bool:
+            prompt_kwargs["show_default"] = self.show_default
+
         return prompt(
             self.prompt,
             default=default,
@@ -2803,7 +2809,7 @@ class Option(Parameter):
             show_choices=self.show_choices,
             confirmation_prompt=self.confirmation_prompt,
             value_proc=lambda x: self.process_value(ctx, x),
-            show_default=(False if self.show_default is False else True),
+            **prompt_kwargs,
         )
 
     def resolve_envvar_value(self, ctx: Context) -> str | None:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2798,7 +2798,7 @@ class Option(Parameter):
         # If show_default is set to True/False, provide this to `prompt` as well. For
         # non-bool values of `show_default`, we use `prompt`'s default behavior
         prompt_kwargs: t.Any = {}
-        if type(self.show_default) is bool:
+        if isinstance(self.show_default, bool):
             prompt_kwargs["show_default"] = self.show_default
 
         return prompt(

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -449,11 +449,12 @@ def test_confirmation_prompt(runner, prompt, input, default, expect):
         assert "Confirm Password: " in result.output
 
 
-def test_show_default_false_hides_prompt(runner):
+def test_false_show_default_cause_no_default_display_in_prompt(runner):
     @click.command()
     @click.option("--arg1", show_default=False, prompt=True, default="my-default-value")
     def cmd(arg1):
         pass
 
+    # Confirm that the default value is not included in the output when `show_default` is False
     result = runner.invoke(cmd, input="my-input", standalone_mode=False)
     assert "my-default-value" not in result.output

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -455,6 +455,7 @@ def test_false_show_default_cause_no_default_display_in_prompt(runner):
     def cmd(arg1):
         pass
 
-    # Confirm that the default value is not included in the output when `show_default` is False
+    # Confirm that the default value is not included in the output when `show_default`
+    # is False
     result = runner.invoke(cmd, input="my-input", standalone_mode=False)
     assert "my-default-value" not in result.output

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -447,3 +447,13 @@ def test_confirmation_prompt(runner, prompt, input, default, expect):
 
     if prompt == "Confirm Password":
         assert "Confirm Password: " in result.output
+
+
+def test_show_default_false_hides_prompt(runner):
+    @click.command()
+    @click.option("--arg1", show_default=False, prompt=True, default="my-default-value")
+    def cmd(arg1):
+        pass
+
+    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
+    assert "my-default-value" not in result.output


### PR DESCRIPTION
Previously, when `show_default` was False on an `Option`, the value could still appear in the prompt. Remove this so that sensitive values can be hidden from prompts.

Checklist:
- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
