### PR TITLE
Move `--help` option defaults from its class to its decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,8 @@ Unreleased
 -   ``Choice`` is now generic and supports any iterable value.
     This allows you to use enums and other non-``str`` values. :pr:`2796`
     :issue:`605`
+-   Fix setup of help option's defaults when using a custom class on its
+    decorator. Removes ``HelpOption``. :issue:`2832` :pr:`2840`
 
 Version 8.1.8
 -------------

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -19,7 +19,6 @@ from .decorators import command as command
 from .decorators import confirmation_option as confirmation_option
 from .decorators import group as group
 from .decorators import help_option as help_option
-from .decorators import HelpOption as HelpOption
 from .decorators import make_pass_decorator as make_pass_decorator
 from .decorators import option as option
 from .decorators import pass_context as pass_context

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1014,25 +1014,21 @@ class Command:
         return list(all_names)
 
     def get_help_option(self, ctx: Context) -> Option | None:
-        """Returns the help option object."""
-        help_options = self.get_help_option_names(ctx)
+        """Returns the help option object.
 
-        if not help_options or not self.add_help_option:
+        Skipped if :attr:`add_help_option` is ``False``.
+        """
+        help_option_names = self.get_help_option_names(ctx)
+
+        if not help_option_names or not self.add_help_option:
             return None
 
-        def show_help(ctx: Context, param: Parameter, value: str) -> None:
-            if value and not ctx.resilient_parsing:
-                echo(ctx.get_help(), color=ctx.color)
-                ctx.exit()
+        # Avoid circular import.
+        from .decorators import help_option
 
-        return Option(
-            help_options,
-            is_flag=True,
-            is_eager=True,
-            expose_value=False,
-            callback=show_help,
-            help=_("Show this message and exit."),
-        )
+        # apply help_option decorator and pop resulting option
+        help_option(*help_option_names)(self)
+        return self.params.pop() # type: ignore[return-value]
 
     def make_parser(self, ctx: Context) -> _OptionParser:
         """Creates the underlying option parser for this command."""

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import typing as t
-from collections import abc
 from functools import update_wrapper
 from gettext import gettext as _
 
@@ -525,41 +524,28 @@ def version_option(
     return option(*param_decls, **kwargs)
 
 
-class HelpOption(Option):
+def help_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
     """Pre-configured ``--help`` option which immediately prints the help page
     and exits the program.
+
+    :param param_decls: One or more option names. Defaults to the single
+        value ``"--help"``.
+    :param kwargs: Extra arguments are passed to :func:`option`.
     """
 
-    def __init__(
-        self,
-        param_decls: abc.Sequence[str] | None = None,
-        **kwargs: t.Any,
-    ) -> None:
-        if not param_decls:
-            param_decls = ("--help",)
-
-        kwargs.setdefault("is_flag", True)
-        kwargs.setdefault("expose_value", False)
-        kwargs.setdefault("is_eager", True)
-        kwargs.setdefault("help", _("Show this message and exit."))
-        kwargs.setdefault("callback", self.show_help)
-
-        super().__init__(param_decls, **kwargs)
-
-    @staticmethod
     def show_help(ctx: Context, param: Parameter, value: bool) -> None:
         """Callback that print the help page on ``<stdout>`` and exits."""
         if value and not ctx.resilient_parsing:
             echo(ctx.get_help(), color=ctx.color)
             ctx.exit()
 
+    if not param_decls:
+        param_decls = ("--help",)
 
-def help_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
-    """Decorator for the pre-configured ``--help`` option defined above.
+    kwargs.setdefault("is_flag", True)
+    kwargs.setdefault("expose_value", False)
+    kwargs.setdefault("is_eager", True)
+    kwargs.setdefault("help", _("Show this message and exit."))
+    kwargs.setdefault("callback", show_help)
 
-    :param param_decls: One or more option names. Defaults to the single
-        value ``"--help"``.
-    :param kwargs: Extra arguments are passed to :func:`option`.
-    """
-    kwargs.setdefault("cls", HelpOption)
     return option(*param_decls, **kwargs)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -724,6 +724,45 @@ def test_option_custom_class_reusable(runner):
         assert "you wont see me" not in result.output
 
 
+@pytest.mark.parametrize("custom_class", (True, False))
+@pytest.mark.parametrize(
+    ("name_specs", "expected"),
+    (
+        (
+            ("-h", "--help"),
+            "  -h, --help  Show this message and exit.\n",
+        ),
+        (
+            ("-h",),
+            "  -h      Show this message and exit.\n"
+            "  --help  Show this message and exit.\n",
+        ),
+        (
+            ("--help",),
+            "  --help  Show this message and exit.\n",
+        ),
+    ),
+)
+def test_help_option_custom_names_and_class(runner, custom_class, name_specs, expected):
+    class CustomHelpOption(click.Option):
+        pass
+
+    option_attrs = {}
+    if custom_class:
+        option_attrs["cls"] = CustomHelpOption
+
+    @click.command()
+    @click.help_option(*name_specs, **option_attrs)
+    def cmd():
+        pass
+
+    for arg in name_specs:
+        result = runner.invoke(cmd, [arg])
+        assert not result.exception
+        assert result.exit_code == 0
+        assert expected in result.output
+
+
 def test_bool_flag_with_type(runner):
     @click.command()
     @click.option("--shout/--no-shout", default=False, type=bool)


### PR DESCRIPTION
This is a proposal to fix #2832, which points to a subtle change in behavior of the help option introduced in 8.1.8.

The root of the problem is that by deduplicating code in 8.1.8 (see: #2563), I introduced a `HelpOption` class, to centralize the setup necessary to make a standard `Option` behave like an help option.

In #2832, a user is relying on a custom class to feed the `@help_option` decorator. This bypass all the custom setup made by `HelpOption`, and produce the discrepancy in behavior between 8.1.7 and 8.1.8.

This PR:
- Reverts back to setting up all parameters of the help option in the decorator instead of the `HelpOption` class
- Aligns `@help_option` implementation with the way Click is doing for the others (like `@password_option`, `@version_option`, ...) 
- Removes the `click.decorators.HelpOption` class as a consequence
- Adds a complete unit test to check combination of custom class and option names leads to expected results


Checklist:
- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.