### PR TITLE
fix _AtomicFile.close ignoring delete parameter

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -464,7 +464,13 @@ class _AtomicFile:
         if self.closed:
             return
         self._f.close()
-        os.replace(self._tmp_filename, self._real_filename)
+        if delete:
+            try:
+                os.unlink(self._tmp_filename)
+            except OSError:
+                pass
+        else:
+            os.replace(self._tmp_filename, self._real_filename)
         self.closed = True
 
     def __getattr__(self, name: str) -> t.Any:


### PR DESCRIPTION
`_AtomicFile.close()` accepts a `delete` parameter, and `__exit__` passes `delete=True` when an exception occurs during the context manager block. However, the `close` method unconditionally calls `os.replace`, moving the (potentially incomplete) temp file over the original regardless of whether `delete` is `True`.

This defeats the purpose of atomic writes — if an error occurs while writing, the original file should be preserved and the temp file should be cleaned up instead.

This change makes `close` check the `delete` flag. When `True`, it removes the temp file with `os.unlink` rather than replacing the original. The `os.unlink` call is wrapped in a try/except to handle cases where the temp file may have already been removed.
