### PR TITLE
fix: flush pager stdin after each write for streaming output

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -466,6 +466,7 @@ def _pipepager(
                 text = strip_ansi(text)
 
             c.stdin.write(text)
+            c.stdin.flush()
     except BrokenPipeError:
         # In case the pager exited unexpectedly, ignore the broken pipe error.
         pass


### PR DESCRIPTION
## Problem

When using `echo_via_pager` with a generator, output is not displayed until the internal buffer fills (typically 512 lines / 8KB). This is because the subprocess stdin pipe is not flushed after each write.

```python
import click
import time

def _generator():
    for i in range(10000):
        time.sleep(0.01)
        yield f"{i+1:07}\n"

@click.command
def main():
    click.echo_via_pager(_generator())
```

Expected: text appears immediately as it's generated.
Actual: nothing shows until ~512 lines have been yielded.

## Solution

Add `c.stdin.flush()` after each `c.stdin.write(text)` in `_pipepager()` to ensure text is immediately sent to the pager process. This enables real-time streaming of generator output while maintaining all existing error handling.

## Files Changed

- `src/click/_termui_impl.py`: Added `flush()` call after `write()` in `_pipepager()`

## Testing

All 143 existing tests pass. The `BrokenPipeError` handler already covers the case where the pager exits unexpectedly during a flush.

Closes #3242