### PR TITLE
Fix closing of callbacks on CLI exit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Unreleased
     the ``mix_stderr`` parameter in ``CliRunner``. :issue:`2522` :pr:`2523`
 -   ``Option.show_envvar`` now also shows environment variable in error messages.
     :issue:`2695` :pr:`2696`
+-   Force closing of context on CLI exits to fix missing callbacks invocation.
+    :pr:`2680`
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,8 +45,9 @@ Unreleased
     the ``mix_stderr`` parameter in ``CliRunner``. :issue:`2522` :pr:`2523`
 -   ``Option.show_envvar`` now also shows environment variable in error messages.
     :issue:`2695` :pr:`2696`
--   Force closing of context on CLI exits to fix missing callbacks invocation.
-    :pr:`2680`
+-   ``Context.close`` will be called on exit. This results in all
+    ``Context.call_on_close`` callbacks and context managers added via
+    ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
 
 
 Version 8.1.8

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -494,3 +494,8 @@ cleanup function.
             db.record_use()
             db.save()
             db.close()
+
+
+.. versionchanged:: 8.2 ``Context.call_on_close`` and context managers registered
+    via ``Context.with_resource`` will be closed when the CLI exits. These were
+    previously not called on exit.

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -699,7 +699,13 @@ class Context:
         raise Abort()
 
     def exit(self, code: int = 0) -> t.NoReturn:
-        """Exits the application with a given exit code."""
+        """Exits the application with a given exit code.
+
+        .. versionchanged:: 8.2
+            Force closing of callbacks registered with
+            :meth:`call_on_close` before exiting the CLI.
+        """
+        self.close()
         raise Exit(code)
 
     def get_usage(self) -> str:


### PR DESCRIPTION
This PR forces the context to close itself on CLI exits.

This makes sure all callbacks registered by invoked options are properly called whenever a `ctx.exit()` action is triggered. Which has the effect of preventing state leaks.

These leaks cannot be witness in standard CLI operations, because on `ctx.exit()` call, the OS process that is running the Python CLI will be destroyed.

Still, in unittests, these state leaks will leads to flaky and non-deterministic tests, as the `pytest`, `tox` or any other test framework will keep using the same Python interpreter. To demonstrate this, I implemented a unit test using loggers as a fixture, in addition to a generic unit test.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
