### PR TITLE
Deduplicate `--help` option definition

### DIFF
--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -19,6 +19,7 @@ from .decorators import command as command
 from .decorators import confirmation_option as confirmation_option
 from .decorators import group as group
 from .decorators import help_option as help_option
+from .decorators import HelpOption as HelpOption
 from .decorators import make_pass_decorator as make_pass_decorator
 from .decorators import option as option
 from .decorators import pass_context as pass_context

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1285,25 +1285,19 @@ class Command(BaseCommand):
         return list(all_names)
 
     def get_help_option(self, ctx: Context) -> t.Optional["Option"]:
-        """Returns the help option object."""
+        """Returns the help option object.
+
+        Unless ``add_help_option`` is ``False``.
+        """
         help_options = self.get_help_option_names(ctx)
 
         if not help_options or not self.add_help_option:
             return None
 
-        def show_help(ctx: Context, param: "Parameter", value: str) -> None:
-            if value and not ctx.resilient_parsing:
-                echo(ctx.get_help(), color=ctx.color)
-                ctx.exit()
+        # Avoid circular import.
+        from .decorators import HelpOption
 
-        return Option(
-            help_options,
-            is_flag=True,
-            is_eager=True,
-            expose_value=False,
-            callback=show_help,
-            help=_("Show this message and exit."),
-        )
+        return HelpOption(help_options)
 
     def make_parser(self, ctx: Context) -> OptionParser:
         """Creates the underlying option parser for this command."""

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -1,7 +1,7 @@
-from collections import abc
 import inspect
 import types
 import typing as t
+from collections import abc
 from functools import update_wrapper
 from gettext import gettext as _
 
@@ -530,7 +530,7 @@ class HelpOption(Option):
 
     def __init__(
         self,
-        param_decls: abc.Sequence[str] | None = None,
+        param_decls: t.Optional[abc.Sequence[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         if not param_decls:

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -1,7 +1,6 @@
 import inspect
 import types
 import typing as t
-from collections import abc
 from functools import update_wrapper
 from gettext import gettext as _
 
@@ -530,7 +529,7 @@ class HelpOption(Option):
 
     def __init__(
         self,
-        param_decls: t.Optional[abc.Sequence[str]] = None,
+        param_decls: t.Optional[t.Sequence[str]] = None,
         **kwargs: t.Any,
     ) -> None:
         if not param_decls:


### PR DESCRIPTION
Just stumbled upon an opportunity to deduplicate the code producing the default `--help` option across Click code.

Should I create a specific issue for that PR?

As this is just a refactor, I did not mentioned this into the changelog or docs.

The current tests demonstrates this PR does not introduce regressions.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
