### PR TITLE
remove suffixes from generated command name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Unreleased
 
 -   Enable deferred evaluation of annotations with
     ``from __future__ import annotations``. :pr:`2270`
+-   When generating a command's name from a decorated function's name, the
+    suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
+    :issue:`2322`
 
 
 Version 8.1.7

--- a/tests/test_command_decorators.py
+++ b/tests/test_command_decorators.py
@@ -1,3 +1,5 @@
+import pytest
+
 import click
 
 
@@ -69,3 +71,22 @@ def test_params_argument(runner):
     assert cli.params[1].name == "b"
     result = runner.invoke(cli, ["1", "2"])
     assert result.output == "1 2\n"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "init_data",
+        "init_data_command",
+        "init_data_cmd",
+        "init_data_group",
+        "init_data_grp",
+    ],
+)
+def test_generate_name(name: str) -> None:
+    def f():
+        pass
+
+    f.__name__ = name
+    f = click.command(f)
+    assert f.name == "init-data"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -249,7 +249,7 @@ def test_other_command_invoke_with_defaults(runner):
     result = runner.invoke(cli, standalone_mode=False)
     # invoke should type cast default values, str becomes int, empty
     # multiple should be empty tuple instead of None
-    assert result.return_value == ("other-cmd", 42, 15, ())
+    assert result.return_value == ("other", 42, 15, ())
 
 
 def test_invoked_subcommand(runner):


### PR DESCRIPTION
When generating a command's name from the function's name, the suffixes `_command`, `_cmd`, `_group`, and `_grp` are removed.

fixes #2322 