### PR TITLE
Fix completions for quoted/escaped parameters in Fish

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -405,6 +405,8 @@ class FishComplete(ShellComplete):
     def get_completion_args(self) -> tuple[list[str], str]:
         cwords = split_arg_string(os.environ["COMP_WORDS"])
         incomplete = os.environ["COMP_CWORD"]
+        if incomplete:
+            incomplete = split_arg_string(incomplete)[0]
         args = cwords[1:]
 
         # Fish stores the partial word in both COMP_WORDS and

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -346,6 +346,7 @@ def test_full_source(runner, shell):
         ("zsh", {"COMP_WORDS": "a b", "COMP_CWORD": "1"}, "plain\nb\nbee\n"),
         ("fish", {"COMP_WORDS": "", "COMP_CWORD": ""}, "plain,a\nplain,b\tbee\n"),
         ("fish", {"COMP_WORDS": "a b", "COMP_CWORD": "b"}, "plain,b\tbee\n"),
+        ("fish", {"COMP_WORDS": 'a "b', "COMP_CWORD": '"b'}, "plain,b\tbee\n"),
     ],
 )
 @pytest.mark.usefixtures("_patch_for_completion")


### PR DESCRIPTION
Fix completions for Fish shell when the value being completed has spaces
or is enclosed in quotes

Fixes #2995 

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
