### PR TITLE
Fix flag_value class instantiation when default=True

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2283,8 +2283,20 @@ class Parameter:
         if value is UNSET:
             value = self.default
 
+        # Don't call the default if it was auto-set from True to flag_value on an Option.
+        # The flag_value is meant to be used as-is, not called. This prevents classes
+        # and other callables used as flag_value from being instantiated when the user
+        # sets default=True. When the user explicitly sets default=SomeCallable, it
+        # should still be called. Refs: https://github.com/pallets/click/issues/3121
         if call and callable(value):
-            value = value()
+            is_auto_flag_value = (
+                isinstance(self, Option)
+                and hasattr(self, "_default_is_auto_flag_value")
+                and self._default_is_auto_flag_value
+                and value is self.flag_value
+            )
+            if not is_auto_flag_value:
+                value = value()
 
         return value
 
@@ -2808,6 +2820,8 @@ class Option(Parameter):
             is_flag and isinstance(self.type, types.BoolParamType)
         )
         self.flag_value: t.Any = flag_value
+        # Track whether default was auto-set from True to flag_value
+        self._default_is_auto_flag_value: bool = False
 
         # Set boolean flag default to False if unset and not required.
         if self.is_bool_flag:
@@ -2822,6 +2836,7 @@ class Option(Parameter):
         # https://github.com/pallets/click/pull/3030/commits/06847da
         if self.default is True and self.flag_value is not UNSET:
             self.default = self.flag_value
+            self._default_is_auto_flag_value = True
 
         # Set the default flag_value if it is not set.
         if self.flag_value is UNSET:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2148,7 +2148,7 @@ def test_custom_type_flag_value_standalone_option(runner, opt_params, args, expe
             {"flag_value": Class1, "default": True},
             {"flag_value": Class2},
             [],
-            re.compile(r"'<test_options.Class1 object at 0x[0-9A-Fa-f]+>'"),
+            "<class 'test_options.Class1'>",
         ),
         (
             {"flag_value": Class1, "default": True},
@@ -2170,7 +2170,7 @@ def test_custom_type_flag_value_standalone_option(runner, opt_params, args, expe
             {"flag_value": Class1, "type": UNPROCESSED, "default": True},
             {"flag_value": Class2, "type": UNPROCESSED},
             [],
-            re.compile(r"<test_options.Class1 object at 0x[0-9A-Fa-f]+>"),
+            Class1,
         ),
         (
             {"flag_value": Class1, "type": UNPROCESSED, "default": True},


### PR DESCRIPTION
## Summary
Fixes #3121

When using a class or callable as `flag_value` with `default=True`, the class was being instantiated instead of being used as-is in Click 8.3.0.

## Root Cause
In Click 8.3.0, when `default=True` and `flag_value` is set, the Option initialization automatically sets `self.default = self.flag_value` to maintain backward compatibility. However, when `get_default()` is later called, it checks if the default is callable and calls it, which causes classes and other callables to be instantiated.

## Solution
- Track whether the default was auto-converted from `True` to `flag_value` using a new `_default_is_auto_flag_value` flag
- In `get_default()`, only call the default if it's not an auto-converted flag value
- When users explicitly set `default=SomeCallable`, it still gets called as expected (preserving existing behavior)

## Test Plan
- All existing tests pass (1319 passed)
- Updated test expectations for cases that were testing the buggy behavior
- Verified fix with reproduction cases:
  - `default=True, flag_value=SomeClass` → returns class (not instance)
  - `default=SomeClass, flag_value=SomeClass` → returns instance (as intended)
  - `--flag` explicitly passed → returns class (correct behavior)