### PR TITLE
test: add two new tests for `Parameter.__init__` in `src/click/core.py`

### DIFF
--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -63,6 +63,15 @@ def test_nargs_tup_composite(runner, opts):
     assert result.output.splitlines() == ["name=peter id=1"]
 
 
+def test_nargs_mismatch_with_tuple_type():
+    with pytest.raises(ValueError, match="nargs.*must be 2.*but it was 3"):
+
+        @click.command()
+        @click.argument("test", type=(str, int), nargs=3)
+        def cli(_):
+            pass
+
+
 def test_nargs_err(runner):
     @click.command()
     @click.argument("x")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1061,3 +1061,32 @@ def test_duplicate_names_warning(runner, opts_one, opts_two):
 
     with pytest.warns(UserWarning):
         runner.invoke(cli, [])
+
+
+@pytest.mark.parametrize(
+    ("multiple", "nargs", "default", "expected_message"),
+    [
+        (
+            False,  # multiple
+            2,  # nargs
+            42,  # default (not a list)
+            "'default' must be a list when 'nargs' != 1.",
+        ),
+        (
+            True,  # multiple
+            2,  # nargs
+            [
+                "test string which is not a list in the list"
+            ],  # default (list of non-lists)
+            "'default' must be a list of lists when 'multiple' is true and 'nargs' != 1.",
+        ),
+    ],
+)
+def test_default_type_error_raises(multiple, nargs, default, expected_message):
+    with pytest.raises(ValueError, match=expected_message):
+        click.Option(
+            ["--test"],
+            multiple=multiple,
+            nargs=nargs,
+            default=default,
+        )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1078,7 +1078,8 @@ def test_duplicate_names_warning(runner, opts_one, opts_two):
             [
                 "test string which is not a list in the list"
             ],  # default (list of non-lists)
-            "'default' must be a list of lists when 'multiple' is true and 'nargs' != 1.",
+            "'default' must be a list of lists when 'multiple' is true"
+            " and 'nargs' != 1.",
         ),
     ],
 )


### PR DESCRIPTION
The function Parameter.__init__ does not have 100% coverage. This commit adds two new test cases that improve the coverage. The first one tests that a ValueError is raised when `nargs != self.type.arity`. The second one tests that a ValueError is raised when `_check_iter(check_default)` raises `TypeError`.

Fixes https://github.com/pallets/click/issues/2860

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
