### PR TITLE
remove py2 compat from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,6 @@
 from pallets_sphinx_themes import get_version
 from pallets_sphinx_themes import ProjectLink
 
-import click._compat
-
-# compat until pallets-sphinx-themes is updated
-click._compat.text_type = str
-
 # Project --------------------------------------------------------------
 
 project = "Click"


### PR DESCRIPTION
Following the new release of `pallets-sphinx-themes 2.1.1`, we can get rid of a compatibility workaround.

- fixes https://github.com/pallets/pallets-sphinx-themes/pull/69

### Checklist

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
