### PR TITLE
ensure context `__exit__` is called during shell completion

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1127,7 +1127,7 @@ class Command:
 
         ctx = self.context_class(self, info_name=info_name, parent=parent, **extra)
 
-        with ctx.scope(cleanup=False):
+        with ctx:
             self.parse_args(ctx, args)
         return ctx
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -557,7 +557,9 @@ def _resolve_context(
                     if cmd is None:
                         return ctx
 
-                    with cmd.make_context(name, args, parent=ctx, resilient_parsing=True) as sub_ctx:
+                    with cmd.make_context(
+                        name, args, parent=ctx, resilient_parsing=True
+                    ) as sub_ctx:
                         args = sub_ctx._protected_args + sub_ctx.args
                         ctx = sub_ctx
                 else:

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -544,44 +544,43 @@ def _resolve_context(
     :param args: List of complete args before the incomplete value.
     """
     ctx_args["resilient_parsing"] = True
-    ctx = cli.make_context(prog_name, args.copy(), **ctx_args)
-    args = ctx._protected_args + ctx.args
+    with cli.make_context(prog_name, args.copy(), **ctx_args) as ctx:
+        args = ctx._protected_args + ctx.args
 
-    while args:
-        command = ctx.command
+        while args:
+            command = ctx.command
 
-        if isinstance(command, Group):
-            if not command.chain:
-                name, cmd, args = command.resolve_command(ctx, args)
-
-                if cmd is None:
-                    return ctx
-
-                ctx = cmd.make_context(name, args, parent=ctx, resilient_parsing=True)
-                args = ctx._protected_args + ctx.args
-            else:
-                sub_ctx = ctx
-
-                while args:
+            if isinstance(command, Group):
+                if not command.chain:
                     name, cmd, args = command.resolve_command(ctx, args)
 
                     if cmd is None:
                         return ctx
 
-                    sub_ctx = cmd.make_context(
-                        name,
-                        args,
-                        parent=ctx,
-                        allow_extra_args=True,
-                        allow_interspersed_args=False,
-                        resilient_parsing=True,
-                    )
-                    args = sub_ctx.args
+                    with cmd.make_context(name, args, parent=ctx, resilient_parsing=True) as sub_ctx:
+                        args = sub_ctx._protected_args + sub_ctx.args
+                        ctx = sub_ctx
+                else:
+                    sub_ctx = ctx
 
-                ctx = sub_ctx
-                args = [*sub_ctx._protected_args, *sub_ctx.args]
-        else:
-            break
+                    while args:
+                        name, cmd, args = command.resolve_command(ctx, args)
+
+                        if cmd is None:
+                            return ctx
+
+                        with cmd.make_context(
+                            name,
+                            args,
+                            parent=ctx,
+                            allow_extra_args=True,
+                            allow_interspersed_args=False,
+                            resilient_parsing=True,
+                        ) as sub_ctx:
+                            args = sub_ctx.args
+                            ctx = sub_ctx
+            else:
+                break
 
     return ctx
 


### PR DESCRIPTION
The necessary modifications will ensure that the context's `__exit__` function is called during shell completion, addressing the issue of unclosed file options.

fixes #2644