### PR TITLE
Document show_envvar in Help Pages

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -145,6 +145,22 @@ For single option boolean flags, the default remains hidden if the default value
    invoke(dots, args=['--help'])
 ```
 
+## Showing Environment Variables
+
+To control the appearance of environment variables pass `show_envvar`.
+
+```{eval-rst}
+.. click:example::
+
+    @click.command()
+    @click.option('--username', envvar='USERNAME', show_envvar=True)
+    def greet(username):
+        click.echo(f'Hello {username}!')
+
+.. click:run::
+    invoke(greet, args=['--help'])
+```
+
 ## Click's Wrapping Behavior
 
 Click's default wrapping ignores single new lines and rewraps the text based on the width of the terminal to a maximum of 80 characters by default, but this can be modified with {attr}`~Context.max_content_width`. In the example notice how the second grouping of three lines is rewrapped into a single paragraph.


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->

I had to go to the API documentation to find out how to enable this feature. I would've also liked to add the relevant information to the "Option" page, but without seeing anything for `show_default` on the Option page as well, I decided it may be out of scope for this PR.

Credit to @meejah for checking the documentation first, and noticing its absence.