### PR TITLE
Update docs for enum choice

### DIFF
--- a/docs/parameter-types.rst
+++ b/docs/parameter-types.rst
@@ -33,8 +33,8 @@ Example:
     import enum
 
     class HashType(enum.Enum):
-        MD5 = 'MD5'
-        SHA1 = 'SHA1'
+        MD5 = enum.auto()
+        SHA1 = enum.auto()
 
     @click.command()
     @click.option('--hash-type',
@@ -54,9 +54,8 @@ What it looks like:
     println()
     invoke(digest, args=['--help'])
 
-Since version 8.2.0 any iterable may be passed to :class:`Choice`, here
-an ``Enum`` is used which will result in all enum values to be valid
-choices.
+Any iterable may be passed to :class:`Choice`. If an ``Enum`` is passed, the
+names of the enum members will be used as valid choices.
 
 Choices work with options that have ``multiple=True``. If a ``default``
 value is given with ``multiple=True``, it should be a list or tuple of


### PR DESCRIPTION
Update the documentation for passing an `Enum` to `click.Choice`.

fixes #2911 

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
