### PR TITLE
Fix documenting-arguments anchor in docs

### DIFF
--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -30,8 +30,6 @@ Simple example:
     invoke(hello, args=['--help'])
 
 
-.. _documenting-arguments:
-
 Command Short Help
 ------------------
 
@@ -69,6 +67,8 @@ The help epilog is printed at the end of the help and is useful for showing exam
 .. click:run::
 
     invoke(init, args=['--help'])
+
+.. _documenting-arguments:
 
 Documenting Arguments
 ----------------------


### PR DESCRIPTION
Judging from other places in the documentation which link to this anchor, this anchor is misplaced:

https://click.palletsprojects.com/en/stable/parameters/:

![image](https://github.com/user-attachments/assets/044f58db-2eee-4dd9-8c39-114a097f31d4)

https://click.palletsprojects.com/en/stable/arguments/:

![image](https://github.com/user-attachments/assets/c356ec49-9efb-456e-8fff-9108e3ad3e34)

I don't think that https://click.palletsprojects.com/en/stable/documentation/#command-short-help is relevant in both of these. https://click.palletsprojects.com/en/stable/documentation/#id1 seems to be a better fit.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
