### PR TITLE
Shell completion overrides are documented as taking keyword arguments

### DIFF
--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -138,7 +138,7 @@ def cli(ev):
 ## Overriding Value Completion
 
 Value completions for a parameter can be customized without a custom type by providing a `shell_complete` function. The
-function is used instead of any completion provided by the type. It is passed 3 keyword arguments:
+function is used instead of any completion provided by the type. It is passed 3 positional arguments:
 
 - `ctx` - The current command context.
 - `param` - The current parameter requesting completion.


### PR DESCRIPTION
The documentation indicates that shell completion override functions are "passed 3 keyword arguments", but are in fact [passed *zero* keyword arguments and three *positional* arguments](https://github.com/pallets/click/blob/5dd628854c0b61bbdc07f22004c5da8fa8ee9481/src/click/core.py#L2440). 🙂