### PR TITLE
Fix CliRunner TypeError with pathlib.Path arguments

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -494,6 +494,13 @@ class CliRunner:
 
             if isinstance(args, str):
                 args = shlex.split(args)
+            elif args is not None:
+                # Convert path-like objects to strings to prevent parser errors
+                # See: https://github.com/pallets/click/issues/1324
+                args = [
+                    str(arg) if hasattr(arg, '__fspath__') else arg
+                    for arg in args
+                ]
 
             try:
                 prog_name = extra.pop("prog_name")

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -497,10 +497,7 @@ class CliRunner:
             elif args is not None:
                 # Convert path-like objects to strings to prevent parser errors
                 # See: https://github.com/pallets/click/issues/1324
-                args = [
-                    str(arg) if hasattr(arg, '__fspath__') else arg
-                    for arg in args
-                ]
+                args = [str(arg) if hasattr(arg, "__fspath__") else arg for arg in args]
 
             try:
                 prog_name = extra.pop("prog_name")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -476,8 +476,8 @@ def test_pathlib_path_in_args_works_with_fix():
     """
     Test that passing pathlib.Path objects to CliRunner.invoke() now works correctly.
 
-    This verifies the fix for: "object of type 'PosixPath' has no len()" when Path objects
-    were passed to Click's argument parser instead of strings.
+    This verifies the fix for: "object of type 'PosixPath' has no len()" when Path
+    objects were passed to Click's argument parser instead of strings.
 
     See: https://github.com/pallets/click/issues/1324
     """
@@ -539,7 +539,8 @@ def test_various_pathlib_objects_work_consistently(path_input):
     """
     Test that all types of pathlib.Path objects work consistently with the fix.
 
-    This ensures automatic Path-to-string conversion works for different Path object types.
+    This ensures automatic Path-to-string conversion works for different Path
+    object types.
     """
 
     @click.command()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -586,5 +586,8 @@ def test_direct_parser_still_fails_with_pathlib():
 
     # This should still fail with Path objects (parser behavior unchanged)
     test_path = Path("/tmp/test")
-    with pytest.raises(TypeError, match=r"('PosixPath' has no length|object of type 'PosixPath' has no len)"):
+    with pytest.raises(
+        TypeError,
+        match=r"('PosixPath' has no length|object of type 'PosixPath' has no len)",
+    ):
         parser.parse_args([test_path])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -586,5 +586,5 @@ def test_direct_parser_still_fails_with_pathlib():
 
     # This should still fail with Path objects (parser behavior unchanged)
     test_path = Path("/tmp/test")
-    with pytest.raises(TypeError, match="object of type 'PosixPath' has no len"):
+    with pytest.raises(TypeError, match=r"('PosixPath' has no length|object of type 'PosixPath' has no len)"):
         parser.parse_args([test_path])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from io import BytesIO
+from pathlib import Path
 
 import pytest
 
@@ -469,3 +470,113 @@ def test_isolation_flushes_unflushed_stderr():
 
     result = runner.invoke(cli)
     assert result.stderr == "gyarados gyarados gyarados"
