### PR TITLE
fix color handling in test runner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
     multiple lines. :issue:`2697`
 -   Fixed issue that prevented a default value of ``""`` from being displayed in
     the help for an option. :issue:`2500`
+-   The test runner handles stripping color consistently on Windows.
+    :issue:`2705`
 
 
 Version 8.1.7

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -8,6 +8,7 @@ import tempfile
 import typing as t
 from types import TracebackType
 
+from . import _compat
 from . import formatting
 from . import termui
 from . import utils
@@ -315,6 +316,7 @@ class CliRunner:
         termui.hidden_prompt_func = hidden_input
         termui._getchar = _getchar
         utils.should_strip_ansi = should_strip_ansi  # type: ignore
+        _compat.should_strip_ansi = should_strip_ansi
 
         old_env = {}
         try:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,7 +5,6 @@ from io import BytesIO
 import pytest
 
 import click
-from click._compat import WIN
 from click.testing import CliRunner
 
 
@@ -184,7 +183,6 @@ def test_catch_exceptions():
     assert result.exit_code == 1
 
 
-@pytest.mark.skipif(WIN, reason="Test does not make sense on Windows.")
 def test_with_color():
     @click.command()
     def cli():


### PR DESCRIPTION
When using `CliRunner.invoke()`, the isolation function was not mocking `_compat.should_strip_ansi` 
in addition to the `utils.should_strip_ansi`. The `_compat ` version is only called when on Windows machines which is why it was missed. Also changed the `test_testing.py::test_with_color` to no longer skip when on windows. This will ensure that future changes to the `testing.py` modules will not cause a regression back to previous behavior.

fixes #2705 

Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- [x] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
