### PR TITLE
docs: guard AliasedGroup.resolve_command against None command

### DIFF
--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd is not None else None, cmd, args
 ```
 
 It can be used like this:


### PR DESCRIPTION
Fixes #2402.

This updates the `AliasedGroup.resolve_command` example in `docs/extending-click.md` to handle the case where `cmd` can be `None`:

- before: `return cmd.name, cmd, args`
- after: `return cmd.name if cmd is not None else None, cmd, args`

This avoids an `AttributeError` in shell completion when the command name is invalid.