### PR TITLE
Fix printing of default option value to handle empty strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Fix an issue with type hints for ``click.open_file()``. :issue:`2717`
 -   Fix issue where error message for invalid ``click.Path`` displays on
     multiple lines. :issue:`2697`
+-   Fixed issue that prevented a default value of ``""`` from being displayed in
+    the help for an option. :issue:`2500`
 
 
 Version 8.1.7

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2804,6 +2804,8 @@ class Option(Parameter):
                 )[1]
             elif self.is_bool_flag and not self.secondary_opts and not default_value:
                 default_string = ""
+            elif default_value == "":
+                default_string = '""'
             else:
                 default_string = str(default_value)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -786,6 +786,14 @@ def test_show_default_string(runner):
     assert "[default: (unlimited)]" in message
 
 
+def test_show_default_with_empty_string(runner):
+    """When show_default is True and default is set to an empty string."""
+    opt = click.Option(["--limit"], default="", show_default=True)
+    ctx = click.Context(click.Command("cli"))
+    message = opt.get_help_record(ctx)[1]
+    assert '[default: ""]' in message
+
+
 def test_do_not_show_no_default(runner):
     """When show_default is True and no default is set do not show None."""
     opt = click.Option(["--limit"], show_default=True)


### PR DESCRIPTION
Added an explicit check for the default value being an empty string to ensure that the default is displayed.

Fixes https://github.com/pallets/click/issues/2500
<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
