### PR TITLE
CliRunner.set_filesystem() to test in a specific directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
     empty. :issue:`3019` :pr:`3021`
 -   When ``Sentinel.UNSET`` is found during parsing, it will skip calls to
     ``type_cast_value``. :issue:`3069` :pr:`3090`
+-   Adds ``CliRunner.set_filesystem()`` method to test in a specific path. :issue:`3123` :pr:`3124`.
 
 Version 8.3.0
 --------------

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,6 +165,46 @@ def test_cat_with_path_specified():
       assert result.output == 'Hello World!\n'
 ```
 
+## Setting a Specific Working Directory
+
+The {meth}`CliRunner.set_filesystem` works the same as
+{meth}`CliRunner.isolated_filesystem`, but instead must be given a directory
+that already exists. Use this to test commands that require a specific directory
+structure or pre-existing files.
+
+
+```{code-block} python
+:caption: has_html.py
+
+import click
+import sys
+
+@click.command()
+def has_html(f):
+   if os.exists("index.html"):
+      click.echo("index.html exists!")
+   else:
+      sys.exit(1)
+```
+
+```{code-block} python
+:caption: test_cat.py
+
+from click.testing import CliRunner
+from has_html import has_html
+
+def test_get_html(tmp_path):
+
+   with open(tmp_path / 'index.html', 'w') as f:
+      f.write('Hello World!')
+
+   runner = CliRunner()
+   with runner.set_filesystem(tmp_path):
+      result = runner.invoke(has_html)
+      assert result.exit_code == 0
+      assert result.output == 'index.html exists!\n'
+```
+
 ## Input Streams
 
 The test wrapper can provide input data for the input stream (stdin). This is very useful for testing prompts.

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -575,3 +575,30 @@ class CliRunner:
                     shutil.rmtree(dt)
                 except OSError:
                     pass
+
+    @contextlib.contextmanager
+    def set_filesystem(
+        self,
+        work_dir: str | os.PathLike[str],
+    ) -> cabc.Iterator[str]:
+        """A context manager that changes the current working directory to the work_dir.
+        This isolates tests that affect the contents of the CWD to prevent them from
+        interfering with each other.
+
+        :param work_dir: A directory provided by the user, that must exist
+        """
+
+        exists = os.path.exists(work_dir) and os.path.isdir(work_dir)
+        if not exists:
+            raise FileNotFoundError(
+                f"work_dir {work_dir} does not exist or is not a directory."
+            )
+
+        cwd = os.getcwd()
+        os.chdir(work_dir)
+
+        try:
+            # emit whatever was sent in, not the Path object
+            yield str(work_dir)
+        finally:
+            os.chdir(cwd)

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -586,6 +586,8 @@ class CliRunner:
         interfering with each other.
 
         :param work_dir: A directory provided by the user, that must exist
+
+        .. versionchanged::8.3
         """
 
         exists = os.path.exists(work_dir) and os.path.isdir(work_dir)

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -598,7 +598,7 @@ class CliRunner:
         os.chdir(work_dir)
 
         try:
-            # emit whatever was sent in, not the Path object
+            # emit whatever was sent in as a string
             yield str(work_dir)
         finally:
             os.chdir(cwd)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -469,3 +469,60 @@ def test_isolation_flushes_unflushed_stderr():
 
     result = runner.invoke(cli)
     assert result.stderr == "gyarados gyarados gyarados"
+
+
+def test_set_filesystem_runner(tmp_path):
+    """Check that using the CliRunner.set_filesystem works and 
+    runs in the given directory.
+    """
+
+    @click.command()
+    @click.argument("cmd", type=str)
+    def listdir(cmd:str):
+        if cmd == "ls":
+            ls = os.listdir()
+            print(ls)
+            cwd = os.getcwd()
+            print(cwd)
+
+    filename = tmp_path / "test.file"
+    with open(filename, "w") as tmp_file:
+        tmp_file.write("Hello World")
+
+    runner = CliRunner()
+    with runner.set_filesystem(tmp_path):
+        result = runner.invoke(listdir, ["ls"])
+    assert result.stdout.splitlines() == ["['test.file']", f"{tmp_path}"]
+    assert result.exit_code == 0
+
+def test_set_filesystem_runner_path_missing(tmp_path):
+    """Check that using the CliRunner.set_filesystem works raises
+    FileNotFoundError when provided a directory that does not exist
+    """
+
+    @click.command()
+    def listdir():
+        pass
+
+    bad_path = tmp_path / "does_not_exist"
+    runner = CliRunner()
+    with pytest.raises(FileNotFoundError):
+        with runner.set_filesystem(bad_path):
+            _ = runner.invoke(listdir, ["ls"])
+
+def test_set_filesystem_runner_path_notdir(tmp_path):
+    """Check that using the CliRunner.set_filesystem works raises
+    FileNotFoundError when provided a path to a non-directory
+    """
+
+    @click.command()
+    def listdir():
+        pass
+
+    bad_path = tmp_path / "not_a_dir"
+    bad_path.touch()
+
+    runner = CliRunner()
+    with pytest.raises(FileNotFoundError):
+        with runner.set_filesystem(bad_path):
+            _ = runner.invoke(listdir, ["ls"])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -474,6 +474,7 @@ def test_isolation_flushes_unflushed_stderr():
 def test_set_filesystem_runner(tmp_path):
     """Check that using the CliRunner.set_filesystem works and 
     runs in the given directory.
+    Tests :issue:`3123`
     """
 
     @click.command()
@@ -498,6 +499,7 @@ def test_set_filesystem_runner(tmp_path):
 def test_set_filesystem_runner_path_missing(tmp_path):
     """Check that using the CliRunner.set_filesystem works raises
     FileNotFoundError when provided a directory that does not exist
+    Tests :issue:`3123`
     """
 
     @click.command()
@@ -513,6 +515,7 @@ def test_set_filesystem_runner_path_missing(tmp_path):
 def test_set_filesystem_runner_path_notdir(tmp_path):
     """Check that using the CliRunner.set_filesystem works raises
     FileNotFoundError when provided a path to a non-directory
+    Tests :issue:`3123`
     """
 
     @click.command()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -472,14 +472,14 @@ def test_isolation_flushes_unflushed_stderr():
 
 
 def test_set_filesystem_runner(tmp_path):
-    """Check that using the CliRunner.set_filesystem works and 
+    """Check that using the CliRunner.set_filesystem works and
     runs in the given directory.
     Tests :issue:`3123`
     """
 
     @click.command()
     @click.argument("cmd", type=str)
-    def listdir(cmd:str):
+    def listdir(cmd: str):
         if cmd == "ls":
             ls = os.listdir()
             print(ls)
@@ -496,6 +496,7 @@ def test_set_filesystem_runner(tmp_path):
     assert result.stdout.splitlines() == ["['test.file']", f"{tmp_path}"]
     assert result.exit_code == 0
 
+
 def test_set_filesystem_runner_path_missing(tmp_path):
     """Check that using the CliRunner.set_filesystem works raises
     FileNotFoundError when provided a directory that does not exist
@@ -511,6 +512,7 @@ def test_set_filesystem_runner_path_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         with runner.set_filesystem(bad_path):
             _ = runner.invoke(listdir, ["ls"])
+
 
 def test_set_filesystem_runner_path_notdir(tmp_path):
     """Check that using the CliRunner.set_filesystem works raises


### PR DESCRIPTION
Provides the ability to invoke a CliRunner in a specific, pre-existing directory.

#3123
