### PR TITLE
completion(fish): add back ; as line endings in fish script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Fix issue with regex flags in shell completion. :issue:`2581`
 -   Bash version detection issues a warning instead of an error. :issue:`2574`
+-   Fix issue with completion script for Fish shell. :issue:`2567`
 
 
 Version 8.1.6

--- a/docs/shell-completion.rst
+++ b/docs/shell-completion.rst
@@ -62,7 +62,7 @@ program name. This uses ``foo-bar`` as an example.
 
         .. code-block:: fish
 
-            eval (env _FOO_BAR_COMPLETE=fish_source foo-bar)
+            _FOO_BAR_COMPLETE=fish_source foo-bar | source
 
         This is the same file used for the activation script method
         below. For Fish it's probably always easier to use that method.

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -167,25 +167,25 @@ fi
 """
 
 _SOURCE_FISH = """\
-function %(complete_func)s
+function %(complete_func)s;
     set -l response (env %(complete_var)s=fish_complete COMP_WORDS=(commandline -cp) \
-COMP_CWORD=(commandline -t) %(prog_name)s)
+COMP_CWORD=(commandline -t) %(prog_name)s);
 
-    for completion in $response
-        set -l metadata (string split "," $completion)
+    for completion in $response;
+        set -l metadata (string split "," $completion);
 
-        if test $metadata[1] = "dir"
-            __fish_complete_directories $metadata[2]
-        else if test $metadata[1] = "file"
-            __fish_complete_path $metadata[2]
-        else if test $metadata[1] = "plain"
-            echo $metadata[2]
-        end
-    end
-end
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
 
 complete --no-files --command %(prog_name)s --arguments \
-"(%(complete_func)s)"
+"(%(complete_func)s)";
 """
 
 


### PR DESCRIPTION
Adding back line ending which were removed in https://github.com/pallets/click/commit/bcd3faaaaf03933915394f6c24d4f06d22aa8a1d

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2567

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
