### PR TITLE
More robust check of bash version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Unreleased
     :issue:`2632`
 -   Fix ``click.echo(color=...)`` passing ``color`` to coloroma so it can be
     forced on Windows. :issue:`2606`.
-
+-   More robust bash version check, fixing problem on Windows with git-bash.
+    :issue:`2638`
 
 Version 8.1.7
 -------------

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -303,8 +303,8 @@ class BashComplete(ShellComplete):
 
     @staticmethod
     def _check_version() -> None:
-        import subprocess
         import shutil
+        import subprocess
 
         bash_exe = shutil.which("bash")
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -304,9 +304,12 @@ class BashComplete(ShellComplete):
     @staticmethod
     def _check_version() -> None:
         import subprocess
+        import shutil
+
+        bash_exe = shutil.which('bash')
 
         output = subprocess.run(
-            ["bash", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
+            [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
         )
         match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -306,7 +306,7 @@ class BashComplete(ShellComplete):
         import subprocess
         import shutil
 
-        bash_exe = shutil.which('bash')
+        bash_exe = shutil.which("bash")
 
         output = subprocess.run(
             [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -312,7 +312,8 @@ class BashComplete(ShellComplete):
             match = None
         else:
             output = subprocess.run(
-                [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
+                [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'],
+                stdout=subprocess.PIPE,
             )
             match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -308,10 +308,13 @@ class BashComplete(ShellComplete):
 
         bash_exe = shutil.which("bash")
 
-        output = subprocess.run(
-            [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
-        )
-        match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
+        if bash_exe is None:
+            match = None
+        else:
+            output = subprocess.run(
+                [bash_exe, "--norc", "-c", 'echo "${BASH_VERSION}"'], stdout=subprocess.PIPE
+            )
+            match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 
         if match is not None:
             major, minor = match.groups()


### PR DESCRIPTION
More robust check of bash version.

Specifically on windows with git-bash, where python is the normal windows python install

Also use `--norc` flag to avoid recursively loading .bashrc (which can happen when the click completion loading does not work properly)

Testing should not require any additional tests, but rather make sure to run the existing shell completion tests on multiple platforms, eg Linux, Mac, Windows. Or how do you otherwise recommend adding tests for this?

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2638

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
