### PR TITLE
Fix read the docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,5 @@ python:
       path: .
 sphinx:
   builder: dirhtml
+  configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
fix read the docs config issues:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/