### PR TITLE
add FORWARD parameter type and stop parsing arguments when FORWARD is…

### DIFF
--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -54,6 +54,7 @@ from .types import DateTime as DateTime
 from .types import File as File
 from .types import FLOAT as FLOAT
 from .types import FloatRange as FloatRange
+from .types import FORWARD as FORWARD
 from .types import INT as INT
 from .types import IntRange as IntRange
 from .types import ParamType as ParamType
@@ -61,7 +62,6 @@ from .types import Path as Path
 from .types import STRING as STRING
 from .types import Tuple as Tuple
 from .types import UNPROCESSED as UNPROCESSED
-from .types import FORWARD as FORWARD
 from .types import UUID as UUID
 from .utils import echo as echo
 from .utils import format_filename as format_filename

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -61,6 +61,7 @@ from .types import Path as Path
 from .types import STRING as STRING
 from .types import Tuple as Tuple
 from .types import UNPROCESSED as UNPROCESSED
+from .types import FORWARD as FORWARD
 from .types import UUID as UUID
 from .utils import echo as echo
 from .utils import format_filename as format_filename

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -329,7 +329,7 @@ class _OptionParser:
                 return True
             if not largs:
                 break
-            largs = largs[args.nargs:]
+            largs = largs[args.nargs :]
         return False
 
     def _process_args_for_options(self, state: _ParsingState) -> None:

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -201,6 +201,18 @@ class UnprocessedParamType(ParamType):
         return "UNPROCESSED"
 
 
+class ForwardParamType(ParamType):
+    name = "text"
+
+    def convert(
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
+    ) -> t.Any:
+        return value
+
+    def __repr__(self) -> str:
+        return "FORWARD"
+
+
 class StringParamType(ParamType):
     name = "text"
 
@@ -1070,6 +1082,10 @@ def convert_type(ty: t.Any | None, default: t.Any | None = None) -> ParamType:
 #:
 #: .. versionadded:: 4.0
 UNPROCESSED = UnprocessedParamType()
+
+#: A dummy parameter type that just does nothing except stops parsing options
+#: and arguments when this argument is getting parsed.
+FORWARD = ForwardParamType()
 
 #: A unicode string parameter type which is the implicit default.  This
 #: can also be selected by using ``str`` as type.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -332,7 +332,7 @@ def test_forward_options(runner):
 
     args = ["echo", "-foo", "bar", "-f", "-h", "--help"]
     result = runner.invoke(cmd, args)
-    assert result.output.splitlines() == [''] + args
+    assert result.output.splitlines() == [""] + args
 
 
 def test_forward_options_group(runner):
@@ -351,12 +351,21 @@ def test_forward_options_group(runner):
         for dst in dsts:
             click.echo(dst)
 
-
-    result = runner.invoke(cmd, ["-f", "f", "cp", "-a", "a", "src", "dst1",
-                                 "-a", "dst2", "-h", "--help", "-f"])
-    assert result.output.splitlines() == ["f", "a", "src", "dst1", "-a", "dst2",
-                                          "-h", "--help", "-f"]
-
+    result = runner.invoke(
+        cmd,
+        ["-f", "f", "cp", "-a", "a", "src", "dst1", "-a", "dst2", "-h", "--help", "-f"],
+    )
+    assert result.output.splitlines() == [
+        "f",
+        "a",
+        "src",
+        "dst1",
+        "-a",
+        "dst2",
+        "-h",
+        "--help",
+        "-f",
+    ]
 
 
 @pytest.mark.parametrize("doc", ["CLI HELP", None])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -321,6 +321,44 @@ def test_unprocessed_options(runner):
     ]
 
 
+def test_forward_options(runner):
+    @click.command()
+    @click.option("-f")
+    @click.argument("files", nargs=-1, type=click.FORWARD)
+    def cmd(f, files):
+        click.echo(f)
+        for filename in files:
+            click.echo(filename)
+
+    args = ["echo", "-foo", "bar", "-f", "-h", "--help"]
+    result = runner.invoke(cmd, args)
+    assert result.output.splitlines() == [''] + args
+
+
+def test_forward_options_group(runner):
+    @click.group()
+    @click.option("-f")
+    def cmd(f):
+        click.echo(f)
+
+    @cmd.command()
+    @click.option("-a")
+    @click.argument("src", nargs=1)
+    @click.argument("dsts", nargs=-1, type=click.FORWARD)
+    def cp(a, src, dsts):
+        click.echo(a)
+        click.echo(src)
+        for dst in dsts:
+            click.echo(dst)
+
+
+    result = runner.invoke(cmd, ["-f", "f", "cp", "-a", "a", "src", "dst1",
+                                 "-a", "dst2", "-h", "--help", "-f"])
+    assert result.output.splitlines() == ["f", "a", "src", "dst1", "-a", "dst2",
+                                          "-h", "--help", "-f"]
+
+
+
 @pytest.mark.parametrize("doc", ["CLI HELP", None])
 def test_deprecated_in_help_messages(runner, doc):
     @click.command(deprecated=True, help=doc)


### PR DESCRIPTION
This change introduces a new `click.FORWARD` argument type, which stops the parser from further parsing arguments. Is it now possible to forward arguments without any parsing. 
For example:

```
import click


@click.group()
@click.option("-v", "--verbose", is_flag=True)
def docker(verbose):
    pass


@docker.command()
@click.option("-v", "--verbose", is_flag=True)
@click.option("-u", "--user")
@click.argument("image")
@click.argument("command", nargs=-1, type=click.FORWARD)
def run(verbose, user, image, command):
    cmdline = ["docker"] + ([f"-u{user}"] if user else []) + ["run", image] + list(command)
    print(cmdline)


docker()
```

Allows for the following:

```
$ python ./docker.py -v run -u kamil alpine sh --help -u -v
['docker', '-ukamil', 'run', 'alpine', 'sh', '--help', '-u', '-v']
```

Issues:

- https://github.com/pallets/click/issues/1183
- https://github.com/pallets/click/issues/556
- https://github.com/pallets/click/issues/360
- https://github.com/pallets/click/issues/210
- https://github.com/pallets/click/issues/489
- https://stackoverflow.com/questions/42457484/python-click-consume-options-as-arguments

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
