### PR TITLE
docs: Fix issue/pr extlinks in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,8 @@ autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 autodoc_preserve_defaults = True
 extlinks = {
-    "issue": ("https://github.com/pallets/flask/issues/%s", "#%s"),
-    "pr": ("https://github.com/pallets/flask/pull/%s", "#%s"),
+    "issue": ("https://github.com/pallets/click/issues/%s", "#%s"),
+    "pr": ("https://github.com/pallets/click/pull/%s", "#%s"),
 }
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),


### PR DESCRIPTION
Looks like there was a cut/paste typo in 525c5f1 a few weeks ago.

As a result the issue links in the change list link to the flask project rather than click, which caused me some confusion when I didn't immediately realise this was happening.