### PR TITLE
Using correct typing for `param_hint`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Unreleased
 -   Fix reconciliation of `default`, `flag_value` and `type` parameters for
     flag options, as well as parsing and normalization of environment variables.
     :issue:`2952` :pr:`2956`
+-   Fix typing issue in ``BadParameter`` and ``MissingParameter`` exceptions for the
+    parameter ``param_hint`` that did not allow for a sequence of string where the
+    underlying functino ``_join_param_hints`` allows for it. :issue:`2777` :pr:`2990`
 
 Version 8.2.1
 -------------

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -115,7 +115,7 @@ class BadParameter(UsageError):
         message: str,
         ctx: Context | None = None,
         param: Parameter | None = None,
-        param_hint: str | None = None,
+        param_hint: cabc.Sequence[str] | str | None = None,
     ) -> None:
         super().__init__(message, ctx)
         self.param = param
@@ -151,7 +151,7 @@ class MissingParameter(BadParameter):
         message: str | None = None,
         ctx: Context | None = None,
         param: Parameter | None = None,
-        param_hint: str | None = None,
+        param_hint: cabc.Sequence[str] | str | None = None,
         param_type: str | None = None,
     ) -> None:
         super().__init__(message or "", ctx, param, param_hint)
@@ -159,7 +159,7 @@ class MissingParameter(BadParameter):
 
     def format_message(self) -> str:
         if self.param_hint is not None:
-            param_hint: str | None = self.param_hint
+            param_hint: cabc.Sequence[str] | str | None = self.param_hint
         elif self.param is not None:
             param_hint = self.param.get_error_hint(self.ctx)  # type: ignore
         else:


### PR DESCRIPTION
The typing of `param_hint` between `BadParameter`, `MissingParameter` and `_join_param_hints` was different. The firsts only allowed for a `str` where the later also accept a sequence of `str`.

Fixes https://github.com/pallets/click/issues/2777

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
