### PR TITLE
Add link at bottom of docs pages to myst parser docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,7 +128,7 @@ API Reference
 About Project
 ===============
 
-* This documentation is structured according to `Diataxis <https://diataxis.fr/>`_ and written with `MyST-parser <https://myst-parser.readthedocs.io/en/latest/>`_
+* This documentation is structured according to `Diataxis <https://diataxis.fr/>`_ and written with `MyST <https://myst-parser.readthedocs.io/en/latest/>`_
 
 * `Version Policy <https://palletsprojects.com/versions>`_
 


### PR DESCRIPTION
Adds link at bottom of docs pages to myst parser docs

https://github.com/pallets/click/issues/3088
