### PR TITLE
Don't test using a file in docs/

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -680,7 +680,9 @@ def test_expand_args(monkeypatch):
     monkeypatch.setenv("CLICK_TEST", "hello")
     assert "hello" in click.utils._expand_args(["$CLICK_TEST"])
     assert "pyproject.toml" in click.utils._expand_args(["*.toml"])
-    assert os.path.join("docs", "conf.py") in click.utils._expand_args(["**/conf.py"])
+    assert os.path.join("tests", "conftest.py") in click.utils._expand_args(
+        ["**/conftest.py"]
+    )
     assert "*.not-found" in click.utils._expand_args(["*.not-found"])
     # a bad glob pattern, such as a pytest identifier, should return itself
     assert click.utils._expand_args(["test.py::test_bad"])[0] == "test.py::test_bad"


### PR DESCRIPTION
The docs/ directory may not be present when building, and click itself may or may not be in a src/ subdirectory.
Thus, test with a file in tests/.
