### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -36,4 +36,4 @@ Note that I used single quotes above, so my shell is not expanding the environme
 #### Answer
 
 If you don't want Click to emulate (as best it can) unix expansion on Windows, pass windows_expand_args=False when calling the CLI.
-Windows command line doesn't do any *, ~, or $ENV expansion. It also doesn't distinguish between double quotes and single quotes (where the later means "don't expand here"). Click emulates the expansion so that the app behaves similarly on both platforms, but doesn't receive information about what quotes were used.
+Windows command line doesn't do any *, ~, or $ENV expansion. It also doesn't distinguish between double quotes and single quotes (where the latter means "don't expand here"). Click emulates the expansion so that the app behaves similarly on both platforms, but doesn't receive information about what quotes were used.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -19,7 +19,7 @@ Click supports only two principle types of parameters for scripts (by design): o
 
 ## Arguments
 
-- Are optional with in reason, but not entirely so.
+- Are optional within reason, but not entirely so.
 - Recommended to use for subcommands, urls, or files.
 - Can take an arbitrary number of arguments.
 - Are not fully documented by the help page since they may be too specific to be automatically documented. For more see {ref}`documenting-arguments`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -145,7 +145,7 @@ def test_cat():
 ```
 
 Pass in a path to control where the temporary directory is created.
-In this case, the directory will not be removed by Click. Its useful
+In this case, the directory will not be removed by Click. It's useful
 to integrate with a framework like Pytest that manages temporary files.
 
 ```{code-block} python


### PR DESCRIPTION
Fixed 3 typos in the Click documentation:

1. **parameters.md**: Changed 'with in reason' to 'within reason'
2. **testing.md**: Changed 'Its useful' to 'It's useful' 
3. **faqs.md**: Changed 'the later means' to 'the latter means'

These are small documentation fixes as part of the good first issue #3175 (Improve documentation).