### PR TITLE
Fix enum Choice shell completion using str() instead of name

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -387,7 +387,9 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
         """
         from click.shell_completion import CompletionItem
 
-        str_choices = map(str, self.choices)
+        str_choices = [
+            c.name if isinstance(c, enum.Enum) else str(c) for c in self.choices
+        ]
 
         if self.case_sensitive:
             matched = (c for c in str_choices if c.startswith(incomplete))

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -467,6 +467,19 @@ def test_choice_case_sensitive(value, expect):
     assert completions == expect
 
 
+def test_choice_enum_completion():
+    import enum
+
+    class MyEnum(enum.Enum):
+        foo = "bar"
+        baz = "qux"
+
+    cli = Command("cli", params=[Option(["-c"], type=Choice(MyEnum))])
+    assert _get_words(cli, ["-c"], "") == ["foo", "baz"]
+    assert _get_words(cli, ["-c"], "f") == ["foo"]
+    assert _get_words(cli, ["-c"], "b") == ["baz"]
+
+
 @pytest.fixture()
 def _restore_available_shells(tmpdir):
     prev_available_shells = click.shell_completion._available_shells.copy()


### PR DESCRIPTION
Fixes #3015

Choice.shell_complete() was using str() to convert choices to strings for completion, which produces 'MyEnum.foo' for enum members. The accepted CLI value however is 'foo' (the enum name), since normalize_choice uses choice.name for enums.

Changed shell_complete to use choice.name for enum members, matching the actual accepted input values. Added a test verifying enum completions use the name attribute.