### PR TITLE
add -dry-run option to aliases example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 htmlcov/
 .tox/
 docs/_build/
+.venv/

--- a/examples/aliases/aliases.py
+++ b/examples/aliases/aliases.py
@@ -27,7 +27,7 @@ class Config:
         parser.add_section("aliases")
         for key, value in self.aliases.items():
             parser.set("aliases", key, value)
-        with open(filename, "wb") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             parser.write(file)
 
 
@@ -136,8 +136,16 @@ def status(config):
 @click.option(
     "--config_file", type=click.Path(exists=True, dir_okay=False), default="aliases.ini"
 )
-def alias(config, alias_, cmd, config_file):
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would change without writing the config file.",
+)
+def alias(config, alias_, cmd, config_file, dry_run):
     """Adds an alias to the specified configuration file."""
+    if dry_run:
+        click.echo(f"Would add '{alias_}' as alias for '{cmd}' in '{config_file}'")
+        return
     config.add_alias(alias_, cmd)
     config.write_config(config_file)
     click.echo(f"Added '{alias_}' as alias for '{cmd}'")

--- a/tests/test_examples_aliases.py
+++ b/tests/test_examples_aliases.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import configparser
+import importlib.util
+from pathlib import Path
+
+from click.testing import CliRunner
+
+
+def _load_aliases_example_cli():
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "examples" / "aliases" / "aliases.py"
+    spec = importlib.util.spec_from_file_location("click_examples_aliases", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.cli
+
+
+def test_alias_writes_config_file(tmp_path):
+    cli = _load_aliases_example_cli()
+    runner = CliRunner()
+
+    config_path = tmp_path / "aliases.ini"
+    config_path.write_text("", encoding="utf-8")
+
+    result = runner.invoke(
+        cli,
+        ["alias", "foo", "status", "--config_file", str(config_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Added 'foo' as alias for 'status'" in result.output
+
+    parser = configparser.RawConfigParser()
+    parser.read(config_path, encoding="utf-8")
+    assert parser.has_section("aliases")
+    assert parser.get("aliases", "foo") == "status"
+
+
+def test_alias_dry_run_does_not_write_config_file(tmp_path):
+    cli = _load_aliases_example_cli()
+    runner = CliRunner()
+
+    config_path = tmp_path / "aliases.ini"
+    config_path.write_text("", encoding="utf-8")
+    before = config_path.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        cli,
+        ["alias", "foo", "status", "--config_file", str(config_path), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Would add 'foo' as alias for 'status' in" in result.output
+
+    after = config_path.read_text(encoding="utf-8")
+    assert after == before
+
+
+def test_alias_overwrites_existing_alias(tmp_path):
+    cli = _load_aliases_example_cli()
+    runner = CliRunner()
+
+    config_path = tmp_path / "aliases.ini"
+    config_path.write_text("", encoding="utf-8")
+
+    first = runner.invoke(
+        cli,
+        ["alias", "foo", "status", "--config_file", str(config_path)],
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        cli,
+        ["alias", "foo", "commit", "--config_file", str(config_path)],
+    )
+    assert second.exit_code == 0, second.output
+    assert "Added 'foo' as alias for 'commit'" in second.output
+
+    parser = configparser.RawConfigParser()
+    parser.read(config_path, encoding="utf-8")
+    assert parser.get("aliases", "foo") == "commit"


### PR DESCRIPTION
Summary
	•	Added a --dry-run flag to the alias command in examples/aliases/aliases.py to preview alias changes without writing the config file.
	•	Changed config writing to text mode with UTF-8 encoding for correct configparser behavior.

Behavior
	•	alias ALIAS CMD --config_file <file> writes the alias mapping and prints confirmation.
	•	alias ALIAS CMD --config_file <file> --dry-run prints what would change and exits without modifying the file.

Tests
	•	Added tests/test_examples_aliases.py covering write, dry-run no-write, and overwrite behavior.
	•	python -m pytest -q → 1322 passed, 22 skipped, 1 xfailed

Commits
	•	17b8b5f Add dry-run option to aliases example
	•	3b9eb0f Add tests for aliases dry-run behavior
