### PR TITLE
Replace bash shell completion version error with warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 8.1.7
 Unreleased
 
 -   Fix issue with regex flags in shell completion. :issue:`2581`
+-   Bash version detection issues a warning instead of an error. :issue:`2574`
 
 
 Version 8.1.6

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -301,7 +301,8 @@ class BashComplete(ShellComplete):
     name = "bash"
     source_template = _SOURCE_BASH
 
-    def _check_version(self) -> None:
+    @staticmethod
+    def _check_version() -> None:
         import subprocess
 
         output = subprocess.run(
@@ -313,15 +314,17 @@ class BashComplete(ShellComplete):
             major, minor = match.groups()
 
             if major < "4" or major == "4" and minor < "4":
-                raise RuntimeError(
+                echo(
                     _(
                         "Shell completion is not supported for Bash"
                         " versions older than 4.4."
-                    )
+                    ),
+                    err=True,
                 )
         else:
-            raise RuntimeError(
-                _("Couldn't detect Bash version, shell completion is not supported.")
+            echo(
+                _("Couldn't detect Bash version, shell completion is not supported."),
+                err=True,
             )
 
     def source(self) -> str:


### PR DESCRIPTION
Replaces instances of `raise RuntimeError(...)` with `echo(..., err=True)` in `_check_version()`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2574

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
