### PR TITLE
remove msys2 and app engine detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Unreleased
 -   Don't fail when writing filenames to streams with strict errors. Replace invalid
     bytes with the replacement character (``�``). :issue:`2395`
 -   Remove unnecessary attempt to detect MSYS2 environment. :issue:`2355`
+-   Remove outdated and unnecessary detection of App Engine environment. :pr:`2554`
 
 
 Version 8.1.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Unreleased
     ``cls`` parameter is used. :issue:`2294`
 -   Don't fail when writing filenames to streams with strict errors. Replace invalid
     bytes with the replacement character (``�``). :issue:`2395`
+-   Remove unnecessary attempt to detect MSYS2 environment. :issue:`2355`
 
 
 Version 8.1.3

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -7,11 +7,7 @@ import typing as t
 from weakref import WeakKeyDictionary
 
 CYGWIN = sys.platform.startswith("cygwin")
-# Determine local App Engine environment, per Google's own suggestion
-APP_ENGINE = "APPENGINE_RUNTIME" in os.environ and "Development/" in os.environ.get(
-    "SERVER_SOFTWARE", ""
-)
-WIN = sys.platform.startswith("win") and not APP_ENGINE
+WIN = sys.platform.startswith("win")
 auto_wrap_for_ansi: t.Optional[t.Callable[[t.TextIO], t.TextIO]] = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -7,12 +7,11 @@ import typing as t
 from weakref import WeakKeyDictionary
 
 CYGWIN = sys.platform.startswith("cygwin")
-MSYS2 = sys.platform.startswith("win") and ("GCC" in sys.version)
 # Determine local App Engine environment, per Google's own suggestion
 APP_ENGINE = "APPENGINE_RUNTIME" in os.environ and "Development/" in os.environ.get(
     "SERVER_SOFTWARE", ""
 )
-WIN = sys.platform.startswith("win") and not APP_ENGINE and not MSYS2
+WIN = sys.platform.startswith("win") and not APP_ENGINE
 auto_wrap_for_ansi: t.Optional[t.Callable[[t.TextIO], t.TextIO]] = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 


### PR DESCRIPTION
Remove a check added by #1393 trying to fix #1338. The check only accounted for MSYS2 environments that used GCC. #1135 was later merged that added detection for Windows consoles, which would have also addressed the issue. I confirmed that `click.echo` and `click.progressbar` continued to work with the MSYS2 check removed, for msys2 and cygwin environments (which Python sees as posix) and mingw-w64 (which Python sees as Windows). fixes #2355 

I also noticed that there was a check for Google App Engine. This check seems to be from when GAE still supported Python 2, and provided a special local dev server environment. The GAE standard environment sets different env vars now, and the local dev server appears to just run Python in Windows still (and is de-emphasized over running the usual `flask` dev server). I've removed that check as well.