### PR TITLE
test: add two new tests for `Parameter.__init__` (recreation of #2861)

### DIFF
--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -63,6 +63,15 @@ def test_nargs_tup_composite(runner, opts):
     assert result.output.splitlines() == ["name=peter id=1"]
 
 
+def test_nargs_mismatch_with_tuple_type():
+    with pytest.raises(ValueError, match="nargs.*must be 2.*but it was 3"):
+
+        @click.command()
+        @click.argument("test", type=(str, int), nargs=3)
+        def cli(_):
+            pass
+
+
 def test_nargs_err(runner):
     @click.command()
     @click.argument("x")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1453,3 +1453,33 @@ def test_duplicate_names_warning(runner, opts_one, opts_two):
 
     with pytest.warns(UserWarning):
         runner.invoke(cli, [])
+
+
+@pytest.mark.parametrize(
+    ("multiple", "nargs", "default", "expected_message"),
+    [
+        (
+            False,  # multiple
+            2,  # nargs
+            42,  # default (not a list)
+            "'default' must be a list when 'nargs' != 1.",
+        ),
+        (
+            True,  # multiple
+            2,  # nargs
+            [
+                "test string which is not a list in the list"
+            ],  # default (list of non-lists)
+            "'default' must be a list of lists when 'multiple' is true"
+            " and 'nargs' != 1.",
+        ),
+    ],
+)
+def test_default_type_error_raises(multiple, nargs, default, expected_message):
+    with pytest.raises(ValueError, match=expected_message):
+        click.Option(
+            ["--test"],
+            multiple=multiple,
+            nargs=nargs,
+            default=default,
+        )


### PR DESCRIPTION
This is a recreation of #2861, which has been closed and lost by mistake.

It fixes #2860.