### PR TITLE
Require flit-core v3.11+ to ensure license metadata in the distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ typing = [
 ]
 
 [build-system]
-requires = ["flit_core<4"]
+requires = ["flit_core>=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.module]


### PR DESCRIPTION
The distributions of Click v8.1.8 (and probably some earlier ones) don't include license metadata fields. To confirm this, download the distributions and check `click-8.1.8/PKG-INFO` in the source distribution and `click-8.1.8.dist-info/METADATA` in the wheel distribution. According to my research, [`flit-core` v3.11+ is needed for writing license file metadata](https://flit.pypa.io/en/latest/pyproject_toml.html#build-system-section), which was published on 2025-02-19, while Click v8.1.8 was published on 2024-12-21. As a result,

https://github.com/pallets/click/blob/934813e4d421071a1b3db3973c02fe2721359a6e/pyproject.toml#L5

is omitted from the core metadata of the distributions when built with `flit-core` prior to v3.11.

In the meantime, v8.2.0+ got released which include license metadata fields in the distributions – but only coincidentally because `flit-core` v3.11+ had been released and `flit-core<4` was resolved to v3.11+ then. But given the current license-related project metadata, only `flit-core` v3.11+ produces distributions that include license metadata, which can be ensured with a lower bound on `flit-core`, added in this PR. Long story for a minor change. :smile: