### PR TITLE
Mark `make_default_short_help` as private API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Unreleased
     ``pytest-xdist`` to detect test pollution and race conditions. :pr:`3151`
 -   Add contributor documentation for running stress tests, randomized
     parallel tests, and Flask smoke tests. :pr:`3151` :pr:`3177`
+-   Mark ``make_default_short_help`` as private API. :issue:`3189` :pr:`3250`
 
 Version 8.3.2
 -------------

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -57,7 +57,10 @@ def make_str(value: t.Any) -> str:
 
 
 def make_default_short_help(help: str, max_length: int = 45) -> str:
-    """Returns a condensed version of help string."""
+    """Returns a condensed version of help string.
+
+    :meta private:
+    """
     # Consider only the first paragraph.
     paragraph_end = help.find("\n\n")
 


### PR DESCRIPTION
Randomly browsing the backlog, I stumble upon this comment https://github.com/pallets/click/issues/3189#issuecomment-3774030149 where `make_default_short_help` is explicitly stated as private API .

This is a small PR to enforce that.