### PR TITLE
When prompting, use `show_default` as the default if its a string

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2927,11 +2927,12 @@ class Option(Parameter):
         if self.is_bool_flag:
             return confirm(self.prompt, default)
 
-        # If show_default is set to True/False, provide this to `prompt` as well. For
-        # non-bool values of `show_default`, we use `prompt`'s default behavior
+        # If show_default is set to True/False, provide this to `prompt` as well.
         prompt_kwargs: t.Any = {}
         if isinstance(self.show_default, bool):
             prompt_kwargs["show_default"] = self.show_default
+        elif isinstance(self.show_default, str):
+            default=show_default
 
         return prompt(
             self.prompt,


### PR DESCRIPTION
This PR just makes sure the `default` handed to `.prompt` is the `show_default` if its a string (to match the help).

fixes #2836



- [ ] Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
