### PR TITLE
Add parametrized tests for `should_strip_ansi`

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,10 @@
-from click._compat import should_strip_ansi
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import click
 
 
 def test_is_jupyter_kernel_output():
@@ -7,4 +13,43 @@ def test_is_jupyter_kernel_output():
 
     # implementation detail, aka cheapskate test
     JupyterKernelFakeStream.__module__ = "ipykernel.faked"
-    assert not should_strip_ansi(stream=JupyterKernelFakeStream())
+    assert click._compat._is_jupyter_kernel_output(stream=JupyterKernelFakeStream())
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [None, sys.stdin, sys.stderr, sys.stdout],
+)
+@pytest.mark.parametrize(
+    ("color", "expected_override"),
+    [
+        (True, False),
+        (False, True),
+        (None, None),
+    ],
+)
+@pytest.mark.parametrize(
+    ("isatty", "is_jupyter", "expected"),
+    [
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+    ],
+)
+def test_should_strip_ansi(
+    monkeypatch,
+    stream,
+    color: bool | None,
+    expected_override: bool | None,
+    isatty: bool,
+    is_jupyter: bool,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(click._compat, "isatty", lambda x: isatty)
+    monkeypatch.setattr(
+        click._compat, "_is_jupyter_kernel_output", lambda x: is_jupyter
+    )
+
+    if expected_override is not None:
+        expected = expected_override
+    assert click._compat.should_strip_ansi(stream=stream, color=color) == expected


### PR DESCRIPTION
Issue #2606 described a inconsistency in how color=True works between Operating Systems. 
This is because ANSI styles can't always be applied to different terminals on windows. This did not cause issues when running it within the terminals because Colorama would change the ANSI style codes to escape codes for windows when it was required. However, if you were to pipe the `click.echo()` output to a file then the `should_strip_ansi` function would not work on Windows as the other operating systems. 

This is because the `auto_wrap_for_ansi` function was not being called with the color argument. After the `auto_wrap_for_ansi` function is called, it defaults `color=None` and will end up calling `should_strip_ansi` with `color=None` which is different from the original call to `should_strip_ansi` that was called before the wrapper function. 

By passing color to `auto_wrap_for_ansi`, then the behavior of `should_strip_ansi` becomes consistent.

An additional change applied within the PR is to the tests in `test_utils.py`. This is to increase test coverage for the different cases of `click.echo()` and removes the old version of the test. Instead of one test that mocks `isatty()`, there are now three different tests. One that mocks `isatty()=True` and `_is_jupyter_kernel_output()=False`, another that mocks `isatty()=False` and `_is_jupyter_kernel_output()=True` , and the last one mocks both `isatty()=False` and `_is_jupyter_kernel_output()=False`.

fixes #2606 

- [x] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
