### PR TITLE
Expand `Choice` token normalization + make generic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,8 @@ Unreleased
     ``Option.default`` not needing to implement `__bool__`. :pr:`2829`
 -   Incorrect ``click.edit`` typing has been corrected. :pr:`2804`
 -   :class:``Choice`` is now generic and supports any iterable value.
-    This allows you to use enums and other non-``str`` values.
+    This allows you to use enums and other non-``str`` values. :pr:`2796`
+    :issue:`605`
 
 Version 8.1.8
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,13 +88,15 @@ Unreleased
     -   Parameters cannot be required nor prompted or an error is raised.
     -   A warning will be printed when something deprecated is used.
 
--   Add a ``catch_exceptions`` parameter to :class:`CliRunner`. If
-    ``catch_exceptions`` is not passed to :meth:`CliRunner.invoke`,
+-   Add a ``catch_exceptions`` parameter to :class:``CliRunner``. If
+    ``catch_exceptions`` is not passed to :meth:``CliRunner.invoke``,
     the value from :class:`CliRunner`. :issue:`2817` :pr:`2818`
 -   ``Option.flag_value`` will no longer have a default value set based on
     ``Option.default`` if ``Option.is_flag`` is ``False``. This results in
     ``Option.default`` not needing to implement `__bool__`. :pr:`2829`
 -   Incorrect ``click.edit`` typing has been corrected. :pr:`2804`
+-   :class:``Choice`` is now generic and supports any iterable value.
+    This allows you to use enums and other non-``str`` values.
 
 Version 8.1.8
 -------------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -381,7 +381,9 @@ Example:
 
 .. click:example::
 
-    class HashType:
+    import enum
+
+    class HashType(enum.Enum):
         MD5 = 'MD5'
         SHA1 = 'SHA1'
 
@@ -411,8 +413,8 @@ Choices work with options that have ``multiple=True``. If a ``default``
 value is given with ``multiple=True``, it should be a list or tuple of
 valid choices.
 
-Choices should be unique after considering the effects of
-``case_sensitive`` and any specified token normalization function.
+Choices should be unique after normalization, see
+:meth:`Choice.normalize_choice` for more info.
 
 .. versionchanged:: 7.1
     The resulting value from an option will always be one of the

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -375,15 +375,20 @@ In that case you can use :class:`Choice` type.  It can be instantiated
 with a list of valid values.  The originally passed choice will be returned,
 not the str passed on the command line.  Token normalization functions and
 ``case_sensitive=False`` can cause the two to be different but still match.
+:meth:`Choice.normalize_choice` for more info.
 
 Example:
 
 .. click:example::
 
+    class HashType:
+        MD5 = 'MD5'
+        SHA1 = 'SHA1'
+
     @click.command()
     @click.option('--hash-type',
-                  type=click.Choice(['MD5', 'SHA1'], case_sensitive=False))
-    def digest(hash_type):
+                  type=click.Choice(HashType, case_sensitive=False))
+    def digest(hash_type: HashType):
         click.echo(hash_type)
 
 What it looks like:
@@ -398,8 +403,9 @@ What it looks like:
     println()
     invoke(digest, args=['--help'])
 
