### PR TITLE
Fix the indentation size in code snippets

### DIFF
--- a/docs/commands-and-groups.rst
+++ b/docs/commands-and-groups.rst
@@ -255,24 +255,24 @@ the prefix is ``WEB``, then the variable is ``WEB_RUN_SERVER_HOST``.
 
 .. click:example::
 
-   @click.group()
-   @click.option('--debug/--no-debug')
-   def cli(debug):
-       click.echo(f"Debug mode is {'on' if debug else 'off'}")
+    @click.group()
+    @click.option('--debug/--no-debug')
+    def cli(debug):
+        click.echo(f"Debug mode is {'on' if debug else 'off'}")
 
-   @cli.command()
-   @click.option('--username')
-   def greet(username):
-       click.echo(f"Hello {username}!")
+    @cli.command()
+    @click.option('--username')
+    def greet(username):
+        click.echo(f"Hello {username}!")
 
-   if __name__ == '__main__':
-       cli(auto_envvar_prefix='GREETER')
+    if __name__ == '__main__':
+        cli(auto_envvar_prefix='GREETER')
 
 .. click:run::
 
-   invoke(cli, args=['greet',],
-          env={'GREETER_GREET_USERNAME': 'John', 'GREETER_DEBUG': 'false'},
-          auto_envvar_prefix='GREETER')
+    invoke(cli, args=['greet',],
+           env={'GREETER_GREET_USERNAME': 'John', 'GREETER_DEBUG': 'false'},
+           auto_envvar_prefix='GREETER')
 
 Global Context Access
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -142,7 +142,7 @@ For single option boolean flags, the default remains hidden if the default value
             click.echo('-' * n)
 
 .. click:run::
-   invoke(dots, args=['--help'])
+    invoke(dots, args=['--help'])
 ```
 
 ## Click's Wrapping Behavior

--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -115,7 +115,6 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
 It can be used like this:
 
 ```python
-
     @click.group(cls=AliasedGroup)
     def cli():
         pass

--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -115,17 +115,17 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
 It can be used like this:
 
 ```python
-    @click.group(cls=AliasedGroup)
-    def cli():
-        pass
+@click.group(cls=AliasedGroup)
+def cli():
+    pass
 
-    @cli.command
-    def push():
-        pass
+@cli.command
+def push():
+    pass
 
-    @cli.command
-    def pop():
-        pass
+@cli.command
+def pop():
+    pass
 ```
 
 See the [alias example](https://github.com/pallets/click/tree/main/examples/aliases) in Click's repository for another example.

--- a/docs/option-decorators.md
+++ b/docs/option-decorators.md
@@ -38,10 +38,10 @@ Because this combination of parameters is quite common, this can also be
 replaced with the {func}`password_option` decorator:
 
 ```python
-    @click.command()
-    @click.password_option()
-    def encrypt(password):
-        click.echo(f"encoded: to {codecs.encode(password, 'rot13')}")
+@click.command()
+@click.password_option()
+def encrypt(password):
+    click.echo(f"encoded: to {codecs.encode(password, 'rot13')}")
 ```
 
 ## Confirmation Option

--- a/docs/options.md
+++ b/docs/options.md
@@ -372,7 +372,7 @@ To pass in a value in from a specific environment variable use `envvar`.
     @click.command()
     @click.option('--username', envvar='USERNAME')
     def greet(username):
-       click.echo(f"Hello {username}!")
+        click.echo(f"Hello {username}!")
 
 .. click:run::
 
@@ -387,7 +387,7 @@ If a list is passed to `envvar`, the first environment variable found is picked.
     @click.command()
     @click.option('--username', envvar=['ALT_USERNAME', 'USERNAME'])
     def greet(username):
-       click.echo(f"Hello {username}!")
+        click.echo(f"Hello {username}!")
 
 .. click:run::
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -164,5 +164,5 @@ To describe what the default value will be, set it in ``show_default``.
 
 .. click:run::
 
-   invoke(hello, args=["--help"])
+    invoke(hello, args=["--help"])
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ import click
 @click.command()
 @click.argument('name')
 def hello(name):
-   click.echo(f'Hello {name}!')
+    click.echo(f'Hello {name}!')
 ```
 
 ```{code-block} python
@@ -40,10 +40,10 @@ from click.testing import CliRunner
 from hello import hello
 
 def test_hello_world():
-  runner = CliRunner()
-  result = runner.invoke(hello, ['Peter'])
-  assert result.exit_code == 0
-  assert result.output == 'Hello Peter!\n'
+    runner = CliRunner()
+    result = runner.invoke(hello, ['Peter'])
+    assert result.exit_code == 0
+    assert result.output == 'Hello Peter!\n'
 ```
 
 ## Subcommands
@@ -58,11 +58,11 @@ import click
 @click.group()
 @click.option('--debug/--no-debug', default=False)
 def cli(debug):
-   click.echo(f"Debug mode is {'on' if debug else 'off'}")
+    click.echo(f"Debug mode is {'on' if debug else 'off'}")
 
 @cli.command()
 def sync():
-   click.echo('Syncing')
+    click.echo('Syncing')
 ```
 
 ```{code-block} python
@@ -72,11 +72,11 @@ from click.testing import CliRunner
 from sync import cli
 
 def test_sync():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['--debug', 'sync'])
-  assert result.exit_code == 0
-  assert 'Debug mode is on' in result.output
-  assert 'Syncing' in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--debug', 'sync'])
+    assert result.exit_code == 0
+    assert 'Debug mode is on' in result.output
+    assert 'Syncing' in result.output
 ```
 
 ## Context Settings
@@ -91,11 +91,11 @@ import click
 
 @click.group()
 def cli():
-   pass
+    pass
 
 @cli.command()
 def sync():
-   click.echo('Syncing')
+    click.echo('Syncing')
 ```
 
 ```{code-block} python
@@ -105,11 +105,11 @@ from click.testing import CliRunner
 from sync import cli
 
 def test_sync():
-  runner = CliRunner()
-  result = runner.invoke(cli, ['sync'], terminal_width=60)
-  assert result.exit_code == 0
-  assert 'Debug mode is on' in result.output
-  assert 'Syncing' in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli, ['sync'], terminal_width=60)
+    assert result.exit_code == 0
+    assert 'Debug mode is on' in result.output
+    assert 'Syncing' in result.output
 ```
 
 ## File System Isolation
@@ -124,7 +124,7 @@ import click
 @click.command()
 @click.argument('f', type=click.File())
 def cat(f):
-   click.echo(f.read())
+    click.echo(f.read())
 ```
 
 ```{code-block} python
@@ -134,14 +134,14 @@ from click.testing import CliRunner
 from cat import cat
 
 def test_cat():
-   runner = CliRunner()
-   with runner.isolated_filesystem():
-      with open('hello.txt', 'w') as f:
-          f.write('Hello World!')
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('hello.txt', 'w') as f:
+            f.write('Hello World!')
 
-      result = runner.invoke(cat, ['hello.txt'])
-      assert result.exit_code == 0
-      assert result.output == 'Hello World!\n'
+        result = runner.invoke(cat, ['hello.txt'])
+        assert result.exit_code == 0
+        assert result.output == 'Hello World!\n'
 ```
 
 Pass in a path to control where the temporary directory is created.
