### PR TITLE
Use LF line endings for shell completion output

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -16,6 +16,16 @@ from .core import ParameterSource
 from .utils import echo
 
 
+def _write_shell_output(text: str, *, nl: bool = True) -> None:
+    """Write shell completion output with LF line endings.
+
+    Shells such as zsh can reject CRLF-encoded completion scripts, so
+    write bytes to bypass platform newline translation on text streams.
+    """
+
+    echo(text.encode(), nl=nl)
+
+
 def shell_complete(
     cli: Command,
     ctx_args: cabc.MutableMapping[str, t.Any],
@@ -44,11 +54,11 @@ def shell_complete(
     comp = comp_cls(cli, ctx_args, prog_name, complete_var)
 
     if instruction == "source":
-        echo(comp.source())
+        _write_shell_output(comp.source(), nl=False)
         return 0
 
     if instruction == "complete":
-        echo(comp.complete())
+        _write_shell_output(comp.complete())
         return 0
 
     return 1

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,3 +1,4 @@
+import io
 import textwrap
 import warnings
 from collections.abc import Mapping
@@ -9,6 +10,7 @@ from click.core import Argument
 from click.core import Command
 from click.core import Group
 from click.core import Option
+from click.shell_completion import shell_complete
 from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
 from click.shell_completion import ShellComplete
@@ -368,6 +370,20 @@ def test_full_complete(runner, shell, env, expect):
     env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
     assert result.output == expect
+
+
+def test_source_uses_lf_line_endings(monkeypatch):
+    stdout = io.BytesIO()
+    stream = io.TextIOWrapper(stdout, encoding="utf-8", newline="\r\n")
+    monkeypatch.setattr("click.utils._default_text_stdout", lambda: stream)
+
+    cli = Group("cli", commands=[Command("a"), Command("b")])
+    assert shell_complete(cli, {}, "cli", "_CLI_COMPLETE", "zsh_source") == 0
+
+    stream.flush()
+    output = stdout.getvalue()
+    assert b"\r\n" not in output
+    assert b"\n" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -10,9 +10,9 @@ from click.core import Argument
 from click.core import Command
 from click.core import Group
 from click.core import Option
-from click.shell_completion import shell_complete
 from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
+from click.shell_completion import shell_complete
 from click.shell_completion import ShellComplete
 from click.types import Choice
 from click.types import File


### PR DESCRIPTION
## Summary
- write shell completion source and completion output as bytes to bypass platform newline translation
- preserve LF line endings for zsh completion scripts on Windows/MSYS environments
- add a regression test that simulates a CRLF-translating text stdout and verifies zsh source output stays LF-only

## Testing
- PYTHONPATH=src python3 -m pytest tests/test_shell_completion.py

Fixes #3277