### PR TITLE
Don't include envvar in error hint when envvar not configured

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: click
 
+Version 8.2.0
+-------------
+
+Unreleased
+
+- Don't include envvar in error hint when not configured. :issue:`2971`
+
 Version 8.2.1
 -------------
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2676,7 +2676,7 @@ class Option(Parameter):
 
     def get_error_hint(self, ctx: Context) -> str:
         result = super().get_error_hint(ctx)
-        if self.show_envvar:
+        if self.show_envvar and self.envvar is not None:
             result += f" (env var: '{self.envvar}')"
         return result
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -592,6 +592,13 @@ def test_missing_envvar(runner):
     assert result.exit_code == 2
     assert "Error: Missing option '--foo' (env var: 'bar')." in result.output
 
+    cli = click.Command(
+        "cli", params=[click.Option(["--foo"], show_envvar=True, required=True)]
+    )
+    result = runner.invoke(cli)
+    assert result.exit_code == 2
+    assert "Error: Missing option '--foo'." in result.output
+
 
 def test_case_insensitive_choice(runner):
     @click.command()


### PR DESCRIPTION
Add a check for if `envvar` is `None` before appending to the error hint text.

fixes #2971