### PR TITLE
add missing backticks in `format_filename` docs

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -410,7 +410,7 @@ def format_filename(
     with the replacement character ``�``.
 
     Invalid bytes or surrogate escapes will raise an error when written to a
-    stream with ``errors="strict". This will typically happen with ``stdout``
+    stream with ``errors="strict"``. This will typically happen with ``stdout``
     when the locale is something like ``en_GB.UTF-8``.
 
     Many scenarios *are* safe to write surrogates though, due to PEP 538 and


### PR DESCRIPTION
The missing backticks cause the following text up to the next double-backticks to be interpreted as inline code.

<!-- I removed the checklist from the template as I do not think it applies in this case --> 