### PR TITLE
fix: lookup_default returns None instead of leaking internal sentinel

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -685,6 +685,21 @@ class Context:
             self.obj = rv = object_type()
         return rv
 
+    def _lookup_default(self, name: str, call: bool = True) -> t.Any:
+        """Internal version of :meth:`lookup_default` that returns
+        :data:`UNSET` when no value is found, for use by internal
+        methods that need to distinguish missing from ``None``.
+        """
+        if self.default_map is not None:
+            value = self.default_map.get(name, UNSET)
+
+            if call and callable(value):
+                return value()
+
+            return value
+
+        return UNSET
+
     @t.overload
     def lookup_default(
         self, name: str, call: t.Literal[True] = True
@@ -705,15 +720,12 @@ class Context:
         .. versionchanged:: 8.0
             Added the ``call`` parameter.
         """
-        if self.default_map is not None:
-            value = self.default_map.get(name, UNSET)
+        value = self._lookup_default(name, call=call)
 
-            if call and callable(value):
-                return value()
+        if value is UNSET:
+            return None
 
-            return value
-
-        return UNSET
+        return value
 
     def fail(self, message: str) -> t.NoReturn:
         """Aborts the execution of the program with a specific error
@@ -2278,7 +2290,7 @@ class Parameter:
         .. versionchanged:: 8.0
             Added the ``call`` parameter.
         """
-        value = ctx.lookup_default(self.name, call=False)  # type: ignore
+        value = ctx._lookup_default(self.name, call=False)
 
         if value is UNSET:
             value = self.default
@@ -2321,7 +2333,7 @@ class Parameter:
                 source = ParameterSource.ENVIRONMENT
 
         if value is UNSET:
-            default_map_value = ctx.lookup_default(self.name)  # type: ignore
+            default_map_value = ctx._lookup_default(self.name)
             if default_map_value is not UNSET:
                 value = default_map_value
                 source = ParameterSource.DEFAULT_MAP

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -780,3 +780,20 @@ def test_propagate_opt_prefixes():
     ctx = click.Context(click.Command("test2"), parent=parent)
 
     assert ctx._opt_prefixes == {"-", "--", "!"}
+
+
+def test_lookup_default_returns_none_when_missing():
+    """lookup_default should return None, not an internal sentinel,
+    when the key is not in default_map or default_map is None."""
+    cmd = click.Command("test")
+    ctx = click.Context(cmd)
+
+    # No default_map at all
+    assert ctx.lookup_default("missing") is None
+
+    # default_map exists but key is missing
+    ctx.default_map = {"other": "value"}
+    assert ctx.lookup_default("missing") is None
+
+    # default_map has the key
+    assert ctx.lookup_default("other") == "value"


### PR DESCRIPTION
Fixes #3145
 
In 8.3.0, lookup_default started returning the internal Sentinel.UNSET
value instead of None when a key wasn't found in default_map. This broke
code that checked `if default is not None` since UNSET is not None.
 
Extracted the sentinel-aware logic into _lookup_default for internal use
by get_default and consume_value, and made the public lookup_default
convert UNSET to None before returning. This restores the pre-8.3.0
behavior for external callers while keeping the internal distinction
between "missing" and "explicitly None" intact.
 
Added a regression test covering all three cases: no default_map,
default_map without the key, and default_map with the key.