### PR TITLE
Feature: Add usage string to info_dict

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -985,6 +985,7 @@ class Command:
             "short_help": self.short_help,
             "hidden": self.hidden,
             "deprecated": self.deprecated,
+            "usage": self.get_usage(ctx),
         }
 
     def __repr__(self) -> str:


### PR DESCRIPTION
 The Group class's to_info_dict method calls this parent method, so it will automatically get the usage string. It also recursively calls to_info_dict on its sub-commands, so the change will propagate through the entire command tree.
 Added new line -  "usage": self.get_usage(ctx)
Closes #2992 
