### PR TITLE
Close contexts created during shell completion #2644.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,9 @@ Unreleased
 -   If help is shown because ``no_args_is_help`` is enabled (defaults to ``True``
     for groups, ``False`` for commands), the exit code is 2 instead of 0.
     :issue:`1489` :pr:`1489`
+-   Contexts created during shell completion are closed properly, fixing
+    ``ResourceWarning``s when using ``click.File``. :issue:`2644` :pr:`2800`
+    :pr:`2767`
 
 
 Version 8.1.8

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -704,8 +704,8 @@ class Context:
         """Exits the application with a given exit code.
 
         .. versionchanged:: 8.2
-            Force closing of callbacks registered with
-            :meth:`call_on_close` before exiting the CLI.
+            Callbacks and context managers registered with :meth:`call_on_close`
+            and :meth:`with_resource` are closed before exiting.
         """
         self.close()
         raise Exit(code)

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 import click.shell_completion
@@ -414,3 +416,18 @@ def test_add_completion_class_decorator():
     # Using `add_completion_class` as a decorator adds the new shell immediately
     assert "mysh" in click.shell_completion._available_shells
     assert click.shell_completion._available_shells["mysh"] is MyshComplete
+
+
+def test_files_closed() -> None:
+    @click.group()
+    @click.option(
+        "--config_file", default="CONFIG", type=click.File(mode="r"), help="help"
+    )
+    @click.pass_context
+    def cli(ctx, config_file):
+        pass
+
+    with warnings.catch_warnings(record=True) as current_warnings:
+        assert not current_warnings, "There should be no warnings to start"
+        _get_completions(cli, args=[], incomplete="")
+        assert not current_warnings, "There should be no warnings after either"


### PR DESCRIPTION
Includes a test reproducing #2644. Then continues from the work done by @akhil-vempali in #2767 to fix the issue. There was some confusion in the mess of context objects in the implementation that has been fixed in this version.

Resolves #2644.