### PR TITLE
Prevent multiline error message on invalid path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 -   Fix issue where error message for invalid ``click.Path`` displays on
     multiple lines. :issue:`2697`
 
+
 Version 8.1.7
 -------------
 
@@ -17,6 +18,7 @@ Released 2023-08-17
 -   Fix issue with regex flags in shell completion. :issue:`2581`
 -   Bash version detection issues a warning instead of an error. :issue:`2574`
 -   Fix issue with completion script for Fish shell. :issue:`2567`
+
 
 Version 8.1.6
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 8.1.8
 Unreleased
 
 -   Fix an issue with type hints for ``click.open_file()``. :issue:`2717`
+-   Fix issue where error message for invalid ``click.Path`` displays on
+    multiple lines. :issue:`2697`
 
 Version 8.1.7
 -------------
@@ -15,7 +17,6 @@ Released 2023-08-17
 -   Fix issue with regex flags in shell completion. :issue:`2581`
 -   Bash version detection issues a warning instead of an error. :issue:`2574`
 -   Fix issue with completion script for Fish shell. :issue:`2567`
-
 
 Version 8.1.6
 -------------

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -892,7 +892,7 @@ class Path(ParamType):
                 )
             if not self.dir_okay and stat.S_ISDIR(st.st_mode):
                 self.fail(
-                    _("{name} '{filename}' is a directory.").format(
+                    _("{name} {filename!r} is a directory.").format(
                         name=self.name.title(), filename=format_filename(value)
                     ),
                     param,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import os.path
 import pathlib
+import platform
 import tempfile
 
 import pytest
@@ -234,6 +235,9 @@ def test_file_error_surrogates():
     assert message == "Could not open file '�': unknown error"
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Filepath syntax differences."
+)
 def test_invalid_path_with_esc_sequence():
     with pytest.raises(click.BadParameter) as exc_info:
         with tempfile.TemporaryDirectory(prefix="my\ndir") as tempdir:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -232,3 +232,12 @@ def test_file_surrogates(type, tmp_path):
 def test_file_error_surrogates():
     message = FileError(filename="\udcff").format_message()
     assert message == "Could not open file '�': unknown error"
+
+
+def test_path_type_with_esc_sequence():
+    with pytest.raises(click.BadParameter) as exc_info:
+        with tempfile.TemporaryDirectory(prefix=r"my\ndir") as tempdir:
+            click.Path(dir_okay=False, resolve_path=True).convert(tempdir, None, None)
+
+    expected = "my\\\\ndir"
+    assert expected in exc_info.value.message

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,6 @@
 import os.path
 import pathlib
+import platform
 import tempfile
 
 import pytest
@@ -234,10 +235,13 @@ def test_file_error_surrogates():
     assert message == "Could not open file '�': unknown error"
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Filepath syntax differences."
+)
 def test_path_type_with_esc_sequence():
     with pytest.raises(click.BadParameter) as exc_info:
         with tempfile.TemporaryDirectory(prefix=r"my\ndir") as tempdir:
-            click.Path(dir_okay=False, resolve_path=True).convert(tempdir, None, None)
+            click.Path(dir_okay=False).convert(tempdir, None, None)
 
     expected = "my\\\\ndir"
     assert expected in exc_info.value.message

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,5 @@
 import os.path
 import pathlib
-import platform
 import tempfile
 
 import pytest
@@ -235,13 +234,9 @@ def test_file_error_surrogates():
     assert message == "Could not open file '�': unknown error"
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Filepath syntax differences."
-)
 def test_invalid_path_with_esc_sequence():
     with pytest.raises(click.BadParameter) as exc_info:
-        with tempfile.TemporaryDirectory(prefix=r"my\ndir") as tempdir:
+        with tempfile.TemporaryDirectory(prefix="my\ndir") as tempdir:
             click.Path(dir_okay=False).convert(tempdir, None, None)
 
-    expected = "my\\\\ndir"
-    assert expected in exc_info.value.message
+    assert "my\\ndir" in exc_info.value.message

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -238,7 +238,7 @@ def test_file_error_surrogates():
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Filepath syntax differences."
 )
-def test_path_type_with_esc_sequence():
+def test_invalid_path_with_esc_sequence():
     with pytest.raises(click.BadParameter) as exc_info:
         with tempfile.TemporaryDirectory(prefix=r"my\ndir") as tempdir:
             click.Path(dir_okay=False).convert(tempdir, None, None)


### PR DESCRIPTION
Fixes an issue where an invalid `click.Path` parameter, which contains a `\n`, will result in an error that prints out on multiple lines.

fixes #2697
