### PR TITLE
Fix compatibility with pyright 1.1.394

### DIFF
--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -108,8 +108,9 @@ else:
         PyObject_GetBuffer(py_object(obj), byref(buf), flags)
 
         try:
-            buffer_type: Array[c_char] = c_char * buf.len
-            return buffer_type.from_address(buf.buf)  # type: ignore[attr-defined, no-any-return]
+            buffer_type = c_char * buf.len
+            out: Array[c_char] = buffer_type.from_address(buf.buf)
+            return out
         finally:
             PyBuffer_Release(byref(buf))
 


### PR DESCRIPTION
I use `pyright --verifytypes` on a project which depends on `click`. I do not use `--ignoreexternal`.

With `pyright==1.1.394` I started seeing errors.
These are related to how `pyright` considers instance variables without explicit types to be ambiguous. See https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#ambiguous-types.

Click's CI also fails with the latest `pyright`, so I ran `pip-compile` to re-generate the typing requirements, and fixed the issues which came up.

Fixes #2856 