### PR TITLE
fix a race in `click.testing.StreamMixer`'s finalization, seen in a multi-threaded context

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -99,6 +99,18 @@ class StreamMixer:
         self.stdout: io.BytesIO = BytesIOCopy(copy_to=self.output)
         self.stderr: io.BytesIO = BytesIOCopy(copy_to=self.output)
 
+    def __del__(self) -> None:
+        """
+        Guarantee that embedded file-like objects are closed in a
+        predictable order, protecting against races between
+        self.output being closed and other streams being flushed on close
+
+        .. versionadded:: 8.2.2
+        """
+        self.stderr.close()
+        self.stdout.close()
+        self.output.close()
+
 
 class _NamedTextIOWrapper(io.TextIOWrapper):
     def __init__(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -448,8 +448,7 @@ def test_isolation_stderr_errors():
 
     with runner.isolation() as (_, err, _):
         click.echo("\udce2", err=True, nl=False)
-
-    assert err.getvalue() == b"\\udce2"
+        assert err.getvalue() == b"\\udce2"
 
 
 def test_isolation_flushes_unflushed_stderr():
@@ -460,8 +459,7 @@ def test_isolation_flushes_unflushed_stderr():
 
     with runner.isolation() as (_, err, _):
         click.echo("\udce2", err=True, nl=False)
-
-    assert err.getvalue() == b"\\udce2"
+        assert err.getvalue() == b"\\udce2"
 
     @click.command()
     def cli():


### PR DESCRIPTION
xref https://github.com/python/cpython/issues/136248
xref https://github.com/neutrinoceros/inifix/issues/421

The reproducer I used to work on this involves `typer` and multi-threading, and isn't *consistently* failing: I originally only hit the race about once in 10k tries, so this seems difficult to test systematically.
I also am not sure this rare bug warrents an entry in `CHANGES.rst`, but I'm glad to add it if needed.

~Possibly close #824 (?) (more work needed to confirm this)~

update: scratch that, this is a similar looking but different error. My patch doesn't fix the reproducer from https://github.com/pallets/click/issues/824#issuecomment-3027263262

update 2: close #2993

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
