### PR TITLE
Rewrite Commands and Groups docs.

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -7,6 +7,69 @@ In addition to common functionality that is implemented in the library
 itself, there are countless patterns that can be implemented by extending
 Click.  This page should give some insight into what can be accomplished.
 
+.. contents::
+   :depth: 1
+   :local:
+
+.. _custom-groups:
+
+Custom Groups
+-------------
+
+You can customize the behavior of a group beyond the arguments it accepts by
+subclassing :class:`click.Group`.
+
+The most common methods to override are :meth:`~click.Group.get_command` and
+:meth:`~click.Group.list_commands`.
+
+The following example implements a basic plugin system that loads commands from
+Python files in a folder. The command is lazily loaded to avoid slow startup.
+
+.. code-block:: python
+
+    import importlib.util
+    import os
+    import click
+
+    class PluginGroup(click.Group):
+        def __init__(self, name=None, plugin_folder="commands", **kwargs):
+            super().__init__(name=name, **kwargs)
+            self.plugin_folder = plugin_folder
+
+        def list_commands(self, ctx):
+            rv = []
+
+            for filename in os.listdir(self.plugin_folder):
+                if filename.endswith(".py"):
+                    rv.append(filename[:-3])
+
+            rv.sort()
+            return rv
+
+        def get_command(self, ctx, name):
+            path = os.path.join(self.plugin_folder, f"{name}.py")
+            spec = importlib.util.spec_from_file_location(name, path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module.cli
+
+    cli = PluginGroup(
+        plugin_folder=os.path.join(os.path.dirname(__file__), "commands")
+    )
+
+    if __name__ == "__main__":
+        cli()
+
+Custom classes can also be used with decorators:
+
+.. code-block:: python
+
+    @click.group(
+        cls=PluginGroup,
+        plugin_folder=os.path.join(os.path.dirname(__file__), "commands")
+    )
+    def cli():
+        pass
 
 .. _aliases:
 

--- a/docs/commands-and-groups.rst
+++ b/docs/commands-and-groups.rst
@@ -1,0 +1,220 @@
+Basic Commands, Groups, Context
+================================
+
+.. currentmodule:: click
+
+Commands and Groups are the building blocks for Click applications. :class:`Command` wraps a function to make it into a cli command. :class:`Group` wraps Commands and Groups to make them into applications. :class:`Context` is how groups and commands communicate.
+
+.. contents::
+   :depth: 1
+   :local:
+
+Basic Command Example
+----------------------
+A simple command decorator takes no arguments.
+
+.. click:example::
+    @click.command()
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+.. click:run::
+    invoke(hello, args=['--count', '2',])
+
+Renaming Commands
+------------------
+By default the command is the function name with underscores replaced by dashes. To change this pass the  desired name into the first positional argument.
+
+.. click:example::
+    @click.command('say-hello')
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+.. click:run::
+    invoke(hello, args=['--count', '2',])
+
+Deprecating Commands
+---------------------
+To mark a command as deprecated pass in ``deprecated=True``
+
+.. click:example::
+    @click.command('say-hello', deprecated=True)
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+.. click:run::
+    invoke(hello, args=['--count', '2',])
+
+Basic Group Example
+---------------------
+A group wraps command(s). After being wrapped, the commands are nested under that group. You can see that on the help pages and in the execution. By default, invoking the group with no command shows the help page.
+
+.. click:example::
+    @click.group()
+    def greeting():
+        click.echo('Starting greeting ...')
+
+    @greeting.command('say-hello')
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+At the top level:
+
+.. click:run::
+
+    invoke(greeting)
+
+At the command level:
+
+.. click:run::
+
+    invoke(greeting, args=['say-hello'])
+    invoke(greeting, args=['say-hello', '--help'])
+
+As you can see from the above example, the function wrapped by the group decorator executes unless it is interrupted (for example by calling the help).
+
+Renaming Groups
+-----------------
+To have a name other than the decorated function name as the group name, pass it in as the first positional argument.
+
+.. click:example::
+    @click.group('greet_someone')
+    def greeting():
+        click.echo('Starting greeting ...')
+
+    @greeting.command('say-hello')
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+.. click:run::
+
+    invoke(greeting, args=['say-hello'])
+
+Group Invocation Without Command
+--------------------------------
+
+By default, a group is not invoked unless a subcommand is passed. In fact, not
+providing a command automatically passes ``--help`` by default. This behavior
+can be changed by passing ``invoke_without_command=True`` to a group. In that
+case, the callback is always invoked instead of showing the help page. The
+context object also includes information about whether or not the invocation
+would go to a subcommand.
+
+.. click:example::
+
+    @click.group(invoke_without_command=True)
+    @click.pass_context
+    def cli(ctx):
+        if ctx.invoked_subcommand is None:
+            click.echo('I was invoked without subcommand')
+        else:
+            click.echo(f"I am about to invoke {ctx.invoked_subcommand}")
+
+    @cli.command()
+    def sync():
+        click.echo('The subcommand')
+
+.. click:run::
+
+    invoke(cli, prog_name='tool', args=[])
+    invoke(cli, prog_name='tool', args=['sync'])
+
+
+
+Group Separation
+--------------------------
+Within a group, command :ref:`parameters` attached to a command belong only to that command.
+
+.. click:example::
+    @click.group()
+    def greeting():
+        pass
+
+    @greeting.command()
+    @click.option('--count', default=1)
+    def hello(count):
+        for x in range(count):
+            click.echo("Hello!")
+
+    @greeting.command()
+    @click.option('--count', default=1)
+    def goodbye(count):
+        for x in range(count):
+            click.echo("Goodbye!")
+
+.. click:run::
+
+    invoke(greeting, args=['hello', '--count', '2'])
+    invoke(greeting, args=['goodbye', '--count', '2'])
+    invoke(greeting)
+
+Additionally parameters for a given group belong only to that group and not to the commands under it. What this means is that options and arguments for a specific command have to be specified *after* the command name itself, but *before* any other command names.
+
+This behavior is observable with the ``--help`` option. Suppose we have a group called ``tool`` containing a command called ``sub``.
+
+- ``tool --help`` returns the help for the whole program (listing subcommands).
+- ``tool sub --help`` returns the help for the ``sub`` subcommand.
+- But ``tool.py --help sub`` treats ``--help`` as an argument for the main program. Click then invokes the callback for ``--help``, which prints the help and aborts the program before click can process the subcommand.
+
+Arbitrary Nesting
+------------------
+Commands are attached to a group. Multiple groups can be attached to another group. Groups containing multiple groups can be attached to a group, and so on.
+To invoke a command nest under multiple groups, all the above groups must added.
+
+.. click:example::
+
+    @click.group()
+    def cli():
+        pass
+
+    # Not @click so that the group is registered now.
+    @cli.group()
+    def session():
+        click.echo('Starting session')
+
+    @session.command()
+    def initdb():
+        click.echo('Initialized the database')
+
+    @session.command()
+    def dropdb():
+        click.echo('Dropped the database')
+
+.. click:run::
+
+    invoke(cli, args=['session', 'initdb'])
+
+Lazily Attaching Commands
+--------------------------
+Most examples so far have attached the the commands and group immediately, but commands may be registered later. This could be used to split command into multiple Python modules.
+
+.. click:example::
+
+    @click.group()
+    def cli():
+        pass
+
+    @click.command()
+    def initdb():
+        click.echo('Initialized the database')
+
+    @click.command()
+    def dropdb():
+        click.echo('Dropped the database')
+
+    cli.add_command(initdb)
+    cli.add_command(dropdb)
+
+Context Object
+-------------------
+The :class:`Context` object ...

--- a/docs/commands-and-groups.rst
+++ b/docs/commands-and-groups.rst
@@ -53,7 +53,7 @@ To mark a command as deprecated pass in ``deprecated=True``
 
 Basic Group Example
 ---------------------
-A group wraps command(s). After being wrapped, the commands are nested under that group. You can see that on the help pages and in the execution. By default, invoking the group with no command shows the help page.
+A group wraps one or more commands. After being wrapped, the commands are nested under that group. You can see that on the help pages and in the execution. By default, invoking the group with no command shows the help page.
 
 .. click:example::
     @click.group()
@@ -86,7 +86,7 @@ Renaming Groups
 To have a name other than the decorated function name as the group name, pass it in as the first positional argument.
 
 .. click:example::
-    @click.group('greet_someone')
+    @click.group('greet-someone')
     def greeting():
         click.echo('Starting greeting ...')
 
@@ -103,12 +103,7 @@ To have a name other than the decorated function name as the group name, pass it
 Group Invocation Without Command
 --------------------------------
 
-By default, a group is not invoked unless a subcommand is passed. In fact, not
-providing a command automatically passes ``--help`` by default. This behavior
-can be changed by passing ``invoke_without_command=True`` to a group. In that
-case, the callback is always invoked instead of showing the help page. The
-context object also includes information about whether or not the invocation
-would go to a subcommand.
+By default, if a group is passed without a command, the group is not invoked and a command automatically passes ``--help``. To change this, pass ``invoke_without_command=True`` to the group. The context object also includes information about whether or not the group invocation would go to a command nested under it.
 
 .. click:example::
 
@@ -133,7 +128,7 @@ would go to a subcommand.
 
 Group Separation
 --------------------------
-Within a group, command :ref:`parameters` attached to a command belong only to that command.
+Command :ref:`parameters` attached to a command belong only to that command.
 
 .. click:example::
     @click.group()
@@ -164,11 +159,11 @@ This behavior is observable with the ``--help`` option. Suppose we have a group 
 
 - ``tool --help`` returns the help for the whole program (listing subcommands).
 - ``tool sub --help`` returns the help for the ``sub`` subcommand.
-- But ``tool.py --help sub`` treats ``--help`` as an argument for the main program. Click then invokes the callback for ``--help``, which prints the help and aborts the program before click can process the subcommand.
+- But ``tool --help sub`` treats ``--help`` as an argument for the main program. Click then invokes the callback for ``--help``, which prints the help and aborts the program before click can process the subcommand.
 
 Arbitrary Nesting
 ------------------
-:class:`Commands <Command>` are attached to a :class:`Group`. Multiple groups can be attached to another group. Groups containing multiple groups can be attached to a group, and so on. To invoke a command nested under multiple groups, all the groups under which it is nested must added.
+:class:`Commands <Command>` are attached to a :class:`Group`. Multiple groups can be attached to another group. Groups containing multiple groups can be attached to a group, and so on. To invoke a command nested under multiple groups, all the groups under which it is nested must be invoked.
 
 .. click:example::
 
@@ -195,7 +190,7 @@ Arbitrary Nesting
 
 Lazily Attaching Commands
 --------------------------
-Most examples so far have attached the commands and to a group immediately, but commands may be registered later. This could be used to split commands into multiple Python modules. Regardless of how they are attached, the commands are invoked identically.
+Most examples so far have attached the commands to a group immediately, but commands may be registered later. This could be used to split commands into multiple Python modules. Regardless of how they are attached, the commands are invoked identically.
 
 .. click:example::
 
@@ -203,7 +198,7 @@ Most examples so far have attached the commands and to a group immediately, but 
     def cli():
         pass
 
-    @click.command()
+    @cli.command()
     def initdb():
         click.echo('Initialized the database')
 
@@ -211,7 +206,6 @@ Most examples so far have attached the commands and to a group immediately, but 
     def dropdb():
         click.echo('Dropped the database')
 
-    cli.add_command(initdb)
     cli.add_command(dropdb)
 
 .. click:run::

--- a/docs/commands-and-groups.rst
+++ b/docs/commands-and-groups.rst
@@ -168,8 +168,7 @@ This behavior is observable with the ``--help`` option. Suppose we have a group 
 
 Arbitrary Nesting
 ------------------
-Commands are attached to a group. Multiple groups can be attached to another group. Groups containing multiple groups can be attached to a group, and so on.
-To invoke a command nest under multiple groups, all the above groups must added.
+:class:`Commands <Command>` are attached to a :class:`Group`. Multiple groups can be attached to another group. Groups containing multiple groups can be attached to a group, and so on. To invoke a command nested under multiple groups, all the groups under which it is nested must added.
 
 .. click:example::
 
@@ -196,7 +195,7 @@ To invoke a command nest under multiple groups, all the above groups must added.
 
 Lazily Attaching Commands
 --------------------------
-Most examples so far have attached the the commands and group immediately, but commands may be registered later. This could be used to split command into multiple Python modules.
+Most examples so far have attached the commands and to a group immediately, but commands may be registered later. This could be used to split commands into multiple Python modules. Regardless of how they are attached, the commands are invoked identically.
 
 .. click:example::
 
@@ -215,6 +214,11 @@ Most examples so far have attached the the commands and group immediately, but c
     cli.add_command(initdb)
     cli.add_command(dropdb)
 
+.. click:run::
+
+    invoke(cli, args=['initdb'])
+    invoke(cli, args=['dropdb'])
+
 Context Object
 -------------------
-The :class:`Context` object ...
+The :class:`Context` object is how commands and groups communicate.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,7 @@ usage patterns.
    parameters
    arguments
    options
+   commands-and-groups
    commands
    documentation
    prompts

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,8 +76,8 @@ usage patterns.
    options
    option-decorators
    arguments
-   commands
    commands-and-groups
+   commands
    documentation
    prompts
    complex

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -1,3 +1,5 @@
+.. _parameters:
+
 Parameters
 ==========
 


### PR DESCRIPTION
- Rename commands and groups -> Advanced Groups and Context
- Add basic commands, groups, context doc 
   -  collects up and add sections for basic command and groups stuff such as renaming, deprecating
   - Add sections for group separation, arbitrary nesting, and lazily attaching
- Moved custom groups section to Advanced patterns
- Remove sections from  Advanced Groups and Context to rewrite them better in  basic commands, groups, context doc  
   - passing parameters
   - group invocation without command 