### PR TITLE
Added functionality to set flag_value correctly when using envvar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ Unreleased
 -   Add ``ProgressBar(hidden: bool)`` to allow hiding the progressbar. :issue:`2609`
 -   A ``UserWarning`` will be shown when multiple parameters attempt to use the
     same name. :issue:`2396``
+-   When using ``Option.envvar`` with ``Option.flag_value``, the ``flag_value``
+    will always be used instead of the value of the environment variable.
+    :issue:`2746` :pr:`2788`
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2430,15 +2430,19 @@ class Option(Parameter):
     :param hidden: hide this option from help outputs.
     :param attrs: Other command arguments described in :class:`Parameter`.
 
-    .. versionchanged:: 8.1.0
+    .. versionchanged:: 8.2
+        ``envvar`` used with ``flag_value`` will always use the ``flag_value``,
+        previously it would use the value of the environment variable.
+
+    .. versionchanged:: 8.1
         Help text indentation is cleaned here instead of only in the
         ``@option`` decorator.
 
-    .. versionchanged:: 8.1.0
+    .. versionchanged:: 8.1
         The ``show_default`` parameter overrides
         ``Context.show_default``.
 
-    .. versionchanged:: 8.1.0
+    .. versionchanged:: 8.1
         The default of a single option boolean flag is not shown if the
         default value is ``False``.
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2308,10 +2308,8 @@ class Parameter:
 
         if isinstance(self.envvar, str):
             rv = os.environ.get(self.envvar)
-            
+
             if rv:
-                if isinstance(self, Option) and self.is_flag and self.flag_value:
-                    return self.flag_value
                 return rv
         else:
             for envvar in self.envvar:
@@ -2866,6 +2864,8 @@ class Option(Parameter):
         rv = super().resolve_envvar_value(ctx)
 
         if rv is not None:
+            if self.is_flag and self.flag_value:
+                return str(self.flag_value)
             return rv
 
         if (

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2308,8 +2308,10 @@ class Parameter:
 
         if isinstance(self.envvar, str):
             rv = os.environ.get(self.envvar)
-
+            
             if rv:
+                if isinstance(self, Option) and self.is_flag and self.flag_value:
+                    return self.flag_value
                 return rv
         else:
             for envvar in self.envvar:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -197,6 +197,19 @@ def test_nargs_envvar(runner, nargs, value, expect):
     else:
         assert result.return_value == expect
 
+def test_envvar_flag_value(runner):
+    @click.command()
+    # is_flag is implicitly true
+    @click.option('--upper', flag_value='upper', envvar='UPPER')
+    def cmd(upper):
+        click.echo(upper)
+        return upper
+
+    # For whatever value of the `env` variable, if it exists, the flag should be `upper`
+    result = runner.invoke(cmd, env={"UPPER": "whatever"})
+    assert result.output.strip() == 'upper'
+
+    
 
 def test_nargs_envvar_only_if_values_empty(runner):
     @click.command()

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -197,19 +197,19 @@ def test_nargs_envvar(runner, nargs, value, expect):
     else:
         assert result.return_value == expect
 
+
 def test_envvar_flag_value(runner):
     @click.command()
     # is_flag is implicitly true
-    @click.option('--upper', flag_value='upper', envvar='UPPER')
+    @click.option("--upper", flag_value="upper", envvar="UPPER")
     def cmd(upper):
         click.echo(upper)
         return upper
 
     # For whatever value of the `env` variable, if it exists, the flag should be `upper`
     result = runner.invoke(cmd, env={"UPPER": "whatever"})
-    assert result.output.strip() == 'upper'
+    assert result.output.strip() == "upper"
 
-    
 
 def test_nargs_envvar_only_if_values_empty(runner):
     @click.command()


### PR DESCRIPTION
```python
@click.option('--upper', flag_value='upper', envvar='UPPER')
def cmd(upper):
    click.echo(upper)
    return upper
```

### Default use
The expectation of the above code when running `python cmd.py --upper` is to print to stdout `upper` (the flag value). This is default behaviour and works correctly.

### Environment variable use
What is the expectation when we run `UPPER=32 python cmd.py` ?

The program should still print to the screen `upper`, because that is the `flag_value` and there exists an env variable defined with the name `UPPER`, yet it actually prints `32`, the value of the environment variable, which i don't believe is intended.

*I also added a test for this functionality called `test_envvar_flag_value`*
fixes #2746 
