### PR TITLE
Fix handling of options which set both is_flag=False and flag_value=...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 
 Unreleased
 
--   If ``flag_value`` is set or no default is provided the flag can be accepted
-    without an argument.:issue:`3084`
+-   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
+    used without an explicit value. :issue:`3084`
 
 Version 8.3.1
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 .. currentmodule:: click
 
+Unreleased
+
+-   If ``flag_value`` is set or no default is provided the flag can be accepted
+    without an argument.:issue:`3084`
+
 Version 8.3.1
 --------------
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2684,6 +2684,10 @@ class Option(Parameter):
     :param hidden: hide this option from help outputs.
     :param attrs: Other command arguments described in :class:`Parameter`.
 
+    .. versionchanged:: 8.3.dev
+         If ``flag_value`` is set or no default is provided, the flag can be
+         accepted without an argument.
+
     .. versionchanged:: 8.2
         ``envvar`` used with ``flag_value`` will always use the ``flag_value``,
         previously it would use the value of the environment variable.
@@ -2777,10 +2781,13 @@ class Option(Parameter):
             # Implicitly a flag because secondary options names were given.
             elif self.secondary_opts:
                 is_flag = True
-        # The option is explicitly not a flag. But we do not know yet if it needs a
-        # value or not. So we look at the default value to determine it.
+
+        # Handle options that are not flags but provide a flag_value.
+        # If flag_value is set or no default is provided the flag can be accepted
+        # without an argument.
+        # https://github.com/pallets/click/issues/3084
         elif is_flag is False and not self._flag_needs_value:
-            self._flag_needs_value = self.default is UNSET
+            self._flag_needs_value = flag_value is not UNSET or self.default is UNSET
 
         if is_flag:
             # Set missing default for flags if not explicitly required or prompted.

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2684,10 +2684,6 @@ class Option(Parameter):
     :param hidden: hide this option from help outputs.
     :param attrs: Other command arguments described in :class:`Parameter`.
 
-    .. versionchanged:: 8.3.dev
-         If ``flag_value`` is set or no default is provided, the flag can be
-         accepted without an argument.
-
     .. versionchanged:: 8.2
         ``envvar`` used with ``flag_value`` will always use the ``flag_value``,
         previously it would use the value of the environment variable.
@@ -2782,10 +2778,10 @@ class Option(Parameter):
             elif self.secondary_opts:
                 is_flag = True
 
-        # Handle options that are not flags but provide a flag_value.
-        # If flag_value is set or no default is provided the flag can be accepted
-        # without an argument.
-        # https://github.com/pallets/click/issues/3084
+        # The option is explicitly not a flag, but to determine whether or not it needs
+        # value, we need to check if `flag_value` or `default` was set. Either one is
+        # sufficient.
+        # Ref: https://github.com/pallets/click/issues/3084
         elif is_flag is False and not self._flag_needs_value:
             self._flag_needs_value = flag_value is not UNSET or self.default is UNSET
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -15,6 +15,7 @@ import click
 from click import Option
 from click import UNPROCESSED
 from click._utils import UNSET
+from click.testing import CliRunner
 
 
 def test_prefixes(runner):
@@ -2275,3 +2276,36 @@ def test_custom_type_frozenset_flag_value(runner):
     result = runner.invoke(rcli, ["--without-scm-ignore-files"])
     assert result.stdout == "frozenset()"
     assert result.exit_code == 0
+
+
+def test_flag_value_optional_behavior():
+    """Test that options with flag_value and is_flag=False use flag_value
+    when only flag is provided
+
+    Reproduces https://github.com/pallets/click/issues/3084
+    """
+
+    @click.command()
+    @click.option("--name", is_flag=False, flag_value="Flag", default="Default")
+    def hello(name):
+        click.echo(f"Hello, {name}!")
+
+    runner = CliRunner()
+    result = runner.invoke(hello, ["--name"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, Flag!\n"
+
+
+def test_flag_value_with_type_conversion():
+    """Test that flag_value is correctly type-converted when used as an option value."""
+
+    @click.command()
+    @click.option("--count", is_flag=False, flag_value="1", type=int, default=0)
+    def repeat(count):
+        for i in range(count):
+            click.echo(f"Line {i + 1}")
+
+    runner = CliRunner()
+    result = runner.invoke(repeat, ["--count"])
+    assert result.exit_code == 0
+    assert result.output == "Line 1\n"


### PR DESCRIPTION
Given that it's >1 month and the original contributor hasn't made changes, I've squashed #3104 and attempted to bring it up to spec so that the one-line fix itself can merge.
To preserve some level of attribution to the original author, I squashed those commits and added myself as a co-author on the resulting commit.

The separate "cleanup" commit aims to fix internal doc, presentation in the changelog, and to tidy up the new test.
Happy to take further action if it's helpful.

- Fix #3084: Correct flag optional value behavior and add comprehensive tests
- Cleanup changes to fix flag_value bug

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
