### PR TITLE
Fix Choice(enum) auto complete not working 

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -387,7 +387,9 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
         """
         from click.shell_completion import CompletionItem
 
-        str_choices = map(str, self.choices)
+        str_choices = map(
+            lambda choice: self.normalize_choice(choice, ctx=ctx), self.choices
+        )
 
         if self.case_sensitive:
             matched = (c for c in str_choices if c.startswith(incomplete))

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,3 +1,4 @@
+import enum
 import textwrap
 import warnings
 from collections.abc import Mapping
@@ -141,6 +142,18 @@ def test_argument_default():
 
 def test_type_choice():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["a1", "a2", "b"]))])
+    assert _get_words(cli, ["-c"], "") == ["a1", "a2", "b"]
+    assert _get_words(cli, ["-c"], "a") == ["a1", "a2"]
+    assert _get_words(cli, ["-c"], "a2") == ["a2"]
+
+
+def test_type_enum_choice():
+    class MyEnum(enum.Enum):
+        a1 = enum.auto()
+        a2 = enum.auto()
+        b = enum.auto()
+
+    cli = Command("cli", params=[Option(["-c"], type=Choice(MyEnum))])
     assert _get_words(cli, ["-c"], "") == ["a1", "a2", "b"]
     assert _get_words(cli, ["-c"], "a") == ["a1", "a2"]
     assert _get_words(cli, ["-c"], "a2") == ["a2"]

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -470,7 +470,7 @@ def test_context_settings(runner):
     assert result.output == "plain,a\nplain,b\n"
 
 
-@pytest.mark.parametrize(("value", "expect"), [(False, ["Au", "al"]), (True, ["al"])])
+@pytest.mark.parametrize(("value", "expect"), [(False, ["au", "al"]), (True, ["al"])])
 def test_choice_case_sensitive(value, expect):
     cli = Command(
         "cli",


### PR DESCRIPTION
Autocomplete on choices with enums was not working as it didn't use the same logic to normalize it's string value.
I added a test to show the wrong behavior. 

However, when I use the same normalize function I see another test failing, and I wanted to discuss. As from my understanding it is allowed to overwrite the normalize method, so I think we have to use it here, in case it is changed to custom behaviour, as whatever is autocompleted should be a valid input. But this means that default behavior would be that we autocomplete for example Fo to foo if the options are [Foo, Bar] with case insensitive, which fails an existing test and could be seen as a breaking change. Please advice, thank you.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->


fixes #3015


<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
