### PR TITLE
Split generation of help extra items and rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Unreleased
     :issue:`2356`
 -   Do not display default values in prompts when ``Option.show_default`` is
     ``False``. :pr:`2509`
+-   Add ``get_help_extra`` method on ``Option`` to fetch the generated extra
+    items used in ``get_help_record`` to render help text. :issue:`2516`
+    :pr:`2517`
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2688,8 +2688,8 @@ class Option(Parameter):
 
         return ("; " if any_prefix_is_slash else " / ").join(rv), help
 
-    def get_help_extra(self, ctx: Context) -> dict[str, t.Any]:
-        extra: dict[str, t.Any] = {}
+    def get_help_extra(self, ctx: Context) -> types.OptionHelpExtra:
+        extra: types.OptionHelpExtra = {}
 
         if self.show_envvar:
             envvar = self.envvar

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2668,7 +2668,28 @@ class Option(Parameter):
             rv.append(_write_opts(self.secondary_opts))
 
         help = self.help or ""
-        extra = []
+
+        extra = self.get_help_extra(ctx)
+        extra_items = []
+        if "envvars" in extra:
+            extra_items.append(
+                _("env var: {var}").format(var=", ".join(extra["envvars"]))
+            )
+        if "default" in extra:
+            extra_items.append(_("default: {default}").format(default=extra["default"]))
+        if "range" in extra:
+            extra_items.append(extra["range"])
+        if "required" in extra:
+            extra_items.append(_(extra["required"]))
+
+        if extra_items:
+            extra_str = "; ".join(extra_items)
+            help = f"{help}  [{extra_str}]" if help else f"[{extra_str}]"
+
+        return ("; " if any_prefix_is_slash else " / ").join(rv), help
+
+    def get_help_extra(self, ctx: Context) -> dict[str, t.Any]:
+        extra: dict[str, t.Any] = {}
 
         if self.show_envvar:
             envvar = self.envvar
@@ -2682,12 +2703,10 @@ class Option(Parameter):
                     envvar = f"{ctx.auto_envvar_prefix}_{self.name.upper()}"
 
             if envvar is not None:
-                var_str = (
-                    envvar
-                    if isinstance(envvar, str)
-                    else ", ".join(str(d) for d in envvar)
-                )
-                extra.append(_("env var: {var}").format(var=var_str))
+                if isinstance(envvar, str):
+                    extra["envvars"] = (envvar,)
+                else:
+                    extra["envvars"] = tuple(str(d) for d in envvar)
 
         # Temporarily enable resilient parsing to avoid type casting
         # failing for the default. Might be possible to extend this to
@@ -2732,7 +2751,7 @@ class Option(Parameter):
                 default_string = str(default_value)
 
             if default_string:
-                extra.append(_("default: {default}").format(default=default_string))
+                extra["default"] = default_string
 
         if (
             isinstance(self.type, types._NumberRangeBase)
@@ -2742,16 +2761,12 @@ class Option(Parameter):
             range_str = self.type._describe_range()
 
             if range_str:
-                extra.append(range_str)
+                extra["range"] = range_str
 
         if self.required:
-            extra.append(_("required"))
+            extra["required"] = "required"
 
-        if extra:
-            extra_str = "; ".join(extra)
-            help = f"{help}  [{extra_str}]" if help else f"[{extra_str}]"
-
-        return ("; " if any_prefix_is_slash else " / ").join(rv), help
+        return extra
 
     @t.overload
     def get_default(

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1095,3 +1095,10 @@ BOOL = BoolParamType()
 
 #: A UUID parameter.
 UUID = UUIDParameterType()
+
+
+class OptionHelpExtra(t.TypedDict, total=False):
+    envvars: tuple[str, ...]
+    default: str
+    range: str
+    required: str


### PR DESCRIPTION
This:
- fixes #2516.

This is a small refactor of [the original `Option.get_help_record()` method](https://github.com/pallets/click/blob/main/src/click/core.py#L2708), splitting it in two to separate the generation of extra items in help screen and their rendering.

This PR:
- extracts from `get_help_record()` the [code responsible for extra items generation](https://github.com/pallets/click/blob/b0538dffe889ff5d03934927c31a9b71e5129848/src/click/core.py#L2735-L2792C3), and move it to its own `get_help_extra()` method
- leaves the original `get_help_record()` as-is, but rely on the new `get_help_extra()` method to fetch the extra items to render for the help
- makes the new `get_help_extra()` returns a dictionary of extra items to be rendered, so `get_help_record()` can pick them up to render (and translate) them the way it wants
- augments the original `get_help_record()` unittests to inspect values returned by `get_help_extra()` 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
