### PR TITLE
fix: use full argument in NoSuchOption for short options

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,8 +401,7 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(opt, ctx=self.ctx)
-            if option.takes_value:
+raise NoSuchOption(arg, ctx=self.ctx)            if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.
                 if i < len(arg):


### PR DESCRIPTION
## Summary
Fixes #2779 - when a multi-character short option like `-dbgwrong` is passed and not found, the error message previously showed only the first character (e.g., `No such option: -d`) instead of the full argument.

**Root cause:** `_match_short_opt` iterated over single characters and raised `NoSuchOption(opt)` where `opt` was the single-char option string. The `arg` parameter (the full original argument) was available but unused in the error.

**Fix:** Pass `arg` instead of `opt` to `NoSuchOption`, so users see the full string they typed.

**Before:**
```
Error: No such option: -d
```
**After:**
```
Error: No such option: -dbgwrong
```

Closes #2779