### PR TITLE
Add `NoSuchCommand` exception with suggestions for misspelled commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Unreleased
     ``shell=True``. :issue:`3164` :pr:`3186`
 -   Fix Fish shell completion errors when option help text contains newlines.
     :issue:`3043`
+-   Add :class:`NoSuchCommand` exception with suggestions for misspelled
+    commands. :issue:`3107` :pr:`3228`
 
 Version 8.3.3
 -------------

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -33,6 +33,7 @@ from .exceptions import BadParameter as BadParameter
 from .exceptions import ClickException as ClickException
 from .exceptions import FileError as FileError
 from .exceptions import MissingParameter as MissingParameter
+from .exceptions import NoSuchCommand as NoSuchCommand
 from .exceptions import NoSuchOption as NoSuchOption
 from .exceptions import UsageError as UsageError
 from .formatting import HelpFormatter as HelpFormatter

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -29,6 +29,7 @@ from .exceptions import ClickException
 from .exceptions import Exit
 from .exceptions import MissingParameter
 from .exceptions import NoArgsIsHelpError
+from .exceptions import NoSuchCommand
 from .exceptions import UsageError
 from .formatting import HelpFormatter
 from .formatting import join_options
@@ -1937,7 +1938,6 @@ class Group(Command):
         self, ctx: Context, args: list[str]
     ) -> tuple[str | None, Command | None, list[str]]:
         cmd_name = make_str(args[0])
-        original_cmd_name = cmd_name
 
         # Get the command
         cmd = self.get_command(ctx, cmd_name)
@@ -1957,7 +1957,7 @@ class Group(Command):
         if cmd is None and not ctx.resilient_parsing:
             if _split_opt(cmd_name)[0]:
                 self.parse_args(ctx, args)
-            ctx.fail(_("No such command {name!r}.").format(name=original_cmd_name))
+            raise NoSuchCommand(cmd_name, possibilities=self.commands, ctx=ctx)
         return cmd_name if cmd else None, cmd, args[1:]
 
     def shell_complete(self, ctx: Context, incomplete: str) -> list[CompletionItem]:

--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -23,6 +23,15 @@ def _join_param_hints(param_hint: cabc.Sequence[str] | str | None) -> str | None
     return param_hint
 
 
+def _format_possibilities(possibilities: list[str]) -> str:
+    possibility_str = ", ".join(repr(p) for p in sorted(possibilities))
+    return ngettext(
+        "Did you mean {possibility}?",
+        "(Did you mean one of: {possibilities}?)",
+        len(possibilities),
+    ).format(possibility=possibility_str, possibilities=possibility_str)
+
+
 class ClickException(Exception):
     """An exception that Click can handle and show to the user."""
 
@@ -210,8 +219,7 @@ class MissingParameter(BadParameter):
 
 
 class NoSuchOption(UsageError):
