### PR TITLE
Fix decorator typing with _Decorator type alias

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: click
 
+Version 8.1.5
+-------------
+
+Unreleased
+
+- Fix type annotations on the option and argument decorators. :issue:`2558`
+
 Version 8.1.4
 -------------
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -21,7 +21,6 @@ if t.TYPE_CHECKING:
 R = t.TypeVar("R")
 T = t.TypeVar("T")
 _AnyCallable = t.Callable[..., t.Any]
-_Decorator: "te.TypeAlias" = t.Callable[[T], T]
 FC = t.TypeVar("FC", bound=t.Union[_AnyCallable, Command])
 
 
@@ -331,7 +330,7 @@ def _param_memo(f: t.Callable[..., t.Any], param: Parameter) -> None:
 
 def argument(
     *param_decls: str, cls: t.Optional[t.Type[Argument]] = None, **attrs: t.Any
-) -> _Decorator[FC]:
+) -> t.Callable[[FC], FC]:
     """Attaches an argument to the command.  All positional arguments are
     passed as parameter declarations to :class:`Argument`; all keyword
     arguments are forwarded unchanged (except ``cls``).
@@ -359,7 +358,7 @@ def argument(
 
 def option(
     *param_decls: str, cls: t.Optional[t.Type[Option]] = None, **attrs: t.Any
-) -> _Decorator[FC]:
+) -> t.Callable[[FC], FC]:
     """Attaches an option to the command.  All positional arguments are
     passed as parameter declarations to :class:`Option`; all keyword
     arguments are forwarded unchanged (except ``cls``).
@@ -385,7 +384,7 @@ def option(
     return decorator
 
 
-def confirmation_option(*param_decls: str, **kwargs: t.Any) -> _Decorator[FC]:
+def confirmation_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
     """Add a ``--yes`` option which shows a prompt before continuing if
     not passed. If the prompt is declined, the program will exit.
 
@@ -409,7 +408,7 @@ def confirmation_option(*param_decls: str, **kwargs: t.Any) -> _Decorator[FC]:
     return option(*param_decls, **kwargs)
 
 
-def password_option(*param_decls: str, **kwargs: t.Any) -> _Decorator[FC]:
+def password_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
     """Add a ``--password`` option which prompts for a password, hiding
     input and asking to enter the value again for confirmation.
 
@@ -433,7 +432,7 @@ def version_option(
     prog_name: t.Optional[str] = None,
     message: t.Optional[str] = None,
     **kwargs: t.Any,
-) -> _Decorator[FC]:
+) -> t.Callable[[FC], FC]:
     """Add a ``--version`` option which immediately prints the version
     number and exits the program.
 
@@ -539,7 +538,7 @@ def version_option(
     return option(*param_decls, **kwargs)
 
 
-def help_option(*param_decls: str, **kwargs: t.Any) -> _Decorator[FC]:
+def help_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
     """Add a ``--help`` option which immediately prints the help page
     and exits the program.
 


### PR DESCRIPTION
`_Decorator[FC]` is identical to `t.Callable[[FC], FC]`. However, `mypy` currently reads the first type incorrectly and supports the second one fully.

This fix will make mypy checking work correctly on click decorators, and should have no negative impact on other type checkers because the types are effectively "the same".

- fixes #2558

I plan to open a bug report against `mypy` to ask about this issue. It may be a duplicate (https://github.com/python/mypy/issues/13250 ?), but we'll have a thread to pull on there to figure out why this isn't supported when there doesn't appear to be a meaningful difference between the two types.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.

I haven't added tests because any `mypy` testing will require some kind of new framework for testing types.
I think this would be valuable and not hard (e.g. [here's some prior art in marshmallow](https://github.com/marshmallow-code/marshmallow/blob/c5ba8012320f6c1d972d1b048f30728755c84d49/tox.ini#L13-L15) which I helped setup), but it's beyond the scope of a small typing fix.

Instead, I tested `mypy` v1.4.1 (latest) before and after this change on the following small sample:
```python
from click import option

def foo(a: int) -> str:
    return str(a)

reveal_type(option)
foo = option()(foo)
reveal_type(foo)
```

Before the change:
```
$ mypy click_example.py 
click_example.py:8: note: Revealed type is "def [FC <: Union[def (*Any, **Any) -> Any, click.core.Command]] (*param_decls: builtins.str, *, cls: Union[Type[click.core.Option], None] =, **attrs: Any) -> def (FC`-1) -> FC`-1"
click_example.py:9: error: Argument 1 has incompatible type "Callable[[int], str]"; expected <nothing>  [arg-type]
click_example.py:10: note: Revealed type is "<nothing>"
Found 1 error in 1 file (checked 1 source file)
```

After the change:
```
$ mypy click_example.py
click_example.py:8: note: Revealed type is "def (*param_decls: builtins.str, *, cls: Union[Type[click.core.Option], None] =, **attrs: Any) -> def [FC <: Union[def (*Any, **Any) -> Any, click.core.Command]] (FC`-1) -> FC`-1"
click_example.py:10: note: Revealed type is "def (a: builtins.int) -> builtins.str"
Success: no issues found in 1 source file
```

- [x] (N/A) Add or update relevant docs, in the docs folder and in code.

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.

I added a changelog section for 8.1.5 since this is the first change after 8.1.4. I'm happy to make tweaks and changes if this was not appropriate.

- [x] (N/A) Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.