### PR TITLE
fix bug in show defaults when using a flag option and a default map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
     the help for an option. :issue:`2500`
 -   The test runner handles stripping color consistently on Windows.
     :issue:`2705`
+-   Show correct value for flag default when using ``default_map``.
+    :issue:`2632`
 
 
 Version 8.1.7

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2800,7 +2800,7 @@ class Option(Parameter):
                 # For boolean flags that have distinct True/False opts,
                 # use the opt without prefix instead of the value.
                 default_string = split_opt(
-                    (self.opts if self.default else self.secondary_opts)[0]
+                    (self.opts if default_value else self.secondary_opts)[0]
                 )[1]
             elif self.is_bool_flag and not self.secondary_opts and not default_value:
                 default_string = ""

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -59,3 +59,28 @@ def test_multiple_flag_default(runner):
 
     result = runner.invoke(cli, ["-y", "-n", "-f", "-v", "-q"], standalone_mode=False)
     assert result.return_value == ((True, False), (True,), (1, -1))
+
+
+def test_flag_default_map(runner):
+    """test flag with default map"""
+
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option("--name/--no-name", is_flag=True, show_default=True, help="name flag")
+    def foo(name):
+        click.echo(name)
+
+    result = runner.invoke(cli, ["foo"])
+    assert "False" in result.output
+
+    result = runner.invoke(cli, ["foo", "--help"])
+    assert "default: no-name" in result.output
+
+    result = runner.invoke(cli, ["foo"], default_map={"foo": {"name": True}})
+    assert "True" in result.output
+
+    result = runner.invoke(cli, ["foo", "--help"], default_map={"foo": {"name": True}})
+    assert "default: name" in result.output


### PR DESCRIPTION
In latest main, when a flag option is used with `show_default=True` and a `default_map` is passed, `--help` shows the default value in the decorator and not the value in the default map.

This PR does two things:

- Adds unit tests to demonstrate the bug
- Removes the bug from core

fixes #2632
