### PR TITLE
Support `show_default` string in prompts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 8.3.2
 
 Released 2026-04-02
 
+-   Show custom ``show_default`` string in prompts, matching the existing
+    help text behavior. :issue:`2836` :pr:`2837` :pr:`3165` :pr:`3262` :pr:`3280`
 -   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
     used without an explicit value. :issue:`3084` :pr:`3152`
 -   Hide ``Sentinel.UNSET`` values as ``None`` when using ``lookup_default()``.

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3164,10 +3164,9 @@ class Option(Parameter):
                 default = bool(default)
             return confirm(self.prompt, default)
 
-        # If show_default is set to True/False, provide this to `prompt` as well. For
-        # non-bool values of `show_default`, we use `prompt`'s default behavior
+        # If show_default is set to True/False/string, provide this to `prompt` as well.
         prompt_kwargs: t.Any = {}
-        if isinstance(self.show_default, bool):
+        if self.show_default is not None:
             prompt_kwargs["show_default"] = self.show_default
 
         return prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -68,12 +68,10 @@ def _build_prompt(
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
         prompt += f" ({', '.join(map(str, type.choices))})"
-    if show_default:
-        if isinstance(show_default, str):
-            # Use the custom string for display
-            prompt = f"{prompt} [({show_default})]"
-        elif default is not None:
-            prompt = f"{prompt} [{_format_default(default)}]"
+    if isinstance(show_default, str):
+        default = f"({show_default})"
+    if default is not None and show_default:
+        prompt = f"{prompt} [{_format_default(default)}]"
     return f"{prompt}{suffix}"
 
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -125,6 +125,10 @@ def prompt(
                          show_choices is true and text is "Group by" then the
                          prompt will be "Group by (day, week): ".
 
+    .. versionchanged:: 8.3.3
+        ``show_default`` can be a string to show a custom value instead
+        of the actual default, matching the help text behavior.
+
     .. versionchanged:: 8.3.1
         A space is no longer appended to the prompt.
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -60,7 +60,7 @@ def hidden_prompt_func(prompt: str) -> str:
 def _build_prompt(
     text: str,
     suffix: str,
-    show_default: bool = False,
+    show_default: bool | str = False,
     default: t.Any | None = None,
     show_choices: bool = True,
     type: ParamType | None = None,
@@ -68,8 +68,12 @@ def _build_prompt(
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
         prompt += f" ({', '.join(map(str, type.choices))})"
-    if default is not None and show_default:
-        prompt = f"{prompt} [{_format_default(default)}]"
+    if show_default:
+        if isinstance(show_default, str):
+            # Use the custom string for display
+            prompt = f"{prompt} [({show_default})]"
+        elif default is not None:
+            prompt = f"{prompt} [{_format_default(default)}]"
     return f"{prompt}{suffix}"
 
 
@@ -88,7 +92,7 @@ def prompt(
     type: ParamType | t.Any | None = None,
     value_proc: t.Callable[[str], t.Any] | None = None,
     prompt_suffix: str = ": ",
-    show_default: bool = True,
+    show_default: bool | str = True,
     err: bool = False,
     show_choices: bool = True,
 ) -> t.Any:
@@ -112,6 +116,8 @@ def prompt(
                        convert a value.
     :param prompt_suffix: a suffix that should be added to the prompt.
     :param show_default: shows or hides the default value in the prompt.
+        Can also be a string to show a custom value instead of the actual
+        default.
     :param err: if set to true the file defaults to ``stderr`` instead of
                 ``stdout``, the same as with echo.
     :param show_choices: Show or hide choices if the passed type is a Choice.

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -6,6 +6,7 @@ import pytest
 
 import click._termui_impl
 from click._compat import WIN
+from click._utils import UNSET
 from click.exceptions import BadParameter
 from click.exceptions import MissingParameter
 
@@ -494,6 +495,58 @@ def test_false_show_default_cause_no_default_display_in_prompt(runner):
     # is False
     result = runner.invoke(cmd, input="my-input", standalone_mode=False)
     assert "my-default-value" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("show_default", "default", "user_input", "in_prompt", "not_in_prompt"),
+    [
+        # Regular string replaces the actual default in the prompt.
+        ("custom", "actual", "\n", "(custom)", "actual"),
+        # String with spaces.
+        ("custom label", "actual", "\n", "(custom label)", "actual"),
+        # Unicode characters.
+        ("∞", "0", "\n", "(∞)", None),
+        # Numeric default: custom string hides the number.
+        ("unlimited", 42, "\n", "(unlimited)", "42"),
+        # Explicit default=None: custom string still appears, must provide input.
+        ("computed at runtime", None, "value\n", "(computed at runtime)", None),
+        # No default kwarg at all (internal UNSET sentinel): same as None.
+        ("computed at runtime", UNSET, "value\n", "(computed at runtime)", None),
+        # Empty string is falsy: suppresses any default display.
+        ("", "actual", "\n", None, "actual"),
+    ],
+    ids=[
+        "simple-string",
+        "string-with-spaces",
+        "unicode",
+        "numeric-default",
+        "default-is-none",
+        "default-is-unset",
+        "empty-string-is-falsy",
+    ],
+)
+def test_string_show_default_in_prompt(
+    runner, show_default, default, user_input, in_prompt, not_in_prompt
+):
+    """When show_default is a string, the prompt should display that
+    string in parentheses instead of the actual default value,
+    matching the help text behavior. See pallets/click#2836."""
+
+    option_kwargs = {"show_default": show_default, "prompt": True}
+    if default is not UNSET:
+        option_kwargs["default"] = default
+
+    @click.command()
+    @click.option("--arg1", **option_kwargs)
+    def cmd(arg1):
+        click.echo(arg1)
+
+    result = runner.invoke(cmd, input=user_input, standalone_mode=False)
+    prompt_line = result.output.split("\n")[0]
+    if in_prompt is not None:
+        assert in_prompt in prompt_line
+    if not_in_prompt is not None:
+        assert not_in_prompt not in prompt_line
 
 
 REPEAT = object()


### PR DESCRIPTION
## Summary

Fixes #2836

When `show_default` is set to a string on an `Option` with `prompt=True`, the string was only used in the help text but not in the actual prompt. Now the custom string is also displayed in the prompt, matching the behavior of help text.

## Before

```python
@click.option('--name', default='default', show_default='show_default', prompt=True)
```

Help: `--name TEXT  [default: (show_default)]` ✓
Prompt: `Name [default]:` ✗ (shows actual default, not custom string)

## After

Help: `--name TEXT  [default: (show_default)]` ✓  
Prompt: `Name [(show_default)]:` ✓ (now shows custom string)

## Changes

1. **`_build_prompt()`**: Updated to accept `str | bool` for `show_default`. When it's a string, display it in parentheses (matching the help text format).

2. **`prompt()`**: Updated signature to accept `str | bool` for `show_default` parameter, and updated docstring.

3. **`Option.prompt_for_value()`**: Now passes `show_default` to `prompt()` regardless of type (previously only passed it when it was a bool).

## Testing

Manually tested with the reproduction case from the issue. The prompt now correctly shows the custom `show_default` string.