### PR TITLE
Update tests requirements to fix python 3.12 testing

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,9 +11,9 @@ iniconfig==2.0.0
     # via pytest
 packaging==23.1
     # via pytest
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
-pytest==7.3.1
+pytest==7.4.0
     # via -r requirements/tests.in
 tomli==2.0.1
     # via pytest


### PR DESCRIPTION
Python 3.12 was failing to run the py312 environment. The pytest version was 7.3.1. Updating to 7.4.0 fixed the issue.

- fixes #2524 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
