### PR TITLE
Improve typing on Windows

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -10,8 +10,8 @@ import typing as t
 from types import TracebackType
 from weakref import WeakKeyDictionary
 
-CYGWIN = sys.platform.startswith("cygwin")
-WIN = sys.platform.startswith("win")
+CYGWIN = sys.platform == "cygwin"
+WIN = sys.platform == "win32"
 auto_wrap_for_ansi: t.Callable[[t.TextIO], t.TextIO] | None = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -10,8 +10,8 @@ import typing as t
 from types import TracebackType
 from weakref import WeakKeyDictionary
 
-CYGWIN = sys.platform == "cygwin"
-WIN = sys.platform == "win32"
+CYGWIN = sys.platform.startswith("cygwin")
+WIN = sys.platform.startswith("win")
 auto_wrap_for_ansi: t.Callable[[t.TextIO], t.TextIO] | None = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -538,14 +538,14 @@ if sys.platform.startswith("win") and WIN:
         rv = t.cast(t.TextIO, ansi_wrapper.stream)
         _write = rv.write
 
-        def _safe_write(s):
+        def _safe_write(s: str) -> int:
             try:
                 return _write(s)
             except BaseException:
                 ansi_wrapper.reset_all()
                 raise
 
-        rv.write = _safe_write
+        rv.write = _safe_write  # type: ignore[method-assign]
 
         try:
             _ansi_stream_wrappers[stream] = rv

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -711,12 +711,11 @@ if sys.platform == "win32":
         #
         # Anyway, Click doesn't claim to do this Right(tm), and using `getwch`
         # is doing the right thing in more situations than with `getch`.
-        func: t.Callable[[], str]
 
         if echo:
-            func = msvcrt.getwche
+            func = t.cast(t.Callable[[], str], msvcrt.getwche)
         else:
-            func = msvcrt.getwch
+            func = t.cast(t.Callable[[], str], msvcrt.getwch)
 
         rv = func()
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -674,7 +674,7 @@ def _translate_ch_to_exc(ch: str) -> None:
     return None
 
 
-if WIN:
+if sys.platform == "win32":
     import msvcrt
 
     @contextlib.contextmanager
@@ -714,9 +714,9 @@ if WIN:
         func: t.Callable[[], str]
 
         if echo:
-            func = msvcrt.getwche  # type: ignore
+            func = msvcrt.getwche
         else:
-            func = msvcrt.getwch  # type: ignore
+            func = msvcrt.getwch
 
         rv = func()
 

--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -70,6 +70,8 @@ MAX_BYTES_WRITTEN = 32767
 
 if t.TYPE_CHECKING:
     try:
+        # Using `typing_extensions.Buffer` instead of `collections.abc`
+        # on Windows for some reason does not have `Sized` implemented.
         from collections.abc import Buffer  # type: ignore
     except ImportError:
         from typing_extensions import Buffer

--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -13,6 +13,7 @@ import io
 import sys
 import time
 import typing as t
+from ctypes import Array
 from ctypes import byref
 from ctypes import c_char
 from ctypes import c_char_p
@@ -67,6 +68,12 @@ STDERR_FILENO = 2
 EOF = b"\x1a"
 MAX_BYTES_WRITTEN = 32767
 
+if t.TYPE_CHECKING:
+    try:
+        from collections.abc import Buffer  # type: ignore
+    except ImportError:
+        from typing_extensions import Buffer
+
 try:
     from ctypes import pythonapi
 except ImportError:
@@ -93,32 +100,32 @@ else:
     PyObject_GetBuffer = pythonapi.PyObject_GetBuffer
     PyBuffer_Release = pythonapi.PyBuffer_Release
 
-    def get_buffer(obj, writable=False):
+    def get_buffer(obj: Buffer, writable: bool = False) -> Array[c_char]:
         buf = Py_buffer()
-        flags = PyBUF_WRITABLE if writable else PyBUF_SIMPLE
+        flags: int = PyBUF_WRITABLE if writable else PyBUF_SIMPLE
         PyObject_GetBuffer(py_object(obj), byref(buf), flags)
 
         try:
-            buffer_type = c_char * buf.len
+            buffer_type: Array[c_char] = c_char * buf.len
             return buffer_type.from_address(buf.buf)
         finally:
             PyBuffer_Release(byref(buf))
 
 
 class _WindowsConsoleRawIOBase(io.RawIOBase):
-    def __init__(self, handle):
+    def __init__(self, handle: int | None) -> None:
         self.handle = handle
 
-    def isatty(self):
+    def isatty(self) -> t.Literal[True]:
         super().isatty()
         return True
 
 
 class _WindowsConsoleReader(_WindowsConsoleRawIOBase):
-    def readable(self):
+    def readable(self) -> t.Literal[True]:
         return True
 
-    def readinto(self, b):
+    def readinto(self, b: Buffer) -> int:
         bytes_to_be_read = len(b)
         if not bytes_to_be_read:
             return 0
@@ -150,18 +157,18 @@ class _WindowsConsoleReader(_WindowsConsoleRawIOBase):
 
 
 class _WindowsConsoleWriter(_WindowsConsoleRawIOBase):
-    def writable(self):
+    def writable(self) -> t.Literal[True]:
         return True
 
     @staticmethod
-    def _get_error_message(errno):
+    def _get_error_message(errno: int) -> str:
         if errno == ERROR_SUCCESS:
             return "ERROR_SUCCESS"
         elif errno == ERROR_NOT_ENOUGH_MEMORY:
             return "ERROR_NOT_ENOUGH_MEMORY"
         return f"Windows error {errno}"
 
-    def write(self, b):
+    def write(self, b: Buffer) -> int:
         bytes_to_be_written = len(b)
         buf = get_buffer(b)
         code_units_to_be_written = min(bytes_to_be_written, MAX_BYTES_WRITTEN) // 2
@@ -209,7 +216,7 @@ class ConsoleStream:
     def isatty(self) -> bool:
         return self.buffer.isatty()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ConsoleStream name={self.name!r} encoding={self.encoding!r}>"
 
 
@@ -267,16 +274,20 @@ def _get_windows_console_stream(
     f: t.TextIO, encoding: str | None, errors: str | None
 ) -> t.TextIO | None:
     if (
-        get_buffer is not None
-        and encoding in {"utf-16-le", None}
-        and errors in {"strict", None}
-        and _is_console(f)
+        get_buffer is None
+        or encoding not in {"utf-16-le", None}
+        or errors not in {"strict", None}
+        or not _is_console(f)
     ):
-        func = _stream_factories.get(f.fileno())
-        if func is not None:
-            b = getattr(f, "buffer", None)
+        return None
 
-            if b is None:
-                return None
+    func = _stream_factories.get(f.fileno())
+    if func is None:
+        return None
 
-            return func(b)
+    b = getattr(f, "buffer", None)
+
+    if b is None:
+        return None
+
+    return func(b)

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,15 @@ commands = pre-commit run --all-files
 [testenv:typing]
 deps = -r requirements/typing.txt
 commands =
-    mypy
-    pyright tests/typing
-    pyright --verifytypes click --ignoreexternal
+    mypy --platform linux
+    mypy --platform darwin
+    mypy --platform win32
+    pyright tests/typing --pythonplatform Linux
+    pyright tests/typing --pythonplatform Darwin
+    pyright tests/typing --pythonplatform Windows
+    pyright --verifytypes click --ignoreexternal --pythonplatform Linux
+    pyright --verifytypes click --ignoreexternal --pythonplatform Darwin
+    pyright --verifytypes click --ignoreexternal --pythonplatform Windows
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
I was working from Windows for a change, so why not fix some of the typing here?

This makes it so running the type checks on all platforms no longer gives any errors. Additionally, `tox.ini` has been updated to make sure it runs all tests on all platforms. This will do some extra work and make things slower unfortunately. I think if we move to `uv` in the future, we can make this faster (from having a short glance at some information I saw online). One can also run `tox` in parallel, though for some reason you cannot seem to enable that from the config.

- ~~Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.~~
    - No behaviour has been altered.
- [x] Add or update relevant docs, in the docs folder and in code.
- ~~Add an entry in CHANGES.rst summarizing the change and linking to the issue.~~
- ~~Add `.. versionchanged::` entries in any relevant code docs.~~