+
+
+def test_pathlib_path_in_args_works_with_fix():
+    """
+    Test that passing pathlib.Path objects to CliRunner.invoke() now works correctly.
+
+    This verifies the fix for: "object of type 'PosixPath' has no len()" when Path objects
+    were passed to Click's argument parser instead of strings.
+
+    See: https://github.com/pallets/click/issues/1324
+    """
+    @click.command()
+    @click.argument('path')
+    def cmd(path):
+        click.echo(f"Path: {path}")
+
+    runner = CliRunner()
+
+    # This should work fine with strings
+    result = runner.invoke(cmd, ['/tmp/test'])
+    assert result.exit_code == 0
+    assert 'Path: /tmp/test' in result.output
+
+    # This should now work with Path objects too (automatic conversion)
+    test_path = Path('/tmp/test')
+    result = runner.invoke(cmd, [test_path])
+
+    # CliRunner should automatically convert Path to string
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert 'Path: /tmp/test' in result.output
+
+
+def test_pathlib_path_string_conversion_works():
+    """
+    Test that pathlib.Path objects work when converted to strings.
+
+    This demonstrates the correct workaround for the bug.
+    """
+    @click.command()
+    @click.argument('path')
+    def cmd(path):
+        click.echo(f"Path: {path}")
+
+    runner = CliRunner()
+    test_path = Path('/tmp/test')
+
+    # The correct approach: convert Path to string explicitly
+    result = runner.invoke(cmd, [str(test_path)])
+    assert result.exit_code == 0
+    assert 'Path: /tmp/test' in result.output
+
+
+@pytest.mark.parametrize("path_input", [
+    pytest.param(Path("/tmp/test"), id="absolute"),
+    pytest.param(Path("/tmp/test/file.txt"), id="absolute_file"),
+    pytest.param(Path("relative/path"), id="relative"),
+    pytest.param(Path("."), id="current_dir"),
+    pytest.param(Path(".."), id="parent_dir"),
+])
+def test_various_pathlib_objects_work_consistently(path_input):
+    """
+    Test that all types of pathlib.Path objects work consistently with the fix.
+
+    This ensures automatic Path-to-string conversion works for different Path object types.
+    """
+    @click.command()
+    @click.argument('path')
+    def cmd(path):
+        click.echo(f"Path: {path}")
+
+    runner = CliRunner()
+
+    # All Path objects should now work correctly (automatic conversion)
+    result = runner.invoke(cmd, [path_input])
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert f"Path: {str(path_input)}" in result.output
+
+
+def test_direct_parser_still_fails_with_pathlib():
+    """
+    Test that Click's parser still fails when given Path objects directly.
+
+    This ensures we haven't changed the core parser behavior - only CliRunner
+    now handles Path objects gracefully by converting them to strings.
+    """
+    from click.parser import _OptionParser
+    from click.core import Context, Argument
+
+    @click.command()
+    @click.argument('path')
+    def cmd(path):
+        click.echo(f"Path: {path}")
+
+    ctx = Context(cmd)
+    parser = _OptionParser(ctx)
+
+    # Add argument to parser
+    arg = Argument(['path'])
+    arg.add_to_parser(parser, ctx)
+
+    # This should still work with strings
+    result = parser.parse_args(['/tmp/test'])
+    assert result[0]['path'] == '/tmp/test'
+
+    # This should still fail with Path objects (parser behavior unchanged)
+    test_path = Path('/tmp/test')
+    with pytest.raises(TypeError, match="object of type 'PosixPath' has no len"):
+        parser.parse_args([test_path])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -588,6 +588,7 @@ def test_direct_parser_still_fails_with_pathlib():
     test_path = Path("/tmp/test")
     with pytest.raises(
         TypeError,
-        match=r"(object of type '(Posix|Windows)Path' has no len|'(Posix|Windows)Path' has no length)",
+        match=r"(object of type '(Posix|Windows)Path' has no len"
+        r"|'(Posix|Windows)Path' has no length)",
     ):
         parser.parse_args([test_path])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -481,26 +481,27 @@ def test_pathlib_path_in_args_works_with_fix():
 
     See: https://github.com/pallets/click/issues/1324
     """
+
     @click.command()
-    @click.argument('path')
+    @click.argument("path")
     def cmd(path):
         click.echo(f"Path: {path}")
 
     runner = CliRunner()
 
     # This should work fine with strings
-    result = runner.invoke(cmd, ['/tmp/test'])
+    result = runner.invoke(cmd, ["/tmp/test"])
     assert result.exit_code == 0
-    assert 'Path: /tmp/test' in result.output
+    assert "Path: /tmp/test" in result.output
 
     # This should now work with Path objects too (automatic conversion)
-    test_path = Path('/tmp/test')
+    test_path = Path("/tmp/test")
     result = runner.invoke(cmd, [test_path])
 
     # CliRunner should automatically convert Path to string
     assert result.exit_code == 0
     assert result.exception is None
-    assert 'Path: /tmp/test' in result.output
+    assert "Path: /tmp/test" in result.output
 
 
 def test_pathlib_path_string_conversion_works():
@@ -509,35 +510,40 @@ def test_pathlib_path_string_conversion_works():
 
     This demonstrates the correct workaround for the bug.
     """
+
     @click.command()
-    @click.argument('path')
+    @click.argument("path")
     def cmd(path):
         click.echo(f"Path: {path}")
 
     runner = CliRunner()
-    test_path = Path('/tmp/test')
+    test_path = Path("/tmp/test")
 
     # The correct approach: convert Path to string explicitly
     result = runner.invoke(cmd, [str(test_path)])
     assert result.exit_code == 0
