### PR TITLE
Fix tests for python 3.12.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,6 +9,9 @@ extend-select =
 extend-ignore =
     # slice notation whitespace, invalid
     E203
+    # Formatting expects whitespace after colon, this
+    # would cause a lot of changes
+    E231
     # line length, handled by bugbear B950
     E501
     # bare except, handled by bugbear B001
@@ -23,3 +26,10 @@ max-line-length = 80
 per-file-ignores =
     # __init__ exports names
     src/click/__init__.py: F401
+
+    # Format strings causing E702, invalid
+    src/click/termui.py: E702
+
+exclude =
+  .tox
+  build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,6 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear
-          - flake8-implicit-str-concat
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -66,3 +66,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 urllib3==2.0.2
     # via requests
+setuptools
+    # Necessary for pkg_resources to be available for python 3.12

--- a/tox.ini
+++ b/tox.ini
@@ -5,18 +5,28 @@ envlist =
     style
     typing
     docs
+    flake8
 skip_missing_interpreters = true
 
 [testenv]
 package = wheel
 wheel_build_env = .pkg
 deps = -r requirements/tests.txt
-commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
+commands = pytest -v -W ignore::DeprecationWarning --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:style]
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
+
+[testenv:flake8]
+skip_install = true
+deps =
+    flake8
+    flake8-bugbear
+    flake8-implicit-str-concat
+commands =
+    flake8
 
 [testenv:typing]
 package = wheel


### PR DESCRIPTION
- flake8 moved out of pre-commit run, instead added to tox. In pre-commit it was running on more files than what is in the main repo.
- Docs test was failing in 3.12 because it was failing to find pkg_resources. Adding setuptools fixed the issue.
- Pytest was showing a lot of deprecation warnings, those have been cleaned up by how pytest is run.

- fixes #2524 

Checklist:

Changes were associated with how testing is run, no code changes were made.

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue. - Not applicable
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
