### PR TITLE
Fix flag value set when is_flag=True and type is provided

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 Version 8.2.1
 -------------
 
+-   Fix flag value handling for flag options with a provided type. :issue:`2894`
+    :issue:`2897` :pr:`2930`
 
 Version 8.2.0
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2610,10 +2610,11 @@ class Option(Parameter):
             else:
                 self.default = False
 
+        if is_flag and flag_value is None:
+            flag_value = not self.default
+
         self.type: types.ParamType
         if is_flag and type is None:
-            if flag_value is None:
-                flag_value = not self.default
             # Re-guess the type from the flag value instead of the
             # default.
             self.type = types.convert_type(None, flag_value)


### PR DESCRIPTION
When setting the value of a flag, check only if `is_flag` is `True` and `flag_value` is not provided when negating the default flag value.

#2829 introduced a bug by checking if the type of the flag is `None` before setting the value.
Since we still check if `is_flag` is set, objects without a `__bool__` method will not raise an error if `is_flag` is not set.

fixes #2894
fixes #2897

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
