### PR TITLE
Correct click.edit typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,7 @@ Unreleased
 -   ``Option.flag_value`` will no longer have a default value set based on
     ``Option.default`` if ``Option.is_flag`` is ``False``. This results in
     ``Option.default`` not needing to implement `__bool__`. :pr:`2829`
+-   Incorrect ``click.edit`` typing has been corrected. :pr:`2804`
 
 Version 8.1.8
 -------------

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -545,10 +545,18 @@ class Editor:
                 _("{editor}: Editing failed: {e}").format(editor=editor, e=e)
             ) from e
 
-    def edit(self, text: t.AnyStr | None) -> t.AnyStr | None:
+    @t.overload
+    def edit(self, text: bytes | bytearray) -> bytes | None: ...
+
+    # We cannot know whether or not the type expected is str or bytes when None
+    # is passed, so str is returned as that was what was done before.
+    @t.overload
+    def edit(self, text: str | None) -> str | None: ...
+
+    def edit(self, text: str | bytes | bytearray | None) -> str | bytes | None:
         import tempfile
 
-        if not text:
+        if text is None:
             data = b""
         elif isinstance(text, (bytes, bytearray)):
             data = text
@@ -588,7 +596,7 @@ class Editor:
             if isinstance(text, (bytes, bytearray)):
                 return rv
 
-            return rv.decode("utf-8-sig").replace("\r\n", "\n")  # type: ignore
+            return rv.decode("utf-8-sig").replace("\r\n", "\n")
         finally:
             os.unlink(name)
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -686,12 +686,22 @@ def secho(
 
 @t.overload
 def edit(
-    text: t.AnyStr,
+    text: bytes | bytearray,
+    editor: str | None = None,
+    env: cabc.Mapping[str, str] | None = None,
+    require_save: bool = False,
+    extension: str = ".txt",
+) -> bytes | None: ...
+
+
+@t.overload
+def edit(
+    text: str,
     editor: str | None = None,
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-) -> t.AnyStr: ...
+) -> str | None: ...
 
 
 @t.overload
@@ -706,13 +716,13 @@ def edit(
 
 
 def edit(
-    text: t.AnyStr | None = None,
+    text: str | bytes | bytearray | None = None,
     editor: str | None = None,
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
     filename: str | cabc.Iterable[str] | None = None,
-) -> t.AnyStr | None:
+) -> str | bytes | bytearray | None:
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating
     system search path is used for finding the executable) it overrides


### PR DESCRIPTION
The following typing issues existed before:

* `click.edit`
	1. The `text` argument accepted `bytearray` but was not included in the typing.
* `_termui_impl`
	1. If `None` was inputted, `str` would be returned but typing suggested that it would be `str` if `str` was given and `bytes` if `bytes` was given.

This resolved an `type: ignore` as well.


- ~~Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.~~
- ~~Add or update relevant docs, in the docs folder and in code.~~
- ~~Add an entry in CHANGES.rst summarizing the change and linking to the issue.~~
    - Not going to add an entry because `bytearray` was always accepted, just not documented.
- ~~Add `.. versionchanged::` entries in any relevant code docs.~~