-    assert 'Path: /tmp/test' in result.output
+    assert "Path: /tmp/test" in result.output
 
 
-@pytest.mark.parametrize("path_input", [
-    pytest.param(Path("/tmp/test"), id="absolute"),
-    pytest.param(Path("/tmp/test/file.txt"), id="absolute_file"),
-    pytest.param(Path("relative/path"), id="relative"),
-    pytest.param(Path("."), id="current_dir"),
-    pytest.param(Path(".."), id="parent_dir"),
-])
+@pytest.mark.parametrize(
+    "path_input",
+    [
+        pytest.param(Path("/tmp/test"), id="absolute"),
+        pytest.param(Path("/tmp/test/file.txt"), id="absolute_file"),
+        pytest.param(Path("relative/path"), id="relative"),
+        pytest.param(Path("."), id="current_dir"),
+        pytest.param(Path(".."), id="parent_dir"),
+    ],
+)
 def test_various_pathlib_objects_work_consistently(path_input):
     """
     Test that all types of pathlib.Path objects work consistently with the fix.
 
     This ensures automatic Path-to-string conversion works for different Path object types.
     """
+
     @click.command()
-    @click.argument('path')
+    @click.argument("path")
     def cmd(path):
         click.echo(f"Path: {path}")
 
@@ -557,11 +563,12 @@ def test_direct_parser_still_fails_with_pathlib():
     This ensures we haven't changed the core parser behavior - only CliRunner
     now handles Path objects gracefully by converting them to strings.
     """
+    from click.core import Argument
+    from click.core import Context
     from click.parser import _OptionParser
-    from click.core import Context, Argument
 
     @click.command()
-    @click.argument('path')
+    @click.argument("path")
     def cmd(path):
         click.echo(f"Path: {path}")
 
@@ -569,14 +576,14 @@ def test_direct_parser_still_fails_with_pathlib():
     parser = _OptionParser(ctx)
 
     # Add argument to parser
-    arg = Argument(['path'])
+    arg = Argument(["path"])
     arg.add_to_parser(parser, ctx)
 
     # This should still work with strings
-    result = parser.parse_args(['/tmp/test'])
-    assert result[0]['path'] == '/tmp/test'
+    result = parser.parse_args(["/tmp/test"])
+    assert result[0]["path"] == "/tmp/test"
 
     # This should still fail with Path objects (parser behavior unchanged)
-    test_path = Path('/tmp/test')
+    test_path = Path("/tmp/test")
     with pytest.raises(TypeError, match="object of type 'PosixPath' has no len"):
         parser.parse_args([test_path])

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -501,7 +501,7 @@ def test_pathlib_path_in_args_works_with_fix():
     # CliRunner should automatically convert Path to string
     assert result.exit_code == 0
     assert result.exception is None
-    assert "Path: /tmp/test" in result.output
+    assert f"Path: {str(test_path)}" in result.output
 
 
 def test_pathlib_path_string_conversion_works():
@@ -522,7 +522,7 @@ def test_pathlib_path_string_conversion_works():
     # The correct approach: convert Path to string explicitly
     result = runner.invoke(cmd, [str(test_path)])
     assert result.exit_code == 0
-    assert "Path: /tmp/test" in result.output
+    assert f"Path: {str(test_path)}" in result.output
 
 
 @pytest.mark.parametrize(
@@ -588,6 +588,6 @@ def test_direct_parser_still_fails_with_pathlib():
     test_path = Path("/tmp/test")
     with pytest.raises(
         TypeError,
-        match=r"('PosixPath' has no length|object of type 'PosixPath' has no len)",
+        match=r"(object of type '(Posix|Windows)Path' has no len|'(Posix|Windows)Path' has no length)",
     ):
         parser.parse_args([test_path])


### PR DESCRIPTION
## Summary

• Fixes `TypeError: object of type 'PosixPath' has no len()` when passing `pathlib.Path` objects to `CliRunner.invoke()`
• Implements automatic Path-to-string conversion using Python's `__fspath__` protocol
• Preserves backward compatibility and core parser behavior

## Background

When `pathlib.Path` objects are passed to `CliRunner.invoke()`, Click's argument parser crashes because it calls `len()` on the Path object without type checking. This issue was reported in #1324 but remained unresolved with a cryptic error message that doesn't guide users to the solution.

## Changes

**Core Fix (`src/click/testing.py`)**:
- Added automatic conversion of path-like objects to strings in `CliRunner.invoke()`
- Uses Python's standard `__fspath__` protocol for path-like object detection
- Only affects the testing layer, preserving production parser behavior

**Test Coverage (`tests/test_testing.py`)**:
- Added comprehensive test suite with 4 test functions
- Tests various Path object types (absolute, relative, current/parent directories)
- Verifies backward compatibility with existing string arguments
- Confirms core parser behavior remains unchanged

## Related Issues

Fixes #1324