### PR TITLE
Fix Choice shell completion for enum types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Unreleased
 
 -   Fix handling of ``flag_value`` when ``is_flag=False`` to allow such options to be
     used without an explicit value. :issue:`3084`
+-   Fix ``Choice`` shell completion for enum types to use the enum member
+    name instead of ``str()``, which produced unusable values like
+    ``MyEnum.foo`` instead of ``foo``. :issue:`3015`
 
 Version 8.3.1
 --------------

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -387,7 +387,9 @@ class Choice(ParamType, t.Generic[ParamTypeValue]):
         """
         from click.shell_completion import CompletionItem
 
-        str_choices = map(str, self.choices)
+        str_choices = [
+            c.name if isinstance(c, enum.Enum) else str(c) for c in self.choices
+        ]
 
         if self.case_sensitive:
             matched = (c for c in str_choices if c.startswith(incomplete))

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -467,6 +467,20 @@ def test_choice_case_sensitive(value, expect):
     assert completions == expect
 
 
+def test_choice_enum_completion():
+    """Completion for enum choices should use the enum name, not str()."""
+    import enum
+
+    class MyEnum(enum.Enum):
+        foo = "bar"
+        baz = "qux"
+
+    cli = Command("cli", params=[Option(["-c"], type=Choice(MyEnum))])
+    assert _get_words(cli, ["-c"], "") == ["foo", "baz"]
+    assert _get_words(cli, ["-c"], "f") == ["foo"]
+    assert _get_words(cli, ["-c"], "b") == ["baz"]
+
+
 @pytest.fixture()
 def _restore_available_shells(tmpdir):
     prev_available_shells = click.shell_completion._available_shells.copy()


### PR DESCRIPTION
## Summary

- Fix `Choice.shell_complete()` to use `choice.name` for enum members instead of `str()`, which produced unusable completion values like `MyEnum.foo` instead of the accepted CLI value `foo`.
- This aligns `shell_complete` with the existing `normalize_choice` method, which already handles enum members correctly using `choice.name`.
- Added a test verifying enum completions return member names.

Fixes #3015

## Details

When using an enum with `Choice`, e.g.:

```python
class MyEnum(enum.Enum):
    foo = "bar"
    baz = "qux"

@click.option("-c", type=click.Choice(MyEnum))
```

The accepted CLI value is `foo` (the enum member name), since `normalize_choice` (line 298 of `types.py`) uses `choice.name if isinstance(choice, enum.Enum)`. However, `shell_complete` was using `map(str, self.choices)` which produces `MyEnum.foo` — a value that the CLI would then reject.

The fix applies the same enum-aware string conversion in `shell_complete`.

## Test plan

- [x] Added `test_choice_enum_completion` test verifying enum completions use member names
- [x] Existing `test_choice_case_sensitive` test continues to pass
- [x] Full test suite passes (1320 passed, 22 skipped, 1 xfailed)