### PR TITLE
fix: `_termui_impl.open_url()` — 'start' on Windows is a cmd built-in, not an executable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Unreleased
     non-shadowed help option names, so ``Try '... -h'`` no longer points to a
     subcommand option that shadows ``-h``. All surviving names are shown
     (``-h/--help``). :issue:`2790` :pr:`3208`
+-   Use :func:`os.startfile` on Windows to open URLs in :func:`open_url`,
+    replacing the ``start`` built-in which cannot be invoked without
+    ``shell=True``. :issue:`3164` :pr:`3186`
 
 Version 8.3.3
 -------------

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -720,17 +720,16 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
         if locate:
             url = _unquote_file(url)
             args = ["explorer", f"/select,{url}"]
+            try:
+                return subprocess.call(args)
+            except OSError:
+                return 127
         else:
-            args = ["start"]
-            if wait:
-                args.append("/WAIT")
-            args.append("")
-            args.append(url)
-        try:
-            return subprocess.call(args)
-        except OSError:
-            # Command not found
-            return 127
+            try:
+                os.startfile(url)  # type: ignore[attr-defined]
+            except OSError:
+                return 127
+            return 0
     elif CYGWIN:
         if locate:
             url = _unquote_file(url)


### PR DESCRIPTION
fix: _termui_impl.open_url() — 'start' on Windows is a cmd built-in command, not an executable
