### PR TITLE
Make `click.Context` generic over `obj`

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -44,7 +44,13 @@ from .utils import make_str
 from .utils import PacifyFlushWrapper
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
+
     from .shell_completion import CompletionItem
+
+    ObjT = te.TypeVar("ObjT", default=t.Any)
+else:
+    ObjT = t.TypeVar("ObjT")
 
 F = t.TypeVar("F", bound="t.Callable[..., t.Any]")
 V = t.TypeVar("V")
@@ -158,7 +164,7 @@ class ParameterSource(enum.Enum):
     """Used a prompt to confirm a default or provide a value."""
 
 
-class Context:
+class Context(t.Generic[ObjT]):
     """The context is a special internal object that holds state relevant
     for the script execution at every single level.  It's normally invisible
     to commands unless they opt-in to getting access to it.
@@ -267,7 +273,7 @@ class Context:
         command: Command,
         parent: Context | None = None,
         info_name: str | None = None,
-        obj: t.Any | None = None,
+        obj: ObjT | None = None,
         auto_envvar_prefix: str | None = None,
         default_map: cabc.MutableMapping[str, t.Any] | None = None,
         terminal_width: int | None = None,
@@ -304,7 +310,7 @@ class Context:
             obj = parent.obj
 
         #: the user object stored.
-        self.obj: t.Any = obj
+        self.obj: ObjT | None = obj
         self._meta: dict[str, t.Any] = getattr(parent, "meta", {})
 
         #: A dictionary (-like object) with defaults for parameters.

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -13,7 +13,6 @@ from .utils import format_filename
 if t.TYPE_CHECKING:
     from .core import Command
     from .core import Context
-    from .core import ObjT
     from .core import Parameter
 
 

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -13,6 +13,7 @@ from .utils import format_filename
 if t.TYPE_CHECKING:
     from .core import Command
     from .core import Context
+    from .core import ObjT
     from .core import Parameter
 
 
@@ -64,7 +65,7 @@ class UsageError(ClickException):
 
     exit_code = 2
 
-    def __init__(self, message: str, ctx: Context | None = None) -> None:
+    def __init__(self, message: str, ctx: Context[t.Any] | None = None) -> None:
         super().__init__(message)
         self.ctx = ctx
         self.cmd: Command | None = self.ctx.command if self.ctx else None
@@ -113,7 +114,7 @@ class BadParameter(UsageError):
     def __init__(
         self,
         message: str,
-        ctx: Context | None = None,
+        ctx: Context[t.Any] | None = None,
         param: Parameter | None = None,
         param_hint: str | None = None,
     ) -> None:
@@ -149,7 +150,7 @@ class MissingParameter(BadParameter):
     def __init__(
         self,
         message: str | None = None,
-        ctx: Context | None = None,
+        ctx: Context[t.Any] | None = None,
         param: Parameter | None = None,
         param_hint: str | None = None,
         param_type: str | None = None,
@@ -215,7 +216,7 @@ class NoSuchOption(UsageError):
         option_name: str,
         message: str | None = None,
         possibilities: cabc.Sequence[str] | None = None,
-        ctx: Context | None = None,
+        ctx: Context[t.Any] | None = None,
     ) -> None:
         if message is None:
             message = _("No such option: {name}").format(name=option_name)
@@ -248,7 +249,7 @@ class BadOptionUsage(UsageError):
     """
 
     def __init__(
-        self, option_name: str, message: str, ctx: Context | None = None
+        self, option_name: str, message: str, ctx: Context[t.Any] | None = None
     ) -> None:
         super().__init__(message, ctx)
         self.option_name = option_name
@@ -264,9 +265,9 @@ class BadArgumentUsage(UsageError):
 
 
 class NoArgsIsHelpError(UsageError):
-    def __init__(self, ctx: Context) -> None:
-        self.ctx: Context
+    def __init__(self, ctx: Context[t.Any]) -> None:
         super().__init__(ctx.get_help(), ctx=ctx)
+        self.ctx: Context[t.Any]
 
     def show(self, file: t.IO[t.Any] | None = None) -> None:
         echo(self.format_message(), file=file, err=True, color=self.ctx.color)

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -41,7 +41,7 @@ def get_current_context(silent: bool = False) -> Context | None:
     return None
 
 
-def push_context(ctx: Context) -> None:
+def push_context(ctx: Context[t.Any]) -> None:
     """Pushes a new context to the current stack."""
     _local.__dict__.setdefault("stack", []).append(ctx)
 

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -38,6 +38,7 @@ from .exceptions import UsageError
 if t.TYPE_CHECKING:
     from .core import Argument as CoreArgument
     from .core import Context
+    from .core import ObjT
     from .core import Option as CoreOption
     from .core import Parameter as CoreParameter
 
@@ -118,7 +119,7 @@ def _split_opt(opt: str) -> tuple[str, str]:
     return first, opt[1:]
 
 
-def _normalize_opt(opt: str, ctx: Context | None) -> str:
+def _normalize_opt(opt: str, ctx: Context[ObjT] | None) -> str:
     if ctx is None or ctx.token_normalize_func is None:
         return opt
     prefix, opt = _split_opt(opt)
@@ -229,15 +230,15 @@ class _OptionParser:
     implement features that are implemented on a higher level (such as
     types or defaults).
 
-    :param ctx: optionally the :class:`~click.Context` where this parser
+    :param ctx: optionally the :class:`~click.Context[ObjT]` where this parser
                 should go with.
 
     .. deprecated:: 8.2
         Will be removed in Click 9.0.
     """
 
-    def __init__(self, ctx: Context | None = None) -> None:
-        #: The :class:`~click.Context` for this parser.  This might be
+    def __init__(self, ctx: Context[ObjT] | None = None) -> None:
+        #: The :class:`~click.Context[ObjT]` for this parser.  This might be
         #: `None` for some advanced use cases.
         self.ctx = ctx
         #: This controls how the parser deals with interspersed arguments.

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -10,6 +10,7 @@ from .core import Argument
 from .core import Command
 from .core import Context
 from .core import Group
+from .core import ObjT
 from .core import Option
 from .core import Parameter
 from .core import ParameterSource
@@ -17,7 +18,7 @@ from .utils import echo
 
 
 def shell_complete(
-    cli: Command,
+    cli: Command[ObjT],
     ctx_args: cabc.MutableMapping[str, t.Any],
     prog_name: str,
     complete_var: str,
@@ -217,7 +218,7 @@ class ShellComplete:
 
     def __init__(
         self,
-        cli: Command,
+        cli: Command[ObjT],
         ctx_args: cabc.MutableMapping[str, t.Any],
         prog_name: str,
         complete_var: str,
@@ -530,11 +531,11 @@ def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bo
 
 
 def _resolve_context(
-    cli: Command,
+    cli: Command[ObjT],
     ctx_args: cabc.MutableMapping[str, t.Any],
     prog_name: str,
     args: list[str],
-) -> Context:
+) -> Context[ObjT]:
     """Produce the context hierarchy starting with the command and
     traversing the complete arguments. This only follows the commands,
     it doesn't trigger input prompts or callbacks.


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2493 

This is backwards compatible, considering the type var will default to `Any` (as it is currently).

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
