### PR TITLE
Annotate type of `choices` parameter in `click.Choice` as `Collection` instead of `Sequence`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Unreleased
 -   When generating a command's name from a decorated function's name, the
     suffixes ``_command``, ``_cmd``, ``_group``, and ``_grp`` are removed.
     :issue:`2322`
+-   Made the accepted type of the ``choices`` parameter in ``click.Choice`` more generic. :pr:`2736`
 
 
 Version 8.1.7

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -247,7 +247,7 @@ class Choice(ParamType):
     name = "choice"
 
     def __init__(
-        self, choices: cabc.Sequence[str], case_sensitive: bool = True
+        self, choices: cabc.Collection[str], case_sensitive: bool = True
     ) -> None:
         self.choices = choices
         self.case_sensitive = case_sensitive


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->

`Sequence` inherits from `Collection`, and adds `__getitem__`, `__reversed__`, `index` and `count`. None of those methods are actually used by the `Choice` implementation, and switching to `Collection` makes other inputs, like sets and dict [`KeysView`](https://docs.python.org/3/library/collections.abc.html#collections.abc.KeysView), become valid.

From the [`collections.abc`](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) docs:

<table>
    <thead>
        <tr class="row-odd">
            <th class="head">
                <p>ABC</p>
            </th>
            <th class="head">
                <p>Inherits from</p>
            </th>
            <th class="head">
                <p>Abstract Methods</p>
            </th>
            <th class="head">
                <p>Mixin Methods</p>
            </th>
        </tr>
    </thead>
    <tbody>
        <tr class="row-even">
            <td>
                <p><a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Collection"
                        title="collections.abc.Collection"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Collection</span></code></a>
                    <a class="footnote-reference brackets"
                        href="https://docs.python.org/3/library/collections.abc.html#id18" id="id11"
                        role="doc-noteref"><span class="fn-bracket">[</span>1<span class="fn-bracket">]</span></a>
                </p>
            </td>
            <td>
                <p><a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Sized"
                        title="collections.abc.Sized"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Sized</span></code></a>,
                    <a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable"
                        title="collections.abc.Iterable"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Iterable</span></code></a>,
                    <a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Container"
                        title="collections.abc.Container"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Container</span></code></a>
                </p>
            </td>
            <td>
                <p><code class="docutils literal notranslate"><span class="pre">__contains__</span></code>,
                    <code class="docutils literal notranslate"><span class="pre">__iter__</span></code>,
                    <code class="docutils literal notranslate"><span class="pre">__len__</span></code>
                </p>
            </td>
            <td></td>
        </tr>
        <tr class="row-odd">
            <td>
                <p><a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence"
                        title="collections.abc.Sequence"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Sequence</span></code></a>
                </p>
            </td>
            <td>
                <p><a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Reversible"
                        title="collections.abc.Reversible"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Reversible</span></code></a>,
                    <a class="reference internal"
                        href="https://docs.python.org/3/library/collections.abc.html#collections.abc.Collection"
                        title="collections.abc.Collection"><code
                            class="xref py py-class docutils literal notranslate"><span class="pre">Collection</span></code></a>
                </p>
            </td>
            <td>
                <p><code class="docutils literal notranslate"><span class="pre">__getitem__</span></code>,
                    <code class="docutils literal notranslate"><span class="pre">__len__</span></code>
                </p>
            </td>
            <td>
                <p><code class="docutils literal notranslate"><span class="pre">__contains__</span></code>, <code
                        class="docutils literal notranslate"><span class="pre">__iter__</span></code>, <code
                        class="docutils literal notranslate"><span class="pre">__reversed__</span></code>,
                    <code class="docutils literal notranslate"><span class="pre">index</span></code>, and <code
                        class="docutils literal notranslate"><span class="pre">count</span></code>
                </p>
            </td>
        </tr>
    </tbody>
</table>

I can open an issue or a discussion if you think it's more appropriate.