### PR TITLE
Provide altered context to callbacks to hide `UNSET` values as `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
     the ``Context.invoke()`` method. :issue:`3066` :issue:`3065` :pr:`3068`
 -   Fix conversion of ``Sentinel.UNSET`` happening too early, which caused incorrect
     behavior for multiple parameters using the same name. :issue:`3071` :pr:`3079`
+-   Hide ``Sentinel.UNSET`` values as ``None`` when looking up for other parameters
+    through the context inside parameter callbacks. :issue:`3136` :pr:`3137`
 -   Fix rendering when ``prompt`` and ``confirm`` parameter ``prompt_suffix`` is
     empty. :issue:`3019` :pr:`3021`
 -   When ``Sentinel.UNSET`` is found during parsing, it will skip calls to


### PR DESCRIPTION
PR to fix:
- https://github.com/pallets/click/issues/3136
- https://github.com/pallets/flask/issues/5836

This highlight a side-effect introduced in:
- https://github.com/pallets/click/pull/3079
- https://github.com/pallets/click/issues/3071

CC @dotlambda