### PR TITLE
Improve discoverability of Context.max_content_width

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -147,7 +147,7 @@ For single option boolean flags, the default remains hidden if the default value
 
 ## Click's Wrapping Behavior
 
-Click's default wrapping ignores single new lines and rewraps the text based on the width of the terminal, to a maximum of 80 characters. In the example notice how the second grouping of three lines is rewrapped into a single paragraph.
+Click's default wrapping ignores single new lines and rewraps the text based on the width of the terminal to a maximum of 80 characters by default, but this can be modified with {attr}`~Context.max_content_width`. In the example notice how the second grouping of three lines is rewrapped into a single paragraph.
 
 ```{eval-rst}
 .. click:example::


### PR DESCRIPTION
It took me a while to find this option (because I was not familiar with the `Context` class at all,
so I figured this would be an improvement in the documentation.

