### PR TITLE
fix: remove bytes comparison in Path.convert to avoid BytesWarning

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -973,7 +973,7 @@ class Path(ParamType):
     ) -> str | bytes | os.PathLike[str]:
         rv = value
 
-        is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
+        is_dash = self.file_okay and self.allow_dash and rv == "-"
 
         if not is_dash:
             if self.resolve_path:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -136,6 +136,22 @@ def test_path_allow_dash(runner):
     assert result.exit_code == 0
 
 
+def test_path_allow_dash_no_bytes_warning(runner):
+    """Path with allow_dash should not compare str against bytes."""
+    import warnings
+
+    @click.command()
+    @click.argument("input", type=click.Path(allow_dash=True))
+    def foo(input):
+        click.echo(input)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", BytesWarning)
+        result = runner.invoke(foo, ["-"])
+    assert result.exit_code == 0
+    assert result.output == "-\n"
+
+
 def test_file_atomics(runner):
     @click.command()
     @click.argument("output", type=click.File("wb", atomic=True))


### PR DESCRIPTION
Fixes #2877. Remove dead b"-" from the dash check in Path.convert since the value is always str | PathLike[str], never bytes. Running with python -bb -Werror no longer raises BytesWarning.