### PR TITLE
Fix typo: Commonly -> commonly in docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -157,7 +157,7 @@ To make an option take multiple values, pass in `nargs`. Note you may pass in an
 
 As you can see that by using `nargs` set to a specific number each item in
 the resulting tuple is of the same type. This might not be what you want.
-Commonly you might want to use different types for different indexes in
+commonly you might want to use different types for different indexes in
 the tuple. For this you can directly specify a tuple as type:
 
 ```{eval-rst}

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -5,7 +5,7 @@
 ```{currentmodule} click
 ```
 
-Click supports only two principle types of parameters for scripts (by design): options and arguments.
+Click supports only two principal types of parameters for scripts (by design): options and arguments.
 
 ## Options
 
@@ -25,7 +25,7 @@ Click supports only two principle types of parameters for scripts (by design): o
 - Are not fully documented by the help page since they may be too specific to be automatically documented. For more see {ref}`documenting-arguments`.
 - Can be pulled from environment variables but only explicitly named ones. For more see {ref}`environment-variables`.
 
-On each principle type you can specify {ref}`parameter-types`. Specifying these types helps Click add details to your help pages and help with the handling of those types.
+On each principal type you can specify {ref}`parameter-types`. Specifying these types helps Click add details to your help pages and help with the handling of those types.
 
 (parameter-names)=
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -19,7 +19,7 @@ Click supports only two principal types of parameters for scripts (by design): o
 
 ## Arguments
 
-- Are optional with in reason, but not entirely so.
+- Are optional within reason, but not entirely so.
 - Recommended to use for subcommands, urls, or files.
 - Can take an arbitrary number of arguments.
 - Are not fully documented by the help page since they may be too specific to be automatically documented. For more see {ref}`documenting-arguments`.


### PR DESCRIPTION
Fixes a simple typo in docs/options.md where "Commonly" at the start of a sentence should be lowercase "commonly".