### PR TITLE
Fix broken code example in docs under Advanced Patterns

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -435,6 +435,7 @@ defined as a context manager:
         def __enter__(self):
             path = os.path.join(self.home, "repo.db")
             self.db = open_database(path)
+            return self
 
         def __exit__(self, exc_type, exc_value, tb):
             self.db.close()


### PR DESCRIPTION
Fixes a broken code example in the Managing Resources section of Advanced Patterns.

- fixes #2707 