### PR TITLE
Fix default handling to defer `UNSET` normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     :pr:`3055`
 -   Replace ``Sentinel.UNSET`` default values by ``None`` as they're passed through
     the ``Context.invoke()`` method. :issue:`3066` :issue:`3065` :pr:`3068`
+-   Fix conversion of ``Sentinel.UNSET`` happening too early, which caused incorrect
+    behavior for multiple parameters using the same name. :issue:`3071` :pr:`3079`
 
 Version 8.3.0
 --------------

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -84,3 +84,29 @@ def test_flag_default_map(runner):
 
     result = runner.invoke(cli, ["foo", "--help"], default_map={"foo": {"name": True}})
     assert "default: name" in result.output
+
+
+def test_shared_param_prefers_first_default(runner):
+    """test that the first default is chosen when multiple flags share a param name"""
+
+    @click.command
+    @click.option("--red", "color", flag_value="red")
+    @click.option("--green", "color", flag_value="green", default=True)
+    def prefers_green(color):
+        click.echo(color)
+
+    @click.command
+    @click.option("--red", "color", flag_value="red", default=True)
+    @click.option("--green", "color", flag_value="green")
+    def prefers_red(color):
+        click.echo(color)
+
+    result = runner.invoke(prefers_green, [])
+    assert "green" in result.output
+    result = runner.invoke(prefers_green, ["--red"])
+    assert "red" in result.output
+
+    result = runner.invoke(prefers_red, [])
+    assert "red" in result.output
+    result = runner.invoke(prefers_red, ["--green"])
+    assert "green" in result.output


### PR DESCRIPTION
When options are being parsed, multiple options may evaluate to have defaults of `UNSET`, and some may evaluate to have explicitly set defaults of `None`. The normalization of `UNSET -> None` is now deferred until all options have been parsed, so that it is possible to accurately evaluate and save the first non-UNSET default value.

A new test exercises this functionality by pointing two flags at the same parameter declaration, and showing that their behavior is not order sensitive when only one of the flags has a default.

resolves #3071

---

The PR template says to add a note in `CHANGES.rst` for the change, but there's no header for the next release, so I wasn't sure where to put a change note. If a maintainer gives me a pointer in terms of what to do, I'm happy to amend with a change note. :slightly_smiling_face: 