### PR TITLE
Forward exception information to resources registered in a context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Unreleased
 -   Show correct auto complete value for nargs option in combination with flag option :issue:`2813`
 -   Fix handling of quoted and escaped parameters in Fish autocompletion. :issue:`2995` :pr:`3013`
 -   Lazily import ``shutil``. :pr:`3023`
+-   Properly forward exception information to resources registered with
+    ``click.core.Context.with_resource()``. :issue:`2447` :pr:`3058`
 
 Version 8.2.2
 -------------


### PR DESCRIPTION
Updated `Context.close` and `Context.__exit__` to allow forwarding exceptions to the `__exit__` methods of the resources registered using `Context.with_resource`.

Added an extra function to handle both `Context.close` and `Context.__exit__`, called `Context._close_with_exception_info` that accepts all the parameters that `__exit__` and moved the `Content.close` logic there.

Added relevant tests.

- fixes #2447

