### PR TITLE
allow `multiple=True` with flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Unreleased
     ``standalone_mode`` is disabled. :issue:`2380`
 -   ``@group.command`` does not fail if the group was created with a custom
     ``command_class``. :issue:`2416`
+-   ``multiple=True`` is allowed for flag options again and does not require
+    setting ``default=()``. :issue:`2246, 2292, 2295`
 
 
 Version 8.1.3

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2570,8 +2570,13 @@ class Option(Parameter):
             # flag if flag_value is set.
             self._flag_needs_value = flag_value is not None
 
+        self.default: t.Union[t.Any, t.Callable[[], t.Any]]
+
         if is_flag and default_is_missing and not self.required:
-            self.default: t.Union[t.Any, t.Callable[[], t.Any]] = False
+            if multiple:
+                self.default = ()
+            else:
+                self.default = False
 
         if flag_value is None:
             flag_value = not self.default
@@ -2621,9 +2626,6 @@ class Option(Parameter):
 
                 if self.is_flag:
                     raise TypeError("'count' is not valid with 'is_flag'.")
-
-            if self.multiple and self.is_flag:
-                raise TypeError("'multiple' is not valid with 'is_flag', use 'count'.")
 
     def to_info_dict(self) -> t.Dict[str, t.Any]:
         info_dict = super().to_info_dict()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -38,3 +38,24 @@ def test_nargs_plus_multiple(runner):
     result = runner.invoke(cli, [])
     assert not result.exception
     assert result.output.splitlines() == ["<1|2>", "<3|4>"]
+
+
+def test_multiple_flag_default(runner):
+    """Default default for flags when multiple=True should be empty tuple."""
+
+    @click.command
+    # flag due to secondary token
+    @click.option("-y/-n", multiple=True)
+    # flag due to is_flag
+    @click.option("-f", is_flag=True, multiple=True)
+    # flag due to flag_value
+    @click.option("-v", "v", flag_value=1, multiple=True)
+    @click.option("-q", "v", flag_value=-1, multiple=True)
+    def cli(y, f, v):
+        return y, f, v
+
+    result = runner.invoke(cli, standalone_mode=False)
+    assert result.return_value == ((), (), ())
+
+    result = runner.invoke(cli, ["-y", "-n", "-f", "-v", "-q"], standalone_mode=False)
+    assert result.return_value == ((True, False), (True,), (1, -1))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -911,10 +911,6 @@ def test_is_bool_flag_is_correctly_set(option, expected):
     [
         ({"count": True, "multiple": True}, "'count' is not valid with 'multiple'."),
         ({"count": True, "is_flag": True}, "'count' is not valid with 'is_flag'."),
-        (
-            {"multiple": True, "is_flag": True},
-            "'multiple' is not valid with 'is_flag', use 'count'.",
-        ),
     ],
 )
 def test_invalid_flag_combinations(runner, kwargs, message):


### PR DESCRIPTION
#2246 reported that `multiple=True` didn't work with flags since `default=()` was also required. I can't remember the original conversation around that, but instead of setting the default, #2248 made `multiple=True` with flags an error. Comments on the PR, as well as #2292 and #2295 reported that this broke valid uses.

This removes the error and instead sets `default=()` if `multiple=True` for flags. This works if the option is a flag due to a secondary token (`-y/-n`), `is_flag=True`, or `flag_value=value`.

fixes #2246
fixes #2292
fixes #2295