### PR TITLE
Fix colored output on Windows (#2606)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
     :issue:`2705`
 -   Show correct value for flag default when using ``default_map``.
     :issue:`2632`
+-   Fix ``click.echo(color=...)`` passing ``color`` to coloroma so it can be
+    forced on Windows. :issue:`2606`.
 
 
 Version 8.1.7

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -311,7 +311,7 @@ def echo(
             out = strip_ansi(out)
         elif WIN:
             if auto_wrap_for_ansi is not None:
-                file = auto_wrap_for_ansi(file)  # type: ignore
+                file = auto_wrap_for_ansi(file, color)  # type: ignore
             elif not color:
                 out = strip_ansi(out)
 


### PR DESCRIPTION
The `color` parameter of `echo()` was not passed to the `auto_wrap_for_ansi()` function that is used to wrap a stream with `colorama` on Windows. This PR fixes that. 
I did not add an entry to `CHANGES.rst` because there is no `8.1.8dev` version yet

- fixes #2606 


Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
