### PR TITLE
Tone-down the case of `default=True` for flags in documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,16 @@ Version 8.3.x
 
 Unreleased
 
--   Rework relationship between ``flag_value`` and ``default``: the value given to
-    ``default`` is now left untouched, and keep the value it receive. So
-    ``default=<desired_value>`` is respected and ``<desired_value>`` is passed on as-is
-    to the CLI function. With the exception of flag options, where setting
-    ``default=True`` maintain the legacy behavior of defaulting to the ``flag_value``.
-    This allow ``default`` to be of any type, including ``bool`` or ``None``, fixing
-    inconsistencies reported in: :issue:`1992` :issue:`2012` :issue:`2514`
-    :issue:`2610` :issue:`3024` :pr:`3030`
+-   **Improved flag option handling**: Reworked the relationship between ``flag_value``
+    and ``default`` parameters for better consistency:
+
+    * The ``default`` parameter value is now preserved as-is and passed directly
+      to CLI functions (no more unexpected transformations)
+    * Exception: flag options with ``default=True`` maintain backward compatibility
+      by defaulting to their ``flag_value``
+    * The ``default`` parameter can now be any type (``bool``, ``None``, etc.)
+    * Fixes inconsistencies reported in: :issue:`1992` :issue:`2514` :issue:`2610`
+      :issue:`3024` :pr:`3030`
 -   Allow ``default`` to be set on ``Argument`` for ``nargs = -1``. :issue:`2164`
     :pr:`3030`
 -   Show correct auto complete value for ``nargs`` option in combination with flag

--- a/docs/options.md
+++ b/docs/options.md
@@ -335,14 +335,12 @@ To have an flag pass a value to the underlying function set `flag_value`. This a
     invoke(info)
 ```
 
-````{caution}
-The `default` argument of options always give to the underlying function its value *as-is*.
+````{note}
+The `default` value is given to the underlying function as-is. So if you set `default=None`, the value passed to the function is the `None` Python value. Same for any other type.
 
-But for flags, the interaction between `flag_value` and `default` is a bit special.
+But there is a special case for flags. If a flag has a `flag_value`, then setting `default=True` is interpreted as *the flag should be activated by default*. So instead of the underlying function receiving the `True` Python value, it will receive the `flag_value`.
 
-If a flag has a `flag_value`, setting `default` to `True` means that the flag is activated by default. Not that the value passed to the underlying function is the `True` Python value. Instead, the default value will be aligned to the `flag_value` behind the scenes.
-
-Which means, the in example above, this option:
+Which means, in example above, this option:
 
 ```python
 @click.option('--upper', 'transformation', flag_value='upper', default=True)
@@ -354,9 +352,7 @@ is equivalent to:
 @click.option('--upper', 'transformation', flag_value='upper', default='upper')
 ```
 
-This was implemented to support legacy behavior, that will be removed in Click 9.0 to allow for default to take any value, including `True`.
-
-In the mean time, to avoid confusion, it is recommended to always set `default` to the actual default value you want to pass to the underlying function, and not use `True`, `False` or `None`. Unless that's the precise value you want to explicitly force as default.
+Because the two are equivalent, it is recommended to always use the second form, and set `default` to the actual value you want to pass. And not use the special `True` case. This makes the code more explicit and predictable.
 ````
 
 ## Values from Environment Variables

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -302,8 +302,8 @@ def test_boolean_conversion(runner, value, expect):
         (None, [], None),
         # Default is normalized to None if it is UNSET.
         (UNSET, [], None),
-        # Legacy case: if default=True and flag_value is set, The value returned is the
-        # flag_value, not default itself.
+        # Special case: if default=True and flag_value is set, the value returned is the
+        # flag_value, not the True Python value itself.
         (True, [], "upper"),
         # Non-string defaults are process as strings by the default Parameter's type.
         (False, [], "False"),

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1478,11 +1478,11 @@ def test_invalid_flag_definition(runner, args, opts):
         ("xMl", [], "xMl"),
         (" ᕕ( ᐛ )ᕗ ", [], " ᕕ( ᐛ )ᕗ "),
         (None, [], None),
-        # Legacy case: UNSET is not exposed directly to the callback, but converted to
+        # Special case: UNSET is not provided as-is to the callback, but normalized to
         # None.
         (UNSET, [], None),
-        # Legacy case: if default=True and flag_value is set, The value returned is the
-        # flag_value, not default itself.
+        # Special case: if default=True and flag_value is set, the value returned is the
+        # flag_value, not the True Python value itself.
         (True, [], "js"),
         # Non-string defaults are process as strings by the default Parameter's type.
         (False, [], "False"),


### PR DESCRIPTION
This PR reduce the strong langage around the behavior of `default=True` aligning to `flag_value` for flag options. There is not need to declare that case legacy as it has been Click's behavior for a long time.

This address issues uncovered by @davidism in https://github.com/pallets/click/pull/3030#issuecomment-3218244596 .

### Context

This is a follow-up on #3030, which has been merged a little bit early and needs some polishing before Click 8.3.0 release.

Amends: 06847da9126a99c88bf347adf213d33bfe4e4af2
