### PR TITLE
Fix typo in options docs: here -> here's

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -564,7 +564,7 @@ current :class:`Context`, the current :class:`Parameter`, and the value.
 The context provides some useful features such as quitting the
 application and gives access to other already processed parameters.
 
-Here an example for a ``--version`` flag:
+Here's an example for a ``--version`` flag:
 
 .. click:example::
 


### PR DESCRIPTION
This PR updates a phrase in docs to read "Here's an example" instead of "Here an example"