### PR TITLE
close mkstemp fd before reopening file in _tempfilepager

### DIFF
--- a/pr_body_1.md
+++ b/pr_body_1.md
@@ -1,0 +1,5 @@
+`_AtomicFile.close()` accepts a `delete` parameter, and `__exit__` passes `delete=True` when an exception occurs during the context manager block. However, the `close` method unconditionally calls `os.replace`, moving the (potentially incomplete) temp file over the original regardless of whether `delete` is `True`.
+
+This defeats the purpose of atomic writes — if an error occurs while writing, the original file should be preserved and the temp file should be cleaned up instead.
+
+This change makes `close` check the `delete` flag. When `True`, it removes the temp file with `os.unlink` rather than replacing the original. The `os.unlink` call is wrapped in a try/except to handle cases where the temp file may have already been removed.

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -532,6 +532,10 @@ def _tempfilepager(
     import tempfile
 
     fd, filename = tempfile.mkstemp()
+    # Close the file descriptor from mkstemp immediately. The file will
+    # be re-opened below by open_stream for writing. Keeping fd open is
+    # unnecessary and can prevent access on Windows.
+    os.close(fd)
     # TODO: This never terminates if the passed generator never terminates.
     text = "".join(generator)
     if not color:
@@ -545,7 +549,6 @@ def _tempfilepager(
         # Command not found
         pass
     finally:
-        os.close(fd)
         os.unlink(filename)
 
     return True


### PR DESCRIPTION
`_tempfilepager` creates a temporary file using `tempfile.mkstemp()`, which returns an open file descriptor. However, the file is then re-opened via `open_stream(filename, "wb")` for writing without closing the original `fd` first.

The original `fd` stays open for the duration of the write and the entire subprocess call, only being closed in the `finally` block. This is a resource leak and can cause issues on Windows where open file descriptors prevent other processes from accessing the file — the pager subprocess may not be able to read the temp file.

This moves the `os.close(fd)` call to immediately after `mkstemp()`, before the file is re-opened for writing.
