### PR TITLE
Fix shell completion for nested groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 Version 8.2.1
 -------------
 
+- Fix shell completion for nested groups. :issue:`2906` :pr:`2907`
 
 Version 8.2.0
 -------------

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -567,8 +567,8 @@ def _resolve_context(
                     with cmd.make_context(
                         name, args, parent=ctx, resilient_parsing=True
                     ) as sub_ctx:
-                        args = ctx._protected_args + ctx.args
                         ctx = sub_ctx
+                        args = ctx._protected_args + ctx.args
                 else:
                     sub_ctx = ctx
 
@@ -586,8 +586,8 @@ def _resolve_context(
                             allow_interspersed_args=False,
                             resilient_parsing=True,
                         ) as sub_sub_ctx:
-                            args = sub_ctx.args
                             sub_ctx = sub_sub_ctx
+                            args = sub_ctx.args
 
                     ctx = sub_ctx
                     args = [*sub_ctx._protected_args, *sub_ctx.args]

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -40,6 +40,30 @@ def test_group():
     assert _get_words(cli, [], "-") == ["-a", "--help"]
 
 
+def test_nested_group():
+    cli = Group(
+        "cli",
+        commands=[
+            Group(
+                "get",
+                commands=[
+                    Group(
+                        "full",
+                        params=[Option(["--verbose"])],
+                        commands=[Command("data", params=[Option(["-a"])])],
+                    )
+                ],
+            )
+        ],
+    )
+    assert _get_words(cli, [], "") == ["get"]
+    assert _get_words(cli, ["get"], "") == ["full"]
+    assert _get_words(cli, ["get", "full"], "") == ["data"]
+    assert _get_words(cli, ["get", "full"], "-") == ["--verbose", "--help"]
+    assert _get_words(cli, ["get", "full", "data"], "") == []
+    assert _get_words(cli, ["get", "full", "data"], "-") == ["-a", "--help"]
+
+
 def test_group_command_same_option():
     cli = Group(
         "cli", params=[Option(["-a"])], commands=[Command("x", params=[Option(["-a"])])]


### PR DESCRIPTION
We need to extract the args from the fresh context when following nested groups to keep 8.1.8 behavior for shell completion in nested groups

fixes #2906

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
