### PR TITLE
Fix missing reset in isolation function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Unreleased
     :issue:`2452`
 -   Refactor code generating default ``--help`` option to deduplicate code.
     :pr:`2563`
+-   Test ``CLIRunner`` resets patched ``_compat.should_strip_ansi``.
+    :issue:`2732`
 
 
 Version 8.1.7

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -312,6 +312,7 @@ class CliRunner:
         old_hidden_prompt_func = termui.hidden_prompt_func
         old__getchar_func = termui._getchar
         old_should_strip_ansi = utils.should_strip_ansi  # type: ignore
+        old__compat_should_strip_ansi = _compat.should_strip_ansi
         termui.visible_prompt_func = visible_input
         termui.hidden_prompt_func = hidden_input
         termui._getchar = _getchar
@@ -346,6 +347,7 @@ class CliRunner:
             termui.hidden_prompt_func = old_hidden_prompt_func
             termui._getchar = old__getchar_func
             utils.should_strip_ansi = old_should_strip_ansi  # type: ignore
+            _compat.should_strip_ansi = old__compat_should_strip_ansi
             formatting.FORCED_WIDTH = old_forced_width
 
     def invoke(


### PR DESCRIPTION
Adds missing `_compat.should_strip_ansi` reset back to the original version of the function.

fixes #2732 

- [x] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
