### PR TITLE
Add usage to Command.to_info_dict output

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -985,6 +985,7 @@ class Command:
             "short_help": self.short_help,
             "hidden": self.hidden,
             "deprecated": self.deprecated,
+            "usage": self.get_usage(ctx),
         }
 
     def __repr__(self) -> str:

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -73,6 +73,7 @@ HELLO_COMMAND = (
         "short_help": None,
         "hidden": False,
         "deprecated": False,
+        "usage": "Usage:  [OPTIONS]",
     },
 )
 HELLO_GROUP = (
@@ -85,7 +86,19 @@ HELLO_GROUP = (
         "short_help": None,
         "hidden": False,
         "deprecated": False,
-        "commands": {"hello": HELLO_COMMAND[1]},
+        "usage": "Usage:  [OPTIONS] COMMAND [ARGS]...",
+        "commands": {
+            "hello": {
+                "name": "hello",
+                "params": [NUMBER_OPTION[1], HELP_OPTION[1]],
+                "help": None,
+                "epilog": None,
+                "short_help": None,
+                "hidden": False,
+                "deprecated": False,
+                "usage": "Usage: hello [OPTIONS]",
+            },
+        },
         "chain": False,
     },
 )
@@ -231,8 +244,31 @@ def test_parameter(obj, expect):
                 "short_help": None,
                 "hidden": False,
                 "deprecated": False,
+                "usage": "Usage:  [OPTIONS] COMMAND [ARGS]...",
                 "commands": {
-                    "cli": HELLO_GROUP[1],
+                    "cli": {
+                        "name": "cli",
+                        "params": [HELP_OPTION[1]],
+                        "help": None,
+                        "epilog": None,
+                        "short_help": None,
+                        "hidden": False,
+                        "deprecated": False,
+                        "usage": "Usage: cli [OPTIONS] COMMAND [ARGS]...",
+                        "commands": {
+                            "hello": {
+                                "name": "hello",
+                                "params": [NUMBER_OPTION[1], HELP_OPTION[1]],
+                                "help": None,
+                                "epilog": None,
+                                "short_help": None,
+                                "hidden": False,
+                                "deprecated": False,
+                                "usage": "Usage: cli hello [OPTIONS]",
+                            },
+                        },
+                        "chain": False,
+                    },
                     "test": {
                         "name": "test",
                         "params": [NAME_ARGUMENT[1], HELP_OPTION[1]],
@@ -241,6 +277,7 @@ def test_parameter(obj, expect):
                         "short_help": None,
                         "hidden": False,
                         "deprecated": False,
+                        "usage": "Usage: test [OPTIONS] NAME",
                     },
                 },
                 "chain": False,


### PR DESCRIPTION
Fixes #2992

Command.to_info_dict() now includes a 'usage' key containing the output of get_usage(ctx). This lets consumers of to_info_dict() access the usage string directly instead of having to reconstruct it by iterating sub-contexts.

Updated existing tests to include the new key in expected output.