### PR TITLE
Use Enum value for token normalization

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -295,7 +295,7 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
 
         .. versionadded:: 8.2.0
         """
-        normed_value = choice.name if isinstance(choice, enum.Enum) else str(choice)
+        normed_value = choice.value if isinstance(choice, enum.Enum) else str(choice)
 
         if ctx is not None and ctx.token_normalize_func is not None:
             normed_value = ctx.token_normalize_func(normed_value)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -418,19 +418,19 @@ def test_choice_argument_enum(runner):
         assert isinstance(method, MyEnum)
         click.echo(method)
 
-    result = runner.invoke(cli, ["foo"])
+    result = runner.invoke(cli, ["foo-value"])
     assert result.output == "foo-value\n"
     assert not result.exception
 
     result = runner.invoke(cli, ["meh"])
     assert result.exit_code == 2
     assert (
-        "Invalid value for '{foo|bar|baz}': 'meh' is not one of 'foo',"
-        " 'bar', 'baz'." in result.output
+        "Invalid value for '{foo-value|bar-value|baz-value}': 'meh' is not one of"
+        " 'foo-value', 'bar-value', 'baz-value'." in result.output
     )
 
     result = runner.invoke(cli, ["--help"])
-    assert "{foo|bar|baz}" in result.output
+    assert "{foo-value|bar-value|baz-value}" in result.output
 
 
 def test_choice_argument_custom_type(runner):


### PR DESCRIPTION
Uses Enum value instead of Enum name when normalizing Enum choices in `click.Choice`.

fixes #2959 