### PR TITLE
Fix usage string for invoke_without_command groups to mark subcommand as optional

### DIFF
--- a/repro.py
+++ b/repro.py
@@ -1,0 +1,14 @@
+import click
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def main(ctx):
+    if ctx.invoked_subcommand is not None:
+        return
+
+@main.command()
+def sub():
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/repro.py
+++ b/repro.py
@@ -1,14 +1,17 @@
 import click
 
+
 @click.group(invoke_without_command=True)
 @click.pass_context
 def main(ctx):
     if ctx.invoked_subcommand is not None:
         return
 
+
 @main.command()
 def sub():
     pass
+
 
 if __name__ == "__main__":
     main()

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1585,6 +1585,8 @@ class Group(Command):
         if subcommand_metavar is None:
             if chain:
                 subcommand_metavar = "COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]..."
+            elif self.invoke_without_command:
+                subcommand_metavar = "[COMMAND] [ARGS]..."
             else:
                 subcommand_metavar = "COMMAND [ARGS]..."
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -298,6 +298,7 @@ def test_invoked_subcommand(runner):
     assert not result.exception
     assert result.output == "no subcommand, use default\nin subcommand\n"
 
+
 def test_invoke_without_command_usage_shows_optional_subcommand(runner):
     import click
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -298,6 +298,23 @@ def test_invoked_subcommand(runner):
     assert not result.exception
     assert result.output == "no subcommand, use default\nin subcommand\n"
 
+def test_invoke_without_command_usage_shows_optional_subcommand(runner):
+    import click
+
+    @click.group(invoke_without_command=True)
+    @click.pass_context
+    def cli(ctx):
+        if ctx.invoked_subcommand is not None:
+            return
+
+    @cli.command()
+    def sub():
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage: cli [OPTIONS] [COMMAND] [ARGS]..." in result.output
+
 
 def test_aliased_command_canonical_name(runner):
     class AliasedGroup(click.Group):


### PR DESCRIPTION
Fixes #3059

When a group is created with `invoke_without_command=True`, the help usage string currently shows:

    COMMAND [ARGS]...

which incorrectly implies that a subcommand is required. However, in this configuration, the group can be invoked without a subcommand.

This change updates the default `subcommand_metavar` so that the usage string correctly reflects optional behavior:

    [COMMAND] [ARGS]...

The change is limited to non-chain groups with `invoke_without_command=True`, and does not affect existing behavior for other group configurations.

A regression test has been added to verify that the usage output includes `[COMMAND] [ARGS]...` when `--help` is invoked.

Let me know if any adjustments are needed.