### PR TITLE
Fix import path

### DIFF
--- a/docs/entry-points.rst
+++ b/docs/entry-points.rst
@@ -55,7 +55,7 @@ Contents of ``pyproject.toml``:
     ]
 
     [project.scripts]
-    hello = "hello:cli"
+    hello = "hello.hello:cli"
 
     [build-system]
     requires = ["flit_core<4"]


### PR DESCRIPTION
Following the instruction of the [docs for Packaging Entry Points](https://click.palletsprojects.com/en/stable/entry-points/) does not work out of the box if you leave your `__init__.py` empty. 

So either remind people to export their functions in their `__init__.py` or fix the import path specified in the `pyproject.toml` to `hello.hello`, resulting in:
```toml
    [project.scripts]
    hello = "hello.hello:cli"
```