### PR TITLE
[codex] Fix shadowed help hint option

### DIFF
--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -74,14 +74,24 @@ class UsageError(ClickException):
             file = get_text_stderr()
         color = None
         hint = ""
-        if (
-            self.ctx is not None
-            and self.ctx.command.get_help_option(self.ctx) is not None
-        ):
-            hint = _("Try '{command} {option}' for help.").format(
-                command=self.ctx.command_path, option=self.ctx.help_option_names[0]
-            )
-            hint = f"{hint}\n"
+        if self.ctx is not None:
+            help_option = self.ctx.command.get_help_option(self.ctx)
+
+            if help_option is not None:
+                help_option_names = set(help_option.opts)
+                hint_option = next(
+                    (
+                        name
+                        for name in self.ctx.help_option_names
+                        if name in help_option_names
+                    ),
+                    help_option.opts[0],
+                )
+
+                hint = _("Try '{command} {option}' for help.").format(
+                    command=self.ctx.command_path, option=hint_option
+                )
+                hint = f"{hint}\n"
         if self.ctx is not None:
             color = self.ctx.color
             echo(f"{self.ctx.get_usage()}\n{hint}", file=file, color=color)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -215,6 +215,27 @@ def test_formatting_usage_error_nested(runner):
     ]
 
 
+def test_formatting_usage_error_shadowed_help_option(runner):
+    @click.group(context_settings={"help_option_names": ["-h", "--help"]})
+    def cmd():
+        pass
+
+    @cmd.command()
+    @click.argument("required_arg")
+    @click.option("--host", "-h")
+    def foo(required_arg, host):
+        pass
+
+    result = runner.invoke(cmd, ["foo"])
+    assert result.exit_code == 2
+    assert result.output.splitlines() == [
+        "Usage: cmd foo [OPTIONS] REQUIRED_ARG",
+        "Try 'cmd foo --help' for help.",
+        "",
+        "Error: Missing argument 'REQUIRED_ARG'.",
+    ]
+
+
 def test_formatting_usage_error_no_help(runner):
     @click.command(add_help_option=False)
     @click.argument("arg")


### PR DESCRIPTION
Fixes #2790.

## Summary
- choose the help hint from the command's active help option instead of always using `ctx.help_option_names[0]`
- add a regression test for a nested command that shadows `-h` with another option

## Root Cause
`UsageError.show()` built the help hint from the configured preference order in `ctx.help_option_names`, even when a nested command no longer exposed the first name because `-h` had been claimed by another option.

## Validation
- `uv run pytest tests/test_formatting.py -k shadowed_help_option -q`
- `uv run pytest tests/test_formatting.py -q`
- `uv run pytest tests/test_commands.py -q`
- `uv run pytest tests/test_options.py -q`