### PR TITLE
Fix: Bleeding Sentinel.UNSET to upstream users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: click
 
+Version 8.3.1
+--------------
+
+Released TBD
+
+-   **No Sentinel.UNSET seen by users**: Changed how ``UNSET`` is passed from
+    one context to another so that it does not get returned to users.
+
 Version 8.3.0
 --------------
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -799,9 +799,10 @@ class Context:
 
             for param in other_cmd.params:
                 if param.name not in kwargs and param.expose_value:
-                    kwargs[param.name] = param.type_cast_value(  # type: ignore
+                    value = param.type_cast_value(  # type: ignore
                         ctx, param.get_default(ctx)
                     )
+                    kwargs[param.name] = value if value is not UNSET else None
 
             # Track all kwargs as params, so that forward() will pass
             # them on in subsequent calls.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -238,7 +238,9 @@ def test_other_command_invoke_with_defaults(runner):
     @click.option("-a", type=click.INT, default=42)
     @click.option("-b", type=click.INT, default="15")
     @click.option("-c", multiple=True)
-    @click.option("-d",)
+    @click.option(
+        "-d",
+    )
     @click.pass_context
     def other_cmd(ctx, a, b, c, d):
         return ctx.info_name, a, b, c, d

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -238,14 +238,15 @@ def test_other_command_invoke_with_defaults(runner):
     @click.option("-a", type=click.INT, default=42)
     @click.option("-b", type=click.INT, default="15")
     @click.option("-c", multiple=True)
+    @click.option("-d",)
     @click.pass_context
-    def other_cmd(ctx, a, b, c):
-        return ctx.info_name, a, b, c
+    def other_cmd(ctx, a, b, c, d):
+        return ctx.info_name, a, b, c, d
 
     result = runner.invoke(cli, standalone_mode=False)
     # invoke should type cast default values, str becomes int, empty
     # multiple should be empty tuple instead of None
-    assert result.return_value == ("other", 42, 15, ())
+    assert result.return_value == ("other", 42, 15, (), None)
 
 
 def test_invoked_subcommand(runner):


### PR DESCRIPTION
# Summary

Since release `v8.3.0`, the `Sentinel.UNSET` enum value has been bleeding to users of click where options have no default and the value is not required.

This commit contains a test which failed demonstrating the bleeding `UNSET` value and the fix in `src/click/core.py` to return to the previous behavior of returning `None`.

## Issues mentioning this bug

fixes #3065 
fixes #3066 
fixes #3069 

## Moving forward

I'd like feedback on this.

- Is this the right place to make the change?
- Would you like to see more tests to cover this?
- What changes are necessary for the `CHANGES.rst`? I've made a pass, but I cannot guarantee its correct.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
