### PR TITLE
Add format customization flow to `click.prompt` and `click.confirm` via `PromptBuilder` class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: click
 
+Version 8.2.1
+-------------
+
+Unreleased
+
+-   Create ``PrompBuilder`` class for customizing prompts display and add ``builder_cls`` parameter to ``prompt`` and ``confirm`` methods. :issue:`2875`
+
 Version 8.2.0
 -------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,6 +41,8 @@ Decorators
 Utilities
 ---------
 
+.. autoclass:: PromptBuilder
+
 .. autofunction:: echo
 
 .. autofunction:: echo_via_pager

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -32,6 +32,9 @@ provided.  For instance, the following will only accept floats::
 
     value = click.prompt('Please enter a number', default=42.0)
 
+You can customize how to display and format the prompt via providing
+:param:`builder_cls` as an instance of :class:`PromptBuilder`.
+
 Confirmation Prompts
 --------------------
 
@@ -46,3 +49,7 @@ There is also the option to make the function automatically abort the
 execution of the program if it does not return ``True``::
 
     click.confirm('Do you want to continue?', abort=True)
+
+As in `Input Prompts`_ described above, you can customize how to display
+and format the prompt via providing :param:`builder_cls` as an instance
+of :class:`PromptBuilder`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "click"
-version = "8.2.0.dev"
+version = "8.2.1.dev"
 description = "Composable command line interface toolkit"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -57,20 +57,39 @@ def hidden_prompt_func(prompt: str) -> str:
     return getpass.getpass(prompt)
 
 
-def _build_prompt(
-    text: str,
-    suffix: str,
-    show_default: bool = False,
-    default: t.Any | None = None,
-    show_choices: bool = True,
-    type: ParamType | None = None,
-) -> str:
-    prompt = text
-    if type is not None and show_choices and isinstance(type, Choice):
-        prompt += f" ({', '.join(map(str, type.choices))})"
-    if default is not None and show_default:
-        prompt = f"{prompt} [{_format_default(default)}]"
-    return f"{prompt}{suffix}"
+class PromptBuilder:
+    def build(
+        self,
+        text: str,
+        suffix: str,
+        show_default: bool = False,
+        default: t.Any | None = None,
+        show_choices: bool = True,
+        type: ParamType | None = None,
+    ) -> str:
+        prompt = (
+            text
+            + self.add_choices(show_choices=show_choices, type=type)
+            + self.add_default(show_default=show_default, default=default)
+        )
+        return f"{prompt}{suffix}"
+
+    def add_choices(
+        self, show_choices: bool = True, type: ParamType | None = None
+    ) -> str:
+        if type is not None and show_choices and isinstance(type, Choice):
+            return f" ({', '.join(map(str, type.choices))})"
+        return ""
+
+    def add_default(
+        self, show_default: bool = False, default: t.Any | None = None
+    ) -> str:
+        if default is not None and show_default:
+            return f" [{_format_default(default)}]"
+        return ""
+
+
+_build_prompt = PromptBuilder().build
 
 
 def _format_default(default: t.Any) -> t.Any:


### PR DESCRIPTION
This PR implements a base class which allows to customize prompt format when used directly via `click.prompt` or `click.confirm` methods.

It adds an optional parameter which can be an instance of a `PromptBuilder` class or one inheriting from it.

You can customize all of the below in any combination:

- how the prompt is built via overriding `build` method
- how the choices are shown via overriding `add_choices` method
- how the default is shown via overriding `add_default` method
- how to calculate if choices should be shown via overriding `should_add_choices` method
- how to calculate if default should be shown via overriding `should_add_default` method

---
fixes #2875