### PR TITLE
Annotate choices for Choice as Collection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`326`
+-   Use ``typing.Collection`` to annotate ``choices`` argument to ``Choice``. :pr:`2526`
 
 
 Version 8.1.4

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -398,7 +398,7 @@ What it looks like:
     println()
     invoke(digest, args=['--help'])
 
-Only pass the choices as list or tuple. Other iterables (like
+Only pass the choices as list, tuple or set. Other iterables (like
 generators) may lead to unexpected results.
 
 Choices work with options that have ``multiple=True``. If a ``default``

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -241,7 +241,7 @@ class Choice(ParamType):
 
     name = "choice"
 
-    def __init__(self, choices: t.Sequence[str], case_sensitive: bool = True) -> None:
+    def __init__(self, choices: t.Collection[str], case_sensitive: bool = True) -> None:
         self.choices = choices
         self.case_sensitive = case_sensitive
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -512,9 +512,17 @@ def test_missing_required_flag(runner):
     assert "Error: Missing option '--on'." in result.output
 
 
-def test_missing_choice(runner):
+@pytest.mark.parametrize(
+        "choices",
+        [
+            ["foo", "bar"],
+            ("foo", "bar"),
+            {"foo", "bar"},
+        ]
+)
+def test_missing_choice(runner, choices):
     @click.command()
-    @click.option("--foo", type=click.Choice(["foo", "bar"]), required=True)
+    @click.option("--foo", type=click.Choice(choices), required=True)
     def cmd(foo):
         click.echo(foo)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -513,12 +513,12 @@ def test_missing_required_flag(runner):
 
 
 @pytest.mark.parametrize(
-        "choices",
-        [
-            ["foo", "bar"],
-            ("foo", "bar"),
-            {"foo", "bar"},
-        ]
+    "choices",
+    [
+        ["foo", "bar"],
+        ("foo", "bar"),
+        {"foo", "bar"},
+    ],
 )
 def test_missing_choice(runner, choices):
     @click.command()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -131,12 +131,12 @@ def test_path_resolve_symlink(tmp_path, runner):
 
 
 @pytest.mark.parametrize(
-    ("choices" , "choice"),
+    ("choices", "choice"),
     [
         (["a", "b", "c"], "a"),
         ({"a", "b", "c"}, "a"),
         (("a", "b", "c"), "a"),
-    ]
+    ],
 )
 def test_choices_collections(choices, choice, runner):
     option = click.Option(["-a"], type=click.Choice(choices))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -128,3 +128,19 @@ def test_path_resolve_symlink(tmp_path, runner):
     rel_link.symlink_to(pathlib.Path("..") / "file")
     rel_rv = path_type.convert(os.fsdecode(rel_link), param, ctx)
     assert rel_rv == test_file_str
+
+
+@pytest.mark.parametrize(
+    ("choices" , "choice"),
+    [
+        (["a", "b", "c"], "a"),
+        ({"a", "b", "c"}, "a"),
+        (("a", "b", "c"), "a"),
+    ]
+)
+def test_choices_collections(choices, choice, runner):
+    option = click.Option(["-a"], type=click.Choice(choices))
+    cli = click.Command("cli", params=[option], callback=lambda a: a)
+    result = runner.invoke(cli, ["-a", choice], standalone_mode=False)
+    assert result.exception is None
+    assert result.return_value == choice


### PR DESCRIPTION
This PR changes type annotation for `choices` argument on `Choice` from `typing.Sequence[str]` to `typing.Collection[str]`. Additional tests using `list`, `tuple` and `set` were also added.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2525

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