-Only pass the choices as list or tuple. Other iterables (like
-generators) may lead to unexpected results.
+Since version 8.2.0 any iterable may be passed to :class:`Choice`, here
+an ``Enum`` is used which will result in all enum values to be valid
+choices.
 
 Choices work with options that have ``multiple=True``. If a ``default``
 value is given with ``multiple=True``, it should be a list or tuple of

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2192,11 +2192,11 @@ class Parameter:
         """
         return self.name  # type: ignore
 
-    def make_metavar(self) -> str:
+    def make_metavar(self, ctx: Context) -> str:
         if self.metavar is not None:
             return self.metavar
 
-        metavar = self.type.get_metavar(self)
+        metavar = self.type.get_metavar(param=self, ctx=ctx)
 
         if metavar is None:
             metavar = self.type.name.upper()
@@ -2775,7 +2775,7 @@ class Option(Parameter):
                 any_prefix_is_slash = True
 
             if not self.is_flag and not self.count:
-                rv += f" {self.make_metavar()}"
+                rv += f" {self.make_metavar(ctx=ctx)}"
 
             return rv
 
@@ -3056,10 +3056,10 @@ class Argument(Parameter):
             return self.metavar
         return self.name.upper()  # type: ignore
 
-    def make_metavar(self) -> str:
+    def make_metavar(self, ctx: Context) -> str:
         if self.metavar is not None:
             return self.metavar
-        var = self.type.get_metavar(self)
+        var = self.type.get_metavar(param=self, ctx=ctx)
         if not var:
             var = self.name.upper()  # type: ignore
         if self.deprecated:
@@ -3088,10 +3088,10 @@ class Argument(Parameter):
         return name, [arg], []
 
     def get_usage_pieces(self, ctx: Context) -> list[str]:
-        return [self.make_metavar()]
+        return [self.make_metavar(ctx)]
 
     def get_error_hint(self, ctx: Context) -> str:
-        return f"'{self.make_metavar()}'"
+        return f"'{self.make_metavar(ctx)}'"
 
     def add_to_parser(self, parser: _OptionParser, ctx: Context) -> None:
         parser.add_argument(dest=self.name, nargs=self.nargs, obj=self)

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -174,7 +174,9 @@ class MissingParameter(BadParameter):
 
         msg = self.message
         if self.param is not None:
-            msg_extra = self.param.type.get_missing_message(self.param)
+            msg_extra = self.param.type.get_missing_message(
+                param=self.param, ctx=self.ctx
+            )
             if msg_extra:
                 if msg:
                     msg += f". {msg_extra}"

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -250,7 +250,7 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
         tuple.
 
     .. versionadded:: 8.2.0
-        Choices are normalized via :meth:`normalize_choice`
+        Choice normalization can be overridden via :meth:`normalize_choice`.
     """
 
     name = "choice"

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -354,16 +354,12 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
 
         .. versionadded:: 8.2
         """
-        choices_str = ", ".join(self.normalized_mapping(ctx=ctx).values())
-        self.fail(
-            message=ngettext(
-                "{value!r} is not {choice}.",
-                "{value!r} is not one of {choices}.",
-                len(self.choices),
-            ).format(value=value, choice=choices_str, choices=choices_str),
-            param=value,
-            ctx=ctx,
-        )
+        choices_str = ", ".join(map(repr, self.normalized_mapping(ctx=ctx).values()))
+        return ngettext(
+            "{value!r} is not {choice}.",
+            "{value!r} is not one of {choices}.",
+            len(self.choices),
+        ).format(value=value, choice=choices_str, choices=choices_str)
 
     def __repr__(self) -> str:
         return f"Choice({list(self.choices)})"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -382,6 +382,32 @@ def test_choice_option(runner):
     assert "--method [foo|bar|baz]" in result.output
 
 
+def test_choice_option_normalization(runner):
+    @click.command()
+    @click.option(
+        "--method",
+        type=click.Choice(
+            ["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"]
+        ),
+    )
+    def cli(method):
+        click.echo(method)
+
+    result = runner.invoke(cli, ["--method=foo"])
+    assert not result.exception
+    assert result.output == "foo\n"
+
+    result = runner.invoke(cli, ["--method=meh"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '--method': 'meh' is not one of "
+        "'screaming-snake-case', 'snake-case', 'pascalcase', 'kebab-case'."
+    ) in result.output
+
+    result = runner.invoke(cli, ["--help"])
+    assert "--method [foo|bar|baz]" in result.output
+
+
 def test_choice_argument(runner):
     @click.command()
     @click.argument("method", type=click.Choice(["foo", "bar", "baz"]))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -387,25 +387,34 @@ def test_choice_option_normalization(runner):
     @click.option(
         "--method",
         type=click.Choice(
-            ["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"]
+            ["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"],
+            case_sensitive=False,
         ),
     )
     def cli(method):
         click.echo(method)
 
-    result = runner.invoke(cli, ["--method=foo"])
-    assert not result.exception
-    assert result.output == "foo\n"
+    result = runner.invoke(cli, ["--method=snake_case"])
+    assert not result.exception, result.output
+    assert result.output == "snake_case\n"
+
+    # Even though it's case sensitive, the choice's original value is preserved
+    result = runner.invoke(cli, ["--method=pascalcase"])
+    assert not result.exception, result.output
+    assert result.output == "PascalCase\n"
 
     result = runner.invoke(cli, ["--method=meh"])
     assert result.exit_code == 2
     assert (
         "Invalid value for '--method': 'meh' is not one of "
-        "'screaming-snake-case', 'snake-case', 'pascalcase', 'kebab-case'."
+        "'screaming_snake_case', 'snake_case', 'pascalcase', 'kebab-case'."
     ) in result.output
 
     result = runner.invoke(cli, ["--help"])
-    assert "--method [foo|bar|baz]" in result.output
+    assert (
+        "--method [screaming_snake_case|snake_case|pascalcase|kebab-case]"
+        in result.output
+    )
 
 
 def test_choice_argument(runner):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import enum
 import os
 from itertools import chain
 
@@ -382,41 +385,6 @@ def test_choice_option(runner):
     assert "--method [foo|bar|baz]" in result.output
 
 
-def test_choice_option_normalization(runner):
-    @click.command()
-    @click.option(
-        "--method",
-        type=click.Choice(
-            ["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"],
-            case_sensitive=False,
-        ),
-    )
-    def cli(method):
-        click.echo(method)
-
-    result = runner.invoke(cli, ["--method=snake_case"])
-    assert not result.exception, result.output
-    assert result.output == "snake_case\n"
-
-    # Even though it's case sensitive, the choice's original value is preserved
-    result = runner.invoke(cli, ["--method=pascalcase"])
-    assert not result.exception, result.output
-    assert result.output == "PascalCase\n"
-
-    result = runner.invoke(cli, ["--method=meh"])
-    assert result.exit_code == 2
-    assert (
-        "Invalid value for '--method': 'meh' is not one of "
-        "'screaming_snake_case', 'snake_case', 'pascalcase', 'kebab-case'."
-    ) in result.output
-
-    result = runner.invoke(cli, ["--help"])
-    assert (
-        "--method [screaming_snake_case|snake_case|pascalcase|kebab-case]"
-        in result.output
-    )
-
-
 def test_choice_argument(runner):
     @click.command()
     @click.argument("method", type=click.Choice(["foo", "bar", "baz"]))
@@ -436,6 +404,82 @@ def test_choice_argument(runner):
 
     result = runner.invoke(cli, ["--help"])
     assert "{foo|bar|baz}" in result.output
+
+
+def test_choice_argument_enum(runner):
+    class MyEnum(str, enum.Enum):
+        FOO = "foo-value"
+        BAR = "bar-value"
+        BAZ = "baz-value"
+
+    @click.command()
+    @click.argument("method", type=click.Choice(MyEnum, case_sensitive=False))
+    def cli(method: MyEnum):
+        assert isinstance(method, MyEnum)
+        click.echo(method)
+
+    result = runner.invoke(cli, ["foo"])
+    assert result.output == "foo-value\n"
+    assert not result.exception
+
+    result = runner.invoke(cli, ["meh"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '{foo|bar|baz}': 'meh' is not one of 'foo',"
+        " 'bar', 'baz'." in result.output
+    )
+
+    result = runner.invoke(cli, ["--help"])
+    assert "{foo|bar|baz}" in result.output
+
+
+def test_choice_argument_custom_type(runner):
+    class MyClass:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __str__(self) -> str:
+            return self.value
+
+    @click.command()
+    @click.argument(
+        "method", type=click.Choice([MyClass("foo"), MyClass("bar"), MyClass("baz")])
+    )
+    def cli(method: MyClass):
+        assert isinstance(method, MyClass)
+        click.echo(method)
+
+    result = runner.invoke(cli, ["foo"])
+    assert not result.exception
+    assert result.output == "foo\n"
+
+    result = runner.invoke(cli, ["meh"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '{foo|bar|baz}': 'meh' is not one of 'foo',"
+        " 'bar', 'baz'." in result.output
+    )
+
+    result = runner.invoke(cli, ["--help"])
+    assert "{foo|bar|baz}" in result.output
+
+
+def test_choice_argument_none(runner):
+    @click.command()
+    @click.argument(
+        "method", type=click.Choice(["not-none", None], case_sensitive=False)
+    )
+    def cli(method: str | None):
+        assert isinstance(method, str) or method is None
+        click.echo(method)
+
+    result = runner.invoke(cli, ["not-none"])
+    assert not result.exception
+    assert result.output == "not-none\n"
+
+    # None is not yet supported.
+    result = runner.invoke(cli, ["none"])
+    assert result.exception
 
 
 def test_datetime_option_default(runner):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -248,7 +248,7 @@ def test_formatting_usage_custom_help(runner):
 
 def test_formatting_custom_type_metavar(runner):
     class MyType(click.ParamType):
-        def get_metavar(self, param):
+        def get_metavar(self, param: click.Parameter, ctx: click.Context):
             return "MY_TYPE"
 
     @click.command("foo")

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -106,11 +106,11 @@ HELLO_GROUP = (
         ),
         pytest.param(*STRING_PARAM_TYPE, id="STRING ParamType"),
         pytest.param(
-            click.Choice(["a", "b"]),
+            click.Choice(("a", "b")),
             {
                 "param_type": "Choice",
                 "name": "choice",
-                "choices": ["a", "b"],
+                "choices": ("a", "b"),
                 "case_sensitive": True,
             },
             id="Choice ParamType",

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -17,12 +17,37 @@ def test_option_normalization(runner):
 
 def test_choice_normalization(runner):
     @click.command(context_settings=CONTEXT_SETTINGS)
-    @click.option("--choice", type=click.Choice(["Foo", "Bar"]))
-    def cli(choice):
-        click.echo(choice)
+    @click.option(
+        "--method",
+        type=click.Choice(
+            ["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"],
+            case_sensitive=False,
+        ),
+    )
+    def cli(method):
+        click.echo(method)
 
-    result = runner.invoke(cli, ["--CHOICE", "FOO"])
-    assert result.output == "Foo\n"
+    result = runner.invoke(cli, ["--METHOD=snake_case"])
+    assert not result.exception, result.output
+    assert result.output == "snake_case\n"
+
+    # Even though it's case sensitive, the choice's original value is preserved
+    result = runner.invoke(cli, ["--method=pascalcase"])
+    assert not result.exception, result.output
+    assert result.output == "PascalCase\n"
+
+    result = runner.invoke(cli, ["--method=meh"])
+    assert result.exit_code == 2
+    assert (
+        "Invalid value for '--method': 'meh' is not one of "
+        "'screaming_snake_case', 'snake_case', 'pascalcase', 'kebab-case'."
+    ) in result.output
+
+    result = runner.invoke(cli, ["--help"])
+    assert (
+        "--method [screaming_snake_case|snake_case|pascalcase|kebab-case]"
+        in result.output
+    )
 
 
 def test_command_normalization(runner):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -248,5 +248,5 @@ def test_invalid_path_with_esc_sequence():
 
 def test_choice_get_invalid_choice_message():
     choice = click.Choice(["a", "b", "c"])
-    message = choice.get_invalid_choice_message("d")
+    message = choice.get_invalid_choice_message("d", ctx=None)
     assert message == "'d' is not one of 'a', 'b', 'c'."


### PR DESCRIPTION
When looking into #2210, I wasn't sure it was a good idea to show an enum's name to the user. For example:

```python
class MyEnum(enum.Enum):
	ONE = 1
	TWO = 2
	THREE = 3
	ALSO_ONE = 1
```

Would result the following if an invalid value is shown:

```
Error: Invalid value for '{ONE|TWO|THREE|ALSO_ONE}': 'meh' is not one of ONE, TWO, THREE.
```

Though it's not uncommon practice to have kebab-case, imo it's the most convenient typing for the CLI. Then you'd ideally want the user to type `also-one` instead of `ALSO_ONE` or `also_one`.

I realised that we have [token normalization since 2.0](https://click.palletsprojects.com/en/stable/advanced/#token-normalization). I feel like this is not very obvious to users as we don't make the normalization transparent to the user.

```python
@click.option(
	"--method",
	type=click.Choice(
		["SCREAMING_SNAKE_CASE", "snake_case", "PascalCase", "kebab-case"]
	)
)
```

Would in the background casefold the values to `screaming-snake-case`, `snake-case`, `pascalcase`, and `kebab-case`. Though still show the following message:

```
Error: Invalid value for '{SCREAMING_SNAKE_CASE,snake_case,pascalcase,kebab-case}':
'meh' is not one of SCREAMING_SNAKE_CASE, snake_case, pascalcase, kebab-case.
```

This makes token normalization expand to cover normalization output to the user so it would now be:
```
Error: Invalid value for '{screaming_snake_case,snake_case,pascalcase,kebab-case}':
'meh' is not one of screaming_snake_case, snake_case, pascalcase, kebab-case.
```

Note that `screaming_snake_case` and `snake_case` retain their underscores because we're casefolding, not converting to kebab-case. I think we should in the future make kebab-case the default, and/or allow extending the normalization behaviour more easily so this could be converted into `snake-case`.

---

In addition to this normalization, I'm introducing generics into `Choice` and removing the requirement to have choices be `str`. A funny side-effect is that enums can be supported more easily. Right now you'd have to use `click.Choice(list(MyEnum))` though that would result in enum aliases not showing up. We could allow one to do `click.Choice(MyEnum)` and handle the aliasing for them. 🤔 We could prevent people from incorrectly using `click.Choice(list(MyEnum))` by failing if we detect a list of `Enum` types.

Let me know what you think!

Resolves #605.