### PR TITLE
Fix callable flag_value being instantiated when used as default

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2820,8 +2820,10 @@ class Option(Parameter):
         # and a flag_value set to something else. Refs:
         # https://github.com/pallets/click/issues/3024#issuecomment-3146199461
         # https://github.com/pallets/click/pull/3030/commits/06847da
+        self._default_from_flag_value = False
         if self.default is True and self.flag_value is not UNSET:
             self.default = self.flag_value
+            self._default_from_flag_value = True
 
         # Set the default flag_value if it is not set.
         if self.flag_value is UNSET:
@@ -2884,6 +2886,37 @@ class Option(Parameter):
             hidden=self.hidden,
         )
         return info_dict
+
+    @t.overload
+    def get_default(
+        self, ctx: Context, call: t.Literal[True] = True
+    ) -> t.Any | None: ...
+
+    @t.overload
+    def get_default(
+        self, ctx: Context, call: bool = ...
+    ) -> t.Any | t.Callable[[], t.Any] | None: ...
+
+    def get_default(
+        self, ctx: Context, call: bool = True
+    ) -> t.Any | t.Callable[[], t.Any] | None:
+        value = ctx.lookup_default(self.name, call=False)  # type: ignore
+
+        if value is UNSET:
+            value = self.default
+
+        # Don't call the default if it was set from the flag_value via
+        # the ``default=True`` alignment.  A callable flag_value (e.g. a
+        # class used as a flag value) should be returned as-is, not
+        # instantiated.  See https://github.com/pallets/click/issues/3121
+        if (
+            call
+            and callable(value)
+            and not self._default_from_flag_value
+        ):
+            value = value()
+
+        return value
 
     def get_error_hint(self, ctx: Context) -> str:
         result = super().get_error_hint(ctx)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2148,7 +2148,7 @@ def test_custom_type_flag_value_standalone_option(runner, opt_params, args, expe
             {"flag_value": Class1, "default": True},
             {"flag_value": Class2},
             [],
-            re.compile(r"'<test_options.Class1 object at 0x[0-9A-Fa-f]+>'"),
+            "<class 'test_options.Class1'>",
         ),
         (
             {"flag_value": Class1, "default": True},
@@ -2170,7 +2170,7 @@ def test_custom_type_flag_value_standalone_option(runner, opt_params, args, expe
             {"flag_value": Class1, "type": UNPROCESSED, "default": True},
             {"flag_value": Class2, "type": UNPROCESSED},
             [],
-            re.compile(r"<test_options.Class1 object at 0x[0-9A-Fa-f]+>"),
+            Class1,
         ),
         (
             {"flag_value": Class1, "type": UNPROCESSED, "default": True},


### PR DESCRIPTION
Fixes #3121.

When `default=True` is set on a flag option with a callable `flag_value` (e.g. a class), the `default=True` → `flag_value` alignment code (introduced in #3030) replaces the default with the flag_value. Then `get_default()` sees `callable(value)` is True and calls it, instantiating the class instead of returning it as-is.

**Example (from the issue):**
```python
@click.command()
@click.option("--foo", "ty", flag_value=Foo, type=click.UNPROCESSED, default=True)
@click.option("--bar", "ty", flag_value=Bar, type=click.UNPROCESSED)
def main(ty):
    click.echo(repr(ty))
```

Before fix: `main()` with no args prints `<__main__.Foo object at 0x...>` (instance)
After fix: `main()` with no args prints `<class '__main__.Foo'>` (class, as expected)

**Fix:** Track when the default was set from the `default=True` → `flag_value` alignment and skip the callable invocation in `get_default()` for that case. This preserves the existing behavior for explicitly callable defaults (e.g. `default=lambda: ...`) and for `default=SomeClass` set directly by the user.

All 1320 existing tests pass with the fix applied. Updated the two test expectations that documented the buggy behavior.