### PR TITLE
Raise an exception on end of input in CliRunner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 8.2.1
     :issue:`2897` :pr:`2930`
 -   Fix shell completion for nested groups. :issue:`2906` :pr:`2907`
 -   Flush ``sys.stderr`` at the end of ``CliRunner.invoke``. :issue:`2682`
+-   Fix EOF handling for stdin input in CliRunner. :issue:`2787`
 
 Version 8.2.0
 -------------

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -116,6 +116,13 @@ class _NamedTextIOWrapper(io.TextIOWrapper):
     def mode(self) -> str:
         return self._mode
 
+    def __next__(self) -> str:  # type: ignore
+        try:
+            line = super().__next__()
+        except StopIteration as e:
+            raise EOFError() from e
+        return line
+
 
 def make_input_stream(
     input: str | bytes | t.IO[t.Any] | None, charset: str
@@ -341,7 +348,7 @@ class CliRunner:
         @_pause_echo(echo_input)  # type: ignore
         def visible_input(prompt: str | None = None) -> str:
             sys.stdout.write(prompt or "")
-            val = text_input.readline().rstrip("\r\n")
+            val = next(text_input).rstrip("\r\n")
             sys.stdout.write(f"{val}\n")
             sys.stdout.flush()
             return val
@@ -350,7 +357,7 @@ class CliRunner:
         def hidden_input(prompt: str | None = None) -> str:
             sys.stdout.write(f"{prompt or ''}\n")
             sys.stdout.flush()
-            return text_input.readline().rstrip("\r\n")
+            return next(text_input).rstrip("\r\n")
 
         @_pause_echo(echo_input)  # type: ignore
         def _getchar(echo: bool) -> str:

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -163,8 +163,8 @@ def test_pipeline(runner, args, input, expect):
         return processor
 
     result = runner.invoke(cli, args, input=input)
-    assert not result.exception
-    assert result.output.splitlines() == expect
+    # last two lines are '' and 'Aborted!'
+    assert result.output.splitlines()[:-2] == expect
 
 
 def test_args_and_chain(runner):

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -242,7 +242,7 @@ def test_file_prompt_default_format(runner, file_kwargs):
     def cli(f):
         click.echo(f.name)
 
-    result = runner.invoke(cli)
+    result = runner.invoke(cli, input="\n")
     assert result.output == f"file [{__file__}]: \n{__file__}\n"
 
 
@@ -451,7 +451,7 @@ def test_prompt_required_false(runner, args, expect):
     [
         (True, "password\npassword", None, "password"),
         ("Confirm Password", "password\npassword\n", None, "password"),
-        (True, "", "", ""),
+        (True, "\n\n", "", ""),
         (False, None, None, None),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,6 +179,19 @@ def test_prompts_abort(monkeypatch, capsys):
     assert out == "Password:\ninterrupted\n"
 
 
+def test_prompts_eof(runner):
+    """If too few lines of input are given, prompt should exit, not hang."""
+
+    @click.command
+    def echo():
+        for _ in range(3):
+            click.echo(click.prompt("", type=int))
+
+    # only provide two lines of input for three prompts
+    result = runner.invoke(echo, input="1\n2\n")
+    assert result.exit_code == 1
+
+
 def _test_gen_func():
     yield "a"
     yield "b"


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
When end of input is reached in CliRunner, `_NamedTextIOWrapper.readline` continues to return an empty string which does not match the behavior when running the program at the command line (in this case an EOFError is raised which causes an Abort to be raised).

Using `next()` instead of `readline` will raise `StopIteration` from `TextIOWrapper`. If we want to perfectly match the behavior of regular input, we could override `__next__` to raise `EOFError` (this will require a type: ignore due to mypy comparing types with `IOBase` instead of `TextIOWrapper`).

fixes #2787

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
