### PR TITLE
Flush stderr at end of a CliRunner invocation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Unreleased
 -   When generating a command's name from a decorated function's name, the
     suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
     :issue:`2322`
+-   Ensure stderr is completely captured through CliRunner when writing using
+    non-click functions like print
 
 
 Version 8.1.7

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -437,6 +437,7 @@ class CliRunner:
                 if self.mix_stderr:
                     stderr = None
                 else:
+                    sys.stderr.flush()
                     stderr = outstreams[1].getvalue()  # type: ignore
 
         return Result(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import typing as t
 from io import BytesIO
 
 import pytest
@@ -300,11 +301,16 @@ def test_env():
     assert os.environ == env_orig
 
 
-def test_stderr():
+@pytest.mark.parametrize("method", ["click", "python"])
+def test_stderr(method: t.Literal["click", "python"]):
     @click.command()
     def cli_stderr():
-        click.echo("stdout")
-        click.echo("stderr", err=True)
+        if method == "click":
+            click.echo("stdout")
+            click.echo("stderr", err=True)
+        elif method == "python":
+            print("stdout")
+            print("stderr", file=sys.stderr)
 
     runner = CliRunner(mix_stderr=False)
 
@@ -325,7 +331,10 @@ def test_stderr():
 
     @click.command()
     def cli_empty_stderr():
-        click.echo("stdout")
+        if method == "click":
+            click.echo("stdout")
+        elif method == "python":
+            print("stdout")
 
     runner = CliRunner(mix_stderr=False)
 


### PR DESCRIPTION
Fixes 2647

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2647

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
