### PR TITLE
Fix Ruff UP038 warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,9 +132,6 @@ select = [
     "UP",  # pyupgrade
     "W",  # pycodestyle warning
 ]
-ignore = [
-    "UP038",  # keep isinstance tuple
-]
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
Running "ruff format" gives
the warning:

warning: The following rules have been removed and ignoring them has no effect:
    - UP038

so remove the ignore.
