### PR TITLE
docs: add shell completion testing section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Unreleased
 
 -   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
     used without an explicit value. :issue:`3084`
+-   Add a shell completion testing example to the testing docs. :issue:`2299`
 
 Version 8.3.1
 --------------

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -196,3 +196,24 @@ def test_prompts():
 Prompts will be emulated so they write the input data to
 the output stream as well. If hidden input is expected then this
 does not happen.
+
+## Shell Completion
+
+For testing completion suggestions, use {class}`click.shell_completion.ShellComplete`
+to call the completion engine directly.
+
+```{code-block} python
+:caption: test_completion.py
+
+from click.shell_completion import ShellComplete
+from myapp import cli
+
+def _get_completion_values(command, args, incomplete):
+    complete = ShellComplete(command, {}, command.name, "_CLICK_COMPLETE")
+    return [item.value for item in complete.get_completions(args, incomplete)]
+
+def test_option_completion():
+    assert "--env-file" in _get_completion_values(cli, [], "--env")
+```
+
+This pattern is the same approach used by Click's own shell completion tests.


### PR DESCRIPTION
## Summary
- add a new **Shell Completion** section to `docs/testing.md`
- document a minimal helper using `click.shell_completion.ShellComplete` to test completion suggestions directly
- add an `Unreleased` changelog entry in `CHANGES.rst`

This uses the same testing pattern already used in Click's own shell completion tests and gives users a stable migration target from older `get_choices`-based examples.

Fixes #2299