### PR TITLE
Fix pager buffering delay with generator input

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -458,6 +458,7 @@ def _pipepager(
         env=env,
         errors="replace",
         text=True,
+        bufsize=1,
     )
     assert c.stdin is not None
     try:


### PR DESCRIPTION
When using `echo_via_pager()` with a generator, content doesn't appear in the pager until ~8KB of data accumulates in the pipe buffer. This means you can yield hundreds of lines before anything shows up on screen.

The fix is to pass `bufsize=1` to `subprocess.Popen` in `_pipepager()`, which enables line buffering in text mode. Each line gets sent to the pager as soon as it's written instead of sitting in the buffer.

Closes #3242