### PR TITLE
completion doesn't fail with `expose_value=False`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Unreleased
 -   Remove outdated and unnecessary detection of App Engine environment. :pr:`2554`
 -   ``echo()`` does not fail when no streams are attached, such as with ``pythonw`` on
     Windows. :issue:`2415`
+-   Argument with ``expose_value=False`` do not cause completion to fail. :issue:`2336`
 
 
 Version 8.1.3

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -443,7 +443,8 @@ def _is_incomplete_argument(ctx: Context, param: Parameter) -> bool:
         return False
 
     assert param.name is not None
-    value = ctx.params[param.name]
+    # Will be None if expose_value is False.
+    value = ctx.params.get(param.name)
     return (
         param.nargs == -1
         or ctx.get_parameter_source(param.name) is not ParameterSource.COMMANDLINE


### PR DESCRIPTION
fixes #2336 