### PR TITLE
deprecate `OptionParser`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,16 @@ Unreleased
     commands. :issue:`2589`
 -   ``MultiCommand`` is deprecated. ``Group`` is the base class for all group
     commands. :issue:`2590`
+-   The current parser and related classes and methods, are deprecated.
+    :issue:`2205`
+
+    -   ``OptionParser`` and the ``parser`` module, which is a modified copy of
+        ``optparse`` in the standard library.
+    -   ``Context.protected_args`` is unneeded. ``Context.args`` contains any
+        remaining arguments while parsing.
+    -   ``Parameter.add_to_parser`` (on both ``Argument`` and ``Option``) is
+        unneeded. Parsing works directly without building a separate parser.
+    -   ``split_arg_string`` is moved from ``parser`` to ``shell_completion``.
 
 
 Version 8.1.7

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -34,7 +34,6 @@ from .exceptions import UsageError as UsageError
 from .formatting import HelpFormatter as HelpFormatter
 from .formatting import wrap_text as wrap_text
 from .globals import get_current_context as get_current_context
-from .parser import OptionParser as OptionParser
 from .termui import clear as clear
 from .termui import confirm as confirm
 from .termui import echo_via_pager as echo_via_pager
@@ -95,5 +94,16 @@ def __getattr__(name: str) -> object:
             stacklevel=2,
         )
         return _MultiCommand
+
+    if name == "OptionParser":
+        from .parser import _OptionParser
+
+        warnings.warn(
+            "'OptionParser' is deprecated and will be removed in Click 9.0. The"
+            " old parser is available in 'optparse'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _OptionParser
 
     raise AttributeError(name)

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from gettext import gettext as _
 
 from ._compat import term_len
-from .parser import split_opt
+from .parser import _split_opt
 
 # Can force a width.  This is used by the test system
 FORCED_WIDTH: t.Optional[int] = None
@@ -290,7 +290,7 @@ def join_options(options: t.Sequence[str]) -> t.Tuple[str, bool]:
     any_prefix_is_slash = False
 
     for opt in options:
-        prefix = split_opt(opt)[0]
+        prefix = _split_opt(opt)[0]
 
         if prefix == "/":
             any_prefix_is_slash = True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,8 @@
 import pytest
 
 import click
-from click.parser import OptionParser
-from click.parser import split_arg_string
+from click.parser import _OptionParser
+from click.shell_completion import split_arg_string
 
 
 @pytest.mark.parametrize(
@@ -20,13 +20,13 @@ def test_split_arg_string(value, expect):
 
 
 def test_parser_default_prefixes():
-    parser = OptionParser()
+    parser = _OptionParser()
     assert parser._opt_prefixes == {"-", "--"}
 
 
 def test_parser_collects_prefixes():
     ctx = click.Context(click.Command("test"))
-    parser = OptionParser(ctx)
+    parser = _OptionParser(ctx)
     click.Option("+p", is_flag=True).add_to_parser(parser, ctx)
     click.Option("!e", is_flag=True).add_to_parser(parser, ctx)
     assert parser._opt_prefixes == {"-", "--", "+", "!"}


### PR DESCRIPTION
The first step toward rewriting the parser #2205. The `parser` module, `OptionParser`, `Parameter.add_to_parser`, and `Context.protected_args` are all deprecated. Imports will show deprecation warnings.