### PR TITLE
Properly lazily import shutil

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -17,7 +17,6 @@ import typing as t
 from gettext import gettext as _
 from io import StringIO
 from pathlib import Path
-from shutil import which
 from types import TracebackType
 
 from ._compat import _default_text_stdout
@@ -235,8 +234,6 @@ class ProgressBar(t.Generic[V]):
         ).rstrip()
 
     def render_progress(self) -> None:
-        import shutil
-
         if self.hidden:
             return
 
@@ -250,6 +247,8 @@ class ProgressBar(t.Generic[V]):
         buf = []
         # Update width in case the terminal has been resized
         if self.autowidth:
+            import shutil
+
             old_width = self.width
             self.width = 0
             clutter_length = term_len(self.format_progress_line())
@@ -421,10 +420,13 @@ def _pipepager(
     # Split the command into the invoked CLI and its parameters.
     if not cmd_parts:
         return False
+    
+    import shutil
+
     cmd = cmd_parts[0]
     cmd_params = cmd_parts[1:]
 
-    cmd_filepath = which(cmd)
+    cmd_filepath = shutil.which(cmd)
     if not cmd_filepath:
         return False
     # Resolves symlinks and produces a normalized absolute path string.
@@ -510,9 +512,12 @@ def _tempfilepager(
     # Split the command into the invoked CLI and its parameters.
     if not cmd_parts:
         return False
+
+    import shutil
+
     cmd = cmd_parts[0]
 
-    cmd_filepath = which(cmd)
+    cmd_filepath = shutil.which(cmd)
     if not cmd_filepath:
         return False
     # Resolves symlinks and produces a normalized absolute path string.
@@ -573,6 +578,9 @@ class Editor:
                 return rv
         if WIN:
             return "notepad"
+
+        from shutil import which
+
         for editor in "sensible-editor", "vim", "nano":
             if which(editor) is not None:
                 return editor

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -420,7 +420,7 @@ def _pipepager(
     # Split the command into the invoked CLI and its parameters.
     if not cmd_parts:
         return False
-    
+
     import shutil
 
     cmd = cmd_parts[0]

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -119,12 +119,12 @@ class HelpFormatter:
         width: int | None = None,
         max_width: int | None = None,
     ) -> None:
-        import shutil
-
         self.indent_increment = indent_increment
         if max_width is None:
             max_width = 80
         if width is None:
+            import shutil
+
             width = FORCED_WIDTH
             if width is None:
                 width = max(min(shutil.get_terminal_size().columns, max_width) - 2, 50)

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -5,7 +5,6 @@ import contextlib
 import io
 import os
 import shlex
-import shutil
 import sys
 import tempfile
 import typing as t
@@ -571,6 +570,8 @@ class CliRunner:
             os.chdir(cwd)
 
             if temp_dir is None:
+                import shutil
+
                 try:
                     shutil.rmtree(dt)
                 except OSError:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -43,7 +43,6 @@ ALLOWED_IMPORTS = {
     "itertools",
     "os",
     "re",
-    "shutil",
     "stat",
     "struct",
     "sys",


### PR DESCRIPTION
I agree with the intention to lazily import but it wasn't actually happening. Locally I get the following on Python 3.12:

```
❯ python -m timeit -n 1 -r 1 "import shutil"
1 loop, best of 1: 8.09 msec per loop
```