### PR TITLE
adjust type hint for filename parameter in open_file to also take an os.PathLike

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: click
 
+Version 8.1.8
+-------------
+
+Unreleased
+
+-   Fix an issue with type hints for ``click.open_file()``. :issue:`2717`
+
 Version 8.1.7
 -------------
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -353,7 +353,7 @@ def get_text_stream(
 
 
 def open_file(
-    filename: str,
+    filename: t.Union[str, "os.PathLike[str]"],
     mode: str = "r",
     encoding: t.Optional[str] = None,
     errors: t.Optional[str] = "strict",
@@ -374,7 +374,7 @@ def open_file(
         with open_file(filename) as f:
             ...
 
-    :param filename: The name of the file to open, or ``'-'`` for
+    :param filename: The name or Path of the file to open, or ``'-'`` for
         ``stdin``/``stdout``.
     :param mode: The mode in which to open the file.
     :param encoding: The encoding to decode or encode a file opened in


### PR DESCRIPTION
Underlying functions the parameter `filename` is passed to has the type `str | os.PathLike`, but `filename` accepts only `str`. Changed the `filename` type hint to reflect this so that type checking won't complain if, for example, a user passes in a `pathlib.Path`.

Closes #2717

Checklist:

- [x]  Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x]  Add or update relevant docs, in the docs folder and in code.
- [x]  Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x]  Add .. versionchanged:: entries in any relevant code docs.
- [x]  Run pre-commit hooks and fix any issues.
- [x]  Run pytest and tox, no tests failed.