@@ -155,14 +155,14 @@ from click.testing import CliRunner
 from cat import cat
 
 def test_cat_with_path_specified():
-   runner = CliRunner()
-   with runner.isolated_filesystem('~/test_folder'):
-      with open('hello.txt', 'w') as f:
-          f.write('Hello World!')
+    runner = CliRunner()
+    with runner.isolated_filesystem('~/test_folder'):
+        with open('hello.txt', 'w') as f:
+            f.write('Hello World!')
 
-      result = runner.invoke(cat, ['hello.txt'])
-      assert result.exit_code == 0
-      assert result.output == 'Hello World!\n'
+        result = runner.invoke(cat, ['hello.txt'])
+        assert result.exit_code == 0
+        assert result.output == 'Hello World!\n'
 ```
 
 ## Input Streams
@@ -177,7 +177,7 @@ import click
 @click.command()
 @click.option('--foo', prompt=True)
 def prompt(foo):
-   click.echo(f"foo={foo}")
+    click.echo(f"foo={foo}")
 ```
 
 ```{code-block} python
@@ -187,10 +187,10 @@ from click.testing import CliRunner
 from prompt import prompt
 
 def test_prompts():
-   runner = CliRunner()
-   result = runner.invoke(prompt, input='wau wau\n')
-   assert not result.exception
-   assert result.output == 'Foo: wau wau\nfoo=wau wau\n'
+    runner = CliRunner()
+    result = runner.invoke(prompt, input='wau wau\n')
+    assert not result.exception
+    assert result.output == 'Foo: wau wau\nfoo=wau wau\n'
 ```
 
 Prompts will be emulated so they write the input data to

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -309,14 +309,14 @@ import ConfigParser
 
 APP_NAME = 'My Application'
 def read_config():
-cfg = os.path.join(click.get_app_dir(APP_NAME), 'config.ini')
-parser = ConfigParser.RawConfigParser()
-parser.read([cfg])
-rv = {}
-for section in parser.sections():
-    for key, value in parser.items(section):
-        rv[f"{section}.{key}"] = value
-return rv
+    cfg = os.path.join(click.get_app_dir(APP_NAME), 'config.ini')
+    parser = ConfigParser.RawConfigParser()
+    parser.read([cfg])
+    rv = {}
+    for section in parser.sections():
+        for key, value in parser.items(section):
+            rv[f"{section}.{key}"] = value
+    return rv
 ```
 
 ## Showing Progress Bars


### PR DESCRIPTION
Use the same indentation size (4 spaces) for python code snippets, and remove the misplaced newline.

