### PR TITLE
fix: restore click.launch() on Windows with subprocess.call

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -701,11 +701,11 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
             url = _unquote_file(url)
             args = ["explorer", f"/select,{url}"]
         else:
-            args = ["start"]
+            # start is a cmd.exe built-in, not an executable; invoke via cmd /c
+            args = ["cmd", "/c", "start"]
             if wait:
                 args.append("/WAIT")
-            args.append("")
-            args.append(url)
+            args.extend(["", url])
         try:
             return subprocess.call(args)
         except OSError:


### PR DESCRIPTION
## Summary
Fixes #3272.
**Root cause:** Migration from `os.system` to `subprocess.call` used incorrect argument format for the Windows `start` command when opening URLs.
**Fix:** Invoke `start` via `cmd /c` since it is a shell built-in, not an executable.
## Changes
- `src/click/_termui_impl.py`: Fixed `open_url()` Windows subprocess invocation
## Testing
- Verified fix addresses reported WinError 2 scenario
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)