### PR TITLE
fix: show full argument in error for unknown short option

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,7 +401,7 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(opt, ctx=self.ctx)
+                raise NoSuchOption(arg, ctx=self.ctx)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.


### PR DESCRIPTION
## Summary

Fixes #2779

When processing short options character by character, if an unknown option is encountered, the error message now shows the full argument (e.g., `-dbgwrong`) instead of just the first unknown character (e.g., `-d`).

## Before

```
$ python script.py -dbgwrong
Error: No such option: -d
```

## After

```
$ python script.py -dbgwrong
Error: No such option: -dbgwrong
```

## Changes

- Changed `raise NoSuchOption(opt, ctx=self.ctx)` to `raise NoSuchOption(arg, ctx=self.ctx)` in `_match_short_opt`

This provides more context when the user makes a typo in a multi-character short option.