### PR TITLE
fix: preserve multichar short option in unknown-option errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Unreleased
 
 -   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
     used without an explicit value. :issue:`3084`
+-   Fix unknown-option error reporting for malformed multi-character options
+    with a single-character prefix so ``-dbgwrong`` reports ``-dbg`` instead of
+    ``-d`` when ``-dbg`` exists. :issue:`2779`
 
 Version 8.3.1
 --------------

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -490,8 +490,22 @@ class _OptionParser:
             # short option code and will instead raise the no option
             # error.
             if arg[:2] not in self._opt_prefixes:
-                self._match_short_opt(arg, state)
-                return
+                try:
+                    self._match_short_opt(arg, state)
+                    return
+                except NoSuchOption:
+                    # Preserve the longest known option prefix in errors for
+                    # multi-character options with a single-character prefix.
+                    possible_opt = max(
+                        (opt for opt in self._long_opt if arg.startswith(opt)),
+                        key=len,
+                        default=None,
+                    )
+
+                    if possible_opt is not None:
+                        raise NoSuchOption(possible_opt, ctx=self.ctx) from None
+
+                    raise
 
             if not self.ignore_unknown_options:
                 raise

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -155,6 +155,7 @@ def test_unknown_option_for_multichar_short_option(runner):
     assert "No such option: -dbg" in result.output
     assert "No such option: -d" not in result.output
 
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,17 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_unknown_option_for_multichar_short_option(runner):
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        del dbg
+
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exception
+    assert "No such option: -dbg" in result.output
+    assert "No such option: -d" not in result.output
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
fixes #2779

when a multichar option like -dbg is defined, passing -dbgwrong previously reported no such option: -d due to short-option fallback.

this change preserves the longest known option prefix so the error reports no such option: -dbg instead.

it also adds a regression test for this case and includes a changelog entry in CHANGES.rst.