### PR TITLE
fix help hint showing shadowed option name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,35 @@
 .. currentmodule:: click
 
+Version 8.4.0
+-------------
+
+Unreleased
+
+-   :class:`ParamType` typing improvements. :pr:`3371`
+
+    -   :class:`ParamType` is now a generic abstract base class,
+        parameterized by its converted value type.
+    -   :meth:`~ParamType.convert` return types are narrowed on all
+        concrete types (``str`` for :class:`STRING`, ``int`` for
+        :class:`INT`, etc.).
+    -   :meth:`~ParamType.to_info_dict` returns specific
+        :class:`~typing.TypedDict` subclasses instead of
+        ``dict[str, Any]``.
+    -   :class:`CompositeParamType` and the number-range base are now
+        generic with abstract methods.
+-   Split string values from ``default_map`` for parameters with ``nargs > 1``
+    or :class:`Tuple` type, matching environment variable behavior.
+    :issue:`2745` :pr:`3364`
+-   Auto-detect ``type=UNPROCESSED`` for ``flag_value`` of non-basic types
+    (not ``str``, ``int``, ``float``, or ``bool``), so programmer-provided
+    Python objects like classes and enum members are passed through unchanged
+    instead of being stringified. Previously ``type=click.UNPROCESSED`` had
+    to be set explicitly. :issue:`2012` :pr:`3363`
+-   The error hint now uses :meth:`Command.get_help_option_names` to pick
+    non-shadowed help option names, so ``Try '... -h'`` no longer points to a
+    subcommand option that shadows ``-h``. All surviving names are shown
+    (``-h/--help``). :issue:`2790` :pr:`3208`
+
 Version 8.3.3
 -------------
 
@@ -40,10 +70,6 @@ Unreleased
 -   Change :class:`ParameterSource` to an :class:`~enum.IntEnum` and reorder
     its members from most to least explicit, so values can be compared to
     check whether a parameter was explicitly provided. :issue:`2879` :pr:`3248`
--   The error hint now uses :meth:`Command.get_help_option_names` to pick
-    non-shadowed help option names, so ``Try '... -h'`` no longer points to a
-    subcommand option that shadows ``-h``. All surviving names are shown
-    (``-h/--help``). :issue:`2790` :pr:`3208`
 
 Version 8.3.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ Unreleased
 -   Change :class:`ParameterSource` to an :class:`~enum.IntEnum` and reorder
     its members from most to least explicit, so values can be compared to
     check whether a parameter was explicitly provided. :issue:`2879` :pr:`3248`
+-   The error hint now uses :meth:`Command.get_help_option_names` to pick
+    non-shadowed help option names, so ``Try '... -h'`` no longer points to a
+    subcommand option that shadows ``-h``. All surviving names are shown
+    (``-h/--help``). :issue:`2790` :pr:`3208`
 
 Version 8.3.2
 -------------

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -78,8 +78,12 @@ class UsageError(ClickException):
             self.ctx is not None
             and self.ctx.command.get_help_option(self.ctx) is not None
         ):
+            help_names = self.ctx.command.get_help_option_names(self.ctx)
+            # Pick the longest name (like ``--help`` over ``-h``) for
+            # readability in error messages.
             hint = _("Try '{command} {option}' for help.").format(
-                command=self.ctx.command_path, option=self.ctx.help_option_names[0]
+                command=self.ctx.command_path,
+                option=max(help_names, key=len),
             )
             hint = f"{hint}\n"
         if self.ctx is not None:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,3 +1,5 @@
+import pytest
+
 import click
 
 
@@ -244,6 +246,71 @@ def test_formatting_usage_custom_help(runner):
         "",
         "Error: Missing argument 'ARG'.",
     ]
+
+
+@pytest.mark.parametrize(
+    ("help_names", "extra_options", "expected_hint"),
+    [
+        # No shadowing, longest name is picked.
+        (["-h", "--help"], [], "Try 'cli foo --help' for help."),
+        # -h shadowed by a subcommand option, --help still available.
+        (
+            ["-h", "--help"],
+            [click.option("--host", "-h")],
+            "Try 'cli foo --help' for help.",
+        ),
+        # --help shadowed, -h still available.
+        (
+            ["-h", "--help"],
+            [click.option("--help-file", "--help")],
+            "Try 'cli foo -h' for help.",
+        ),
+        # Both names shadowed: no hint line at all.
+        (
+            ["-h", "--help"],
+            [click.option("--host", "-h"), click.option("--help-file", "--help")],
+            None,
+        ),
+        # Single custom help name, not shadowed.
+        (["--man"], [], "Try 'cli foo --man' for help."),
+        # Three help names, one shadowed, longest survivor picked.
+        (
+            ["-h", "--help", "--info"],
+            [click.option("--info-file", "--info")],
+            "Try 'cli foo --help' for help.",
+        ),
+    ],
+)
+def test_formatting_usage_error_help_hint(
+    runner, help_names, extra_options, expected_hint
+):
+    """The error hint should only show non-shadowed help option names,
+    picking the longest for readability.
+
+    https://github.com/pallets/click/issues/2790
+    """
+
+    @click.group(context_settings={"help_option_names": help_names})
+    def cli():
+        pass
+
+    @cli.command()
+    @click.argument("required_arg")
+    def foo(required_arg, **kwargs):
+        pass
+
+    for option in extra_options:
+        option(foo)
+
+    result = runner.invoke(cli, ["foo"])
+    assert result.exit_code == 2
+    lines = result.output.splitlines()
+    assert lines[0] == "Usage: cli foo [OPTIONS] REQUIRED_ARG"
+    assert lines[-1] == "Error: Missing argument 'REQUIRED_ARG'."
+    if expected_hint is not None:
+        assert expected_hint in lines
+    else:
+        assert not any(line.startswith("Try ") for line in lines)
 
 
 def test_formatting_custom_type_metavar(runner):


### PR DESCRIPTION
Fixes #2790.

When a subcommand defines an option that shadows one of the configured help option names (e.g. `-h`), the error hint was still suggesting the shadowed name:

```
Try 'cli foo -h' for help.
```

But `-h` is now the subcommand's `--host` option, not help. Running `cli foo -h` gives `Error: Option '-h' requires an argument.` instead of showing help.

The fix uses `get_help_option_names()` which already exists and filters out names claimed by other parameters. So now the hint picks a working alternative like `--help`:

```
Try 'cli foo --help' for help.
```