-    """Raised if click attempted to handle an option that does not
-    exist.
+    """Raised if Click attempted to handle an option that does not exist.
 
     .. versionadded:: 4.0
     """
@@ -220,27 +228,51 @@ class NoSuchOption(UsageError):
         self,
         option_name: str,
         message: str | None = None,
-        possibilities: cabc.Sequence[str] | None = None,
+        possibilities: cabc.Iterable[str] | None = None,
         ctx: Context | None = None,
     ) -> None:
         if message is None:
-            message = _("No such option: {name}").format(name=option_name)
+            message = _("No such option {name!r}.").format(name=option_name)
 
         super().__init__(message, ctx)
         self.option_name = option_name
-        self.possibilities = possibilities
+        self.possibilities: list[str] | None = None
+        if possibilities:
+            from difflib import get_close_matches
+
+            self.possibilities = get_close_matches(option_name, possibilities)
 
     def format_message(self) -> str:
         if not self.possibilities:
             return self.message
+        return f"{self.message} {_format_possibilities(self.possibilities)}"
 
-        possibility_str = ", ".join(sorted(self.possibilities))
-        suggest = ngettext(
-            "Did you mean {possibility}?",
-            "(Possible options: {possibilities})",
-            len(self.possibilities),
-        ).format(possibility=possibility_str, possibilities=possibility_str)
-        return f"{self.message} {suggest}"
+
+class NoSuchCommand(UsageError):
+    """Raised if Click attempted to handle a command that does not exist."""
+
+    def __init__(
+        self,
+        command_name: str,
+        message: str | None = None,
+        possibilities: cabc.Iterable[str] | None = None,
+        ctx: Context | None = None,
+    ) -> None:
+        if message is None:
+            message = _("No such command {name!r}.").format(name=command_name)
+
+        super().__init__(message, ctx)
+        self.command_name = command_name
+        self.possibilities: list[str] | None = None
+        if possibilities:
+            from difflib import get_close_matches
+
+            self.possibilities = get_close_matches(command_name, possibilities)
+
+    def format_message(self) -> str:
+        if not self.possibilities:
+            return self.message
+        return f"{self.message} {_format_possibilities(self.possibilities)}"
 
 
 class BadOptionUsage(UsageError):

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -360,10 +360,7 @@ class _OptionParser:
         self, opt: str, explicit_value: str | None, state: _ParsingState
     ) -> None:
         if opt not in self._long_opt:
-            from difflib import get_close_matches
-
-            possibilities = get_close_matches(opt, self._long_opt)
-            raise NoSuchOption(opt, possibilities=possibilities, ctx=self.ctx)
+            raise NoSuchOption(opt, possibilities=self._long_opt, ctx=self.ctx)
 
         option = self._long_opt[opt]
         if option.takes_value:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -573,3 +573,35 @@ def test_abort_exceptions_with_disabled_standalone_mode(runner, exc):
     assert rv.exit_code == 1
     assert isinstance(rv.exception.__cause__, exc)
     assert rv.exception.__cause__.args == ("catch me!",)
+
+
+def test_unknown_command(runner):
+    result = runner.invoke(click.Group(), "unknown")
+    assert result.exception
+    assert "No such command 'unknown'." in result.output
+
+
+@pytest.mark.parametrize(
+    ("value", "expect"),
+    [
+        ("pause", "Did you mean 'push'?"),
+        ("decline", "(Did you mean one of: 'declare', 'refine'?)"),
+    ],
+)
+def test_suggest_possible_commands(runner, value, expect):
+    cli = click.Group()
+
+    @cli.command()
+    def push():
+        pass
+
+    @cli.command()
+    def declare():
+        pass
+
+    @cli.command()
+    def refine():
+        pass
+
+    result = runner.invoke(cli, [value])
+    assert expect in result.output

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -141,15 +141,15 @@ def test_unknown_options(runner, unknown_flag):
 
     result = runner.invoke(cli, [unknown_flag])
     assert result.exception
-    assert f"No such option: {unknown_flag}" in result.output
+    assert f"No such option '{unknown_flag}'." in result.output
 
 
 @pytest.mark.parametrize(
     ("value", "expect"),
     [
-        ("--cat", "Did you mean --count?"),
-        ("--bounds", "(Possible options: --bound, --count)"),
-        ("--bount", "(Possible options: --bound, --count)"),
+        ("--cat", "Did you mean '--count'?"),
+        ("--bounds", "(Did you mean one of: '--bound', '--count'?)"),
+        ("--bount", "(Did you mean one of: '--bound', '--count'?)"),
     ],
 )
 def test_suggest_possible_options(runner, value, expect):


### PR DESCRIPTION
This PR adds suggestions to the `"No such command"` error message for misspelled commands, similar to how it's done for `NoSuchOption`.

As part of this update, a new exception was added - `NoSuchCommand`, along with slight formatting changes in `NoSuchOption`, to improve readability and ensure consistency with other errors.

Rejected idea: Adding a shared base exception or mixin for `NoSuchOption` and `NoSuchCommand`.

Fixes #3107.

### Additional behavior changes

- The option possibilities are now calculated within the `NoSuchOption` exception.
- The normalized command name is now used in the `NoSuchCommand` error message.

### Example based on the issue
```
import click


@click.group()
def cli():
    pass


@cli.command()
@click.option("--name", default="World")
def greet(name: str) -> None:
    click.echo(f"Hello, {name}")


if __name__ == "__main__":
    cli()
```

**Before the change:**
```
$ ./main.py greet --nme David
Usage: main.py greet [OPTIONS]
Try 'main.py greet --help' for help.

Error: No such option: --nme Did you mean --name?
```
```
$ ./main.py gret --name David
Usage: main.py [OPTIONS] COMMAND [ARGS]...
Try 'main.py --help' for help.

Error: No such command 'gret'.
```

**After the change:**
```
$ ./main.py greet --nme David
Usage: main.py greet [OPTIONS]
Try 'main.py greet --help' for help.

Error: No such option '--nme'. Did you mean '--name'?
```
```
$ ./main.py gret --name David
Usage: main.py [OPTIONS] COMMAND [ARGS]...
Try 'main.py --help' for help.

Error: No such command 'gret'. Did you mean 'greet'?
```

- [x] Added unit tests for unknown and misspelled commands.