### PR TITLE
Hide `Sentinel.UNSET` values for defaults processed by `Context.invoke`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Version 8.3.x
 
 Unreleased
 
--   Don't discard pager arguments by correctly using subprocess.Popen. :issue:`3039` :pr:`3055`
+-   Don't discard pager arguments by correctly using ``subprocess.Popen``. :issue:`3039`
+    :pr:`3055`
 -   Replace ``Sentinel.UNSET`` default values by ``None`` as they're passed through
     the ``Context.invoke()`` method. :issue:`3066` :issue:`3065` :pr:`3068`
 
@@ -32,7 +33,7 @@ Released 2025-09-17
 -   Lazily import ``shutil``. :pr:`3023`
 -   Properly forward exception information to resources registered with
     ``click.core.Context.with_resource()``. :issue:`2447` :pr:`3058`
--   Fix regression related to EOF handling in CliRunner. :issue:`2939` :pr:`2940`
+-   Fix regression related to EOF handling in ``CliRunner``. :issue:`2939` :pr:`2940`
 
 Version 8.2.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ Version 8.3.x
 Unreleased
 
 -   Don't discard pager arguments by correctly using subprocess.Popen. :issue:`3039` :pr:`3055`
-
-
+-   Replace ``Sentinel.UNSET`` default values by ``None`` as they're passed through
+    the ``Context.invoke()`` method. :issue:`3066` :issue:`3065` :pr:`3068`
 
 Version 8.3.0
 --------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -799,8 +799,18 @@ class Context:
 
             for param in other_cmd.params:
                 if param.name not in kwargs and param.expose_value:
+                    default_value = param.get_default(ctx)
+                    # We explicitly hide the :attr:`UNSET` value to the user, as we
+                    # choose to make it an implementation detail. And because ``invoke``
+                    # has been designed as part of Click public API, we return ``None``
+                    # instead. Refs:
+                    # https://github.com/pallets/click/issues/3066
+                    # https://github.com/pallets/click/issues/3065
+                    # https://github.com/pallets/click/pull/3068
+                    if default_value is UNSET:
+                        default_value = None
                     kwargs[param.name] = param.type_cast_value(  # type: ignore
-                        ctx, param.get_default(ctx)
+                        ctx, default_value
                     )
 
             # Track all kwargs as params, so that forward() will pass


### PR DESCRIPTION
This PR demonstrate and confirm the issue reported in #3066.

It was originally mentioned in #3065.

### Context

This issue follow the introduction in 8.3.0 of a `Sentinel.UNSET` object via the https://github.com/pallets/click/pull/3030 PR. This PR is itself fixing loads of latent edge-cases around flag options, env vars and default values.

The `Context.invoke` method has always been lightly covered by unit tests. So the effect of the introduction of the sentinel did not surfaced during 8.3.0 development. It was only caught by upstream users once 8.3.0 was released.

### Reproduction

Without a patch, we actually have this error:
```
__________ test_other_command_invoke_with_defaults[opt_params4-None] ___________
  tests/test_commands.py:276: in test_other_command_invoke_with_defaults
      assert result.return_value == ("other", expected)
  E   AssertionError: assert ('other', Sentinel.UNSET) == ('other', None)
  E     
  E     At index 1 diff: Sentinel.UNSET != None
  E     
  E     Full diff:
  E       (
  E           'other',
  E     -     None,
  E     +     Sentinel.UNSET,
  E       )
  __________ test_other_command_invoke_with_defaults[opt_params10-None] __________
  tests/test_commands.py:276: in test_other_command_invoke_with_defaults
      assert result.return_value == ("other", expected)
  E   AssertionError: assert ('other', Sentinel.UNSET) == ('other', None)
  E     
  E     At index 1 diff: Sentinel.UNSET != None
  E     
  E     Full diff:
  E       (
  E           'other',
  E     -     None,
  E     +     Sentinel.UNSET,
  E       )
```

### Fix

I propose to simply hide the `UNSET` sentinel within this method as too many projects expect it to be public.

This is not really elegant but is in line with the policy we adopted:
- to hide `UNSET` in `to_info_dict()` method in the original PR:
  - https://github.com/pallets/click/pull/3030/files#diff-11ba83cac151f7b24a1ed7c31a2a522d24d190cfa43199aa478d1e9cd2e6c610L2677-R2820
  - https://github.com/pallets/click/pull/3030#discussion_r2270002483
- to hide `UNSET` in the `callback` in the original PR:
  - https://github.com/pallets/click/commit/029bbeda76aa824149f110408d56de7b402a87ed
  - https://github.com/pallets/click/pull/3030#discussion_r2291553604
- to defer `UNSET` handling as default value in a hotfix for 8.3.0:
  - #3079