### PR TITLE
drop end of life python versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,7 @@ jobs:
           - {name: Mac, python: '3.12', os: macos-latest}
           - {python: '3.11'}
           - {python: '3.10'}
-          - {python: '3.9'}
-          - {python: '3.8'}
-          - {name: PyPy, python: 'pypy-3.10', tox: pypy310}
+          - {name: PyPy, python: 'pypy-3.11', tox: pypy311}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Version 8.2.0
 
 Released 2025-03-26
 
--   Drop support for Python 3.7. :pr:`2588`
+-   Drop support for Python 3.7, 3.8, and 3.9. :pr:`2588` :pr:`2892`
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`2438`
 -   Use ``flit_core`` instead of ``setuptools`` as build backend. :pr:`2543`

--- a/examples/aliases/pyproject.toml
+++ b/examples/aliases/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-aliases"
 version = "1.0.0"
 description = "Click aliases example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/colors/pyproject.toml
+++ b/examples/colors/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-colors"
 version = "1.0.0"
 description = "Click colors example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/completion/pyproject.toml
+++ b/examples/completion/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-completion"
 version = "1.0.0"
 description = "Click completion example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/complex/pyproject.toml
+++ b/examples/complex/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-complex"
 version = "1.0.0"
 description = "Click complex example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/imagepipe/pyproject.toml
+++ b/examples/imagepipe/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-imagepipe"
 version = "1.0.0"
 description = "Click imagepipe example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
     "pillow",

--- a/examples/inout/pyproject.toml
+++ b/examples/inout/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-inout"
 version = "1.0.0"
 description = "Click inout example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/naval/pyproject.toml
+++ b/examples/naval/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-naval"
 version = "1.0.0"
 description = "Click naval example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/repo/pyproject.toml
+++ b/examples/repo/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-repo"
 version = "1.0.0"
 description = "Click repo example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/termui/pyproject.toml
+++ b/examples/termui/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-termui"
 version = "1.0.0"
 description = "Click termui example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/examples/validation/pyproject.toml
+++ b/examples/validation/pyproject.toml
@@ -2,7 +2,7 @@
 name = "click-example-validation"
 version = "1.0.0"
 description = "Click validation example"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python",
     "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "colorama; platform_system == 'Windows'",
 ]
@@ -58,7 +58,7 @@ source = ["click", "tests"]
 source = ["src", "*/site-packages"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 files = ["src/click", "tests/typing"]
 show_error_codes = true
 pretty = true
@@ -71,7 +71,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 include = ["src/click", "tests/typing"]
 typeCheckingMode = "basic"
 
@@ -90,6 +90,9 @@ select = [
     "I",  # isort
     "UP",  # pyupgrade
     "W",  # pycodestyle warning
+]
+ignore = [
+    "UP038",  # keep isinstance tuples
 ]
 
 [tool.ruff.lint.isort]

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -90,7 +90,7 @@ def _check_nested_chain(
 
 
 def batch(iterable: cabc.Iterable[V], batch_size: int) -> list[tuple[V, ...]]:
-    return list(zip(*repeat(iter(iterable), batch_size)))
+    return list(zip(*repeat(iter(iterable), batch_size), strict=False))
 
 
 @contextmanager

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -652,7 +652,7 @@ class FloatRange(_NumberRangeBase, FloatParamType):
         if not open:
             return bound
 
-        # Could use Python 3.9's math.nextafter here, but clamping an
+        # Could use math.nextafter here, but clamping an
         # open float range doesn't seem to be particularly useful. It's
         # left up to the user to write a callback to do it if needed.
         raise RuntimeError("Clamping is not supported for open bounds.")
@@ -1060,7 +1060,9 @@ class Tuple(CompositeParamType):
                 ctx=ctx,
             )
 
-        return tuple(ty(x, param, ctx) for ty, x in zip(self.types, value))
+        return tuple(
+            ty(x, param, ctx) for ty, x in zip(self.types, value, strict=False)
+        )
 
 
 def convert_type(ty: t.Any | None, default: t.Any | None = None) -> ParamType:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -574,7 +574,7 @@ def test_iter_keepopenfile(tmpdir):
     p = tmpdir.mkdir("testdir").join("testfile")
     p.write("\n".join(expected))
     with p.open() as f:
-        for e_line, a_line in zip(expected, click.utils.KeepOpenFile(f)):
+        for e_line, a_line in zip(expected, click.utils.KeepOpenFile(f), strict=False):
             assert e_line == a_line.strip()
 
 
@@ -584,7 +584,7 @@ def test_iter_lazyfile(tmpdir):
     p.write("\n".join(expected))
     with p.open() as f:
         with click.utils.LazyFile(f.name) as lf:
-            for e_line, a_line in zip(expected, lf):
+            for e_line, a_line in zip(expected, lf, strict=False):
                 assert e_line == a_line.strip()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py3{13,12,11,10,9,8}
-    pypy310
+    py3{13,12,11,10}
+    pypy311
     style
     typing
     docs


### PR DESCRIPTION
Per our [version support policy](https://palletsprojects.com/versions):

> When a release is made, it supports all Python versions that are not within six months of end of life (EOL). See [Python's EOL calendar](https://devguide.python.org/versions/) for timing.

3.7 and 3.8 are already end of life. 3.9 is end of life in October.