### PR TITLE
Add functionality to hide the progress bar Issue #2609

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .vscode/
 .venv*/
 venv*/
+.env*/
+env*/
 __pycache__/
 dist/
 .coverage*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Unreleased
 -   ``Context.close`` will be called on exit. This results in all
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
+-   Allow users to hide progressbar output with ``show=False`` argument :issue:`2609`
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Unreleased
 -   ``Context.close`` will be called on exit. This results in all
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
--   Allow users to hide progressbar output with ``show=False`` argument :issue:`2609`
+-   Allow users to hide progressbar output with ``hidden=True`` argument :issue:`2609`
 
 
 Version 8.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Unreleased
 -   ``Context.close`` will be called on exit. This results in all
     ``Context.call_on_close`` callbacks and context managers added via
     ``Context.with_resource`` to be closed on exit as well. :pr:`2680`
--   Allow users to hide progressbar output with ``hidden=True`` argument :issue:`2609`
+-   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
 
 
 Version 8.1.8

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -234,15 +234,14 @@ class ProgressBar(t.Generic[V]):
     def render_progress(self) -> None:
         import shutil
 
+        if self.hidden:
+            return
+
         if not self._is_atty:
-            # Only output the label as it changes if the output is not a
-            # TTY. Use file=stderr if you expect to be piping stdout.
+            # Only output the label once if the output is not a TTY.
             if self._last_line != self.label:
                 self._last_line = self.label
                 echo(self.label, file=self.file, color=self.color)
-            return
-
-        if self.hidden:
             return
 
         buf = []

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -47,6 +47,7 @@ class ProgressBar(t.Generic[V]):
         empty_char: str = " ",
         bar_template: str = "%(bar)s",
         info_sep: str = "  ",
+        show: bool = True,
         show_eta: bool = True,
         show_percent: bool | None = None,
         show_pos: bool = False,
@@ -61,6 +62,7 @@ class ProgressBar(t.Generic[V]):
         self.empty_char = empty_char
         self.bar_template = bar_template
         self.info_sep = info_sep
+        self.show = show
         self.show_eta = show_eta
         self.show_percent = show_percent
         self.show_pos = show_pos
@@ -136,6 +138,8 @@ class ProgressBar(t.Generic[V]):
         return next(iter(self))
 
     def render_finish(self) -> None:
+        if not self.show:
+            return
         if self.is_hidden:
             return
         self.file.write(AFTER_BAR)
@@ -231,6 +235,9 @@ class ProgressBar(t.Generic[V]):
 
     def render_progress(self) -> None:
         import shutil
+
+        if not self.show:
+            return
 
         if self.is_hidden:
             # Only output the label as it changes if the output is not a

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -107,7 +107,7 @@ class ProgressBar(t.Generic[V]):
         self.max_width: int | None = None
         self.entered: bool = False
         self.current_item: V | None = None
-        self._is_hidden: bool = (not isatty(self.file)) | hidden
+        self._is_hidden = not isatty(self.file)
         self._last_line: str | None = None
 
     def __enter__(self) -> ProgressBar[V]:
@@ -139,6 +139,8 @@ class ProgressBar(t.Generic[V]):
 
     def render_finish(self) -> None:
         if self._is_hidden:
+            return
+        if self.hidden:
             return
         self.file.write(AFTER_BAR)
         self.file.flush()
@@ -240,6 +242,8 @@ class ProgressBar(t.Generic[V]):
             if self._last_line != self.label:
                 self._last_line = self.label
                 echo(self.label, file=self.file, color=self.color)
+            return
+        if self.hidden:
             return
 
         buf = []

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -107,7 +107,7 @@ class ProgressBar(t.Generic[V]):
         self.max_width: int | None = None
         self.entered: bool = False
         self.current_item: V | None = None
