### PR TITLE
Fix `group` overload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 8.1.6
 
 Unreleased
 
+-   Fix an issue with type hints for ``@click.group()``. :issue:`2558`
+
 
 Version 8.1.5
 -------------

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -271,15 +271,11 @@ def group(
 
 
 # variant: name omitted, cls _must_ be a keyword argument, @group(cmd=GroupCls, ...)
-# The _correct_ way to spell this overload is to use keyword-only argument syntax:
-# def group(*, cls: t.Type[GrpType], **attrs: t.Any) -> ...
-# However, mypy thinks this doesn't fit the overloaded function. Pyright does
-# accept that spelling, and the following work-around makes pyright issue a
-# warning that GrpType could be left unsolved, but mypy sees it as fine. *shrug*
 @t.overload
 def group(
     name: None = None,
-    cls: t.Type[GrpType] = ...,
+    *,
+    cls: t.Type[GrpType],
     **attrs: t.Any,
 ) -> t.Callable[[_AnyCallable], GrpType]:
     ...

--- a/tests/typing/typing_group_kw_options.py
+++ b/tests/typing/typing_group_kw_options.py
@@ -1,0 +1,11 @@
+from typing_extensions import assert_type
+
+import click
+
+
+@click.group(context_settings={})
+def hello() -> None:
+    pass
+
+
+assert_type(hello, click.Group)


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

Additional fixes for #2558 building on @tinche's PR :)

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

----

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
