### PR TITLE
param hints should not show (env var: None) hint

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2676,7 +2676,7 @@ class Option(Parameter):
 
     def get_error_hint(self, ctx: Context) -> str:
         result = super().get_error_hint(ctx)
-        if self.show_envvar:
+        if self.show_envvar and self.envvar:
             result += f" (env var: '{self.envvar}')"
         return result
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -591,6 +591,13 @@ def test_missing_envvar(runner):
     result = runner.invoke(cli)
     assert result.exit_code == 2
     assert "Error: Missing option '--foo' (env var: 'bar')." in result.output
+    cli = click.Command(
+        "cli",
+        params=[click.Option(["--foo"], envvar=None, show_envvar=True, required=True)],
+    )
+    result = runner.invoke(cli)
+    assert result.exit_code == 2
+    assert "Error: Missing option '--foo'." in result.output
 
 
 def test_case_insensitive_choice(runner):


### PR DESCRIPTION
Environment variable name was added to the error message. Cool, but that is pretty useless if there is not an env var defined for that particular option. 

fixes #<2964>