### PR TITLE
Fixed the description of `is_flag=False, flag_value=value`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -432,8 +432,8 @@ providing only the option's flag without a value will either show a
 prompt or use its `flag_value`.
 
 Setting `is_flag=False, flag_value=value` tells Click that the option
-can still be passed a value, but only if the flag is given the
-`flag_value`.
+can still be passed a value, but if only the flag is given, the
+value will be `flag_value`.
 
 ```{eval-rst}
 .. click:example::


### PR DESCRIPTION
The text had "only if", but the example shows that the behavior "if only" the flag is given, is to return the `flag_value`.

This really confused me the first several times I read it, until I carefully studied the example.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