-        self._is_hidden = not isatty(self.file)
+        self._is_hidden: bool = not isatty(self.file)
         self._last_line: str | None = None
 
     def __enter__(self) -> ProgressBar[V]:

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -364,8 +364,9 @@ def progressbar(
                    length.  If an iterable is not provided the progress bar
                    will iterate over a range of that length.
     :param label: the label to show next to the progress bar.
-    :param hidden: enables or disables the progress bar display.  This is
-                     automatically disabled.
+    :param hidden: hide the progressbar. Defaults to ``False``. When no tty is
+        detected, it will only print the progressbar label. Setting this to
+        ``False`` also disables that.
     :param show_eta: enables or disables the estimated time display.  This is
                      automatically disabled if the length cannot be
                      determined.
@@ -398,6 +399,9 @@ def progressbar(
     :param update_min_steps: Render only when this many updates have
         completed. This allows tuning for very fast iterators.
 
+    .. versionadded:: 8.2
+        The ``hidden`` argument.
+
     .. versionchanged:: 8.0
         Output is shown even if execution time is less than 0.5 seconds.
 
@@ -409,11 +413,10 @@ def progressbar(
         in 7.0 that removed all output.
 
     .. versionadded:: 8.0
-       Added the ``update_min_steps`` parameter.
+       The ``update_min_steps`` parameter.
 
-    .. versionchanged:: 4.0
-        Added the ``color`` parameter. Added the ``update`` method to
-        the object.
+    .. versionadded:: 4.0
+        The ``color`` parameter and ``update`` method.
 
     .. versionadded:: 2.0
     """

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -288,6 +288,7 @@ def progressbar(
     iterable: cabc.Iterable[V] | None = None,
     length: int | None = None,
     label: str | None = None,
+    show: bool = True,
     show_eta: bool = True,
     show_percent: bool | None = None,
     show_pos: bool = False,
@@ -363,6 +364,8 @@ def progressbar(
                    length.  If an iterable is not provided the progress bar
                    will iterate over a range of that length.
     :param label: the label to show next to the progress bar.
+    :param show: enables or disables the progress bar display.  This is
+                     automatically enable.
     :param show_eta: enables or disables the estimated time display.  This is
                      automatically disabled if the length cannot be
                      determined.
@@ -420,6 +423,7 @@ def progressbar(
     return ProgressBar(
         iterable=iterable,
         length=length,
+        show=show,
         show_eta=show_eta,
         show_percent=show_percent,
         show_pos=show_pos,

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -365,7 +365,7 @@ def progressbar(
                    will iterate over a range of that length.
     :param label: the label to show next to the progress bar.
     :param show: enables or disables the progress bar display.  This is
-                     automatically enable.
+                     automatically enabled.
     :param show_eta: enables or disables the estimated time display.  This is
                      automatically disabled if the length cannot be
                      determined.

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -288,7 +288,7 @@ def progressbar(
     iterable: cabc.Iterable[V] | None = None,
     length: int | None = None,
     label: str | None = None,
-    show: bool = True,
+    hidden: bool = False,
     show_eta: bool = True,
     show_percent: bool | None = None,
     show_pos: bool = False,
@@ -364,8 +364,8 @@ def progressbar(
                    length.  If an iterable is not provided the progress bar
                    will iterate over a range of that length.
     :param label: the label to show next to the progress bar.
-    :param show: enables or disables the progress bar display.  This is
-                     automatically enabled.
+    :param hidden: enables or disables the progress bar display.  This is
+                     automatically disabled.
     :param show_eta: enables or disables the estimated time display.  This is
                      automatically disabled if the length cannot be
                      determined.
@@ -423,7 +423,7 @@ def progressbar(
     return ProgressBar(
         iterable=iterable,
         length=length,
-        show=show,
+        hidden=hidden,
         show_eta=show_eta,
         show_percent=show_percent,
         show_pos=show_pos,

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -89,8 +89,8 @@ def test_progressbar_show(runner, monkeypatch):
             for _ in progress:
                 pass
 
-    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: False)
-    assert runner.invoke(cli, []).output == "working\n"
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    assert runner.invoke(cli, []).output == ""
 
 
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -82,6 +82,17 @@ def test_progressbar_hidden(runner, monkeypatch):
     assert runner.invoke(cli, []).output == "working\n"
 
 
+def test_progressbar_show(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with _create_progress() as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "show", lambda _: False)
+    assert runner.invoke(cli, []).output == ""
+
+
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])
 def test_progressbar_time_per_iteration(runner, avg, expected):
     with _create_progress(2, avg=avg) as progress:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -85,12 +85,12 @@ def test_progressbar_hidden(runner, monkeypatch):
 def test_progressbar_hidden_manual(runner, monkeypatch):
     @click.command()
     def cli():
-        with _create_progress(label="working", hidden=True) as progress:
+        with _create_progress(label="see nothing", hidden=True) as progress:
             for _ in progress:
                 pass
 
     monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
-    assert runner.invoke(cli, []).output == "working\n"
+    assert runner.invoke(cli, []).output == ""
 
 
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -85,11 +85,10 @@ def test_progressbar_hidden(runner, monkeypatch):
 def test_progressbar_show(runner, monkeypatch):
     @click.command()
     def cli():
-        with _create_progress() as progress:
+        with _create_progress(show=False) as progress:
             for _ in progress:
                 pass
 
-    monkeypatch.setattr(click._termui_impl, "show", lambda _: False)
     assert runner.invoke(cli, []).output == ""
 
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -85,10 +85,11 @@ def test_progressbar_hidden(runner, monkeypatch):
 def test_progressbar_show(runner, monkeypatch):
     @click.command()
     def cli():
-        with _create_progress(show=False) as progress:
+        with _create_progress(label="working", show=False) as progress:
             for _ in progress:
                 pass
 
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
     assert runner.invoke(cli, []).output == ""
 
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -82,15 +82,15 @@ def test_progressbar_hidden(runner, monkeypatch):
     assert runner.invoke(cli, []).output == "working\n"
 
 
-def test_progressbar_show(runner, monkeypatch):
+def test_progressbar_hidden_manual(runner, monkeypatch):
     @click.command()
     def cli():
-        with _create_progress(label="working", show=False) as progress:
+        with _create_progress(label="working", hidden=True) as progress:
             for _ in progress:
                 pass
 
     monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
-    assert runner.invoke(cli, []).output == ""
+    assert runner.invoke(cli, []).output == "working\n"
 
 
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -89,8 +89,8 @@ def test_progressbar_show(runner, monkeypatch):
             for _ in progress:
                 pass
 
-    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
-    assert runner.invoke(cli, []).output == ""
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: False)
+    assert runner.invoke(cli, []).output == "working\n"
 
 
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -71,7 +71,7 @@ def test_progressbar_length_hint(runner, monkeypatch):
     assert result.exception is None
 
 
-def test_progressbar_hidden(runner, monkeypatch):
+def test_progressbar_no_tty(runner, monkeypatch):
     @click.command()
     def cli():
         with _create_progress(label="working") as progress:


### PR DESCRIPTION
- Added "hidden" argument to click.progressbar to allow users to hide the progressbar output
- Added env to gitignore to match up with the CONTRIBUTING.rst directions
- Added test to verify "hidden" argument is behaving

fixes #2609