### PR TITLE
Fix error message for invalid single-dash multichar options

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,6 +401,20 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
+
+                multi_short_opt = max(
+                    (
+                        short_opt
+                        for short_opt in self._short_opt
+                        if len(short_opt) > 2 and arg.startswith(short_opt)
+                    ),
+                    key=len,
+                    default=None,
+                )
+
+                if multi_short_opt is not None:
+                    raise NoSuchOption(multi_short_opt, ctx=self.ctx)
+
                 raise NoSuchOption(opt, ctx=self.ctx)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
@@ -483,6 +497,19 @@ class _OptionParser:
         try:
             self._match_long_opt(norm_long_opt, explicit_value, state)
         except NoSuchOption:
+            single_prefix_long_opt = max(
+                (
+                    opt
+                    for opt in self._long_opt
+                    if len(opt) > 2 and opt[1] not in self._opt_prefixes and arg.startswith(opt)
+                ),
+                key=len,
+                default=None,
+            )
+
+            if single_prefix_long_opt is not None:
+                raise NoSuchOption(single_prefix_long_opt, ctx=self.ctx)
+
             # At this point the long option matching failed, and we need
             # to try with short options.  However there is a special rule
             # which says, that if we have a two character options prefix

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -501,7 +501,9 @@ class _OptionParser:
                 (
                     opt
                     for opt in self._long_opt
-                    if len(opt) > 2 and opt[1] not in self._opt_prefixes and arg.startswith(opt)
+                    if len(opt) > 2
+                    and opt[1] not in self._opt_prefixes
+                    and arg.startswith(opt)
                 ),
                 key=len,
                 default=None,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,17 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_unknown_option_for_multichar_short_option(runner):
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        pass
+
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exception
+    assert "No such option: -dbg" in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Summary
- detect invalid options that start with a registered single-dash multi-character option (example: -dbgwrong)
- raise NoSuchOption with the full registered option name instead of the first character
- add a regression test for this behavior

Fixes pallets/click#2779