### PR TITLE
fix zsh completion loaded from fpath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 -   Improve responsiveness of ``click.clear()``. :issue:`2284`
 -   Improve command name detection when using Shiv or PEX. :issue:`2332`
 -   Avoid showing empty lines if command help text is empty. :issue:`2368`
+-   ZSH completion script works when loaded from ``fpath``. :issue:`2344`.
 
 
 Version 8.1.3

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -157,7 +157,13 @@ _SOURCE_ZSH = """\
     fi
 }
 
-compdef %(complete_func)s %(prog_name)s;
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    %(complete_func)s "$@"
+else
+    # eval/source/. command, register function for later
+    compdef %(complete_func)s %(prog_name)s
+fi
 """
 
 _SOURCE_FISH = """\


### PR DESCRIPTION
When the ZSH completion script is placed in a directory on `fpath`, it expects to be called directly. Currently, the script only expects to be called with `eval`/`source`/`.`, registering the function to be called later. Look at the last item in `zsh_eval_context` to determine if the autoload mechanism is being used and call directly in that case.

fixes #2344 