### PR TITLE
Fix #2836: Use show_default string in prompts, not just help text

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3145,10 +3145,11 @@ class Option(Parameter):
                 default = bool(default)
             return confirm(self.prompt, default)
 
-        # If show_default is set to True/False, provide this to `prompt` as well. For
-        # non-bool values of `show_default`, we use `prompt`'s default behavior
+        # If show_default is set, provide this to `prompt` as well. When
+        # show_default is a string, pass it through so the prompt displays
+        # the custom string instead of the raw default value.
         prompt_kwargs: t.Any = {}
-        if isinstance(self.show_default, bool):
+        if self.show_default is not None:
             prompt_kwargs["show_default"] = self.show_default
 
         return prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -60,7 +60,7 @@ def hidden_prompt_func(prompt: str) -> str:
 def _build_prompt(
     text: str,
     suffix: str,
-    show_default: bool = False,
+    show_default: bool | str = False,
     default: t.Any | None = None,
     show_choices: bool = True,
     type: ParamType | None = None,
@@ -68,8 +68,11 @@ def _build_prompt(
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
         prompt += f" ({', '.join(map(str, type.choices))})"
-    if default is not None and show_default:
-        prompt = f"{prompt} [{_format_default(default)}]"
+    if show_default:
+        if isinstance(show_default, str):
+            prompt = f"{prompt} [{show_default}]"
+        elif default is not None:
+            prompt = f"{prompt} [{_format_default(default)}]"
     return f"{prompt}{suffix}"
 
 
@@ -88,7 +91,7 @@ def prompt(
     type: ParamType | t.Any | None = None,
     value_proc: t.Callable[[str], t.Any] | None = None,
     prompt_suffix: str = ": ",
-    show_default: bool = True,
+    show_default: bool | str = True,
     err: bool = False,
     show_choices: bool = True,
 ) -> t.Any:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -496,6 +496,37 @@ def test_false_show_default_cause_no_default_display_in_prompt(runner):
     assert "my-default-value" not in result.output
 
 
+def test_show_default_string_in_prompt(runner):
+    """When show_default is a string, the prompt should display that string
+    instead of the raw default value. See issue #2836."""
+
+    @click.command()
+    @click.option(
+        "--arg1",
+        show_default="current value",
+        prompt=True,
+        default="my-default-value",
+    )
+    def cmd(arg1):
+        click.echo(arg1)
+
+    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
+    # The custom show_default string should appear in the prompt
+    assert "current value" in result.output
+    # The raw default value should NOT appear in the prompt
+    assert "my-default-value" not in result.output
+
+
+def test_show_default_true_shows_actual_default_in_prompt(runner):
+    @click.command()
+    @click.option("--arg1", show_default=True, prompt=True, default="my-default-value")
+    def cmd(arg1):
+        pass
+
+    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
+    assert "my-default-value" in result.output
+
+
 REPEAT = object()
 """Sentinel value to indicate that the prompt is expected to be repeated.
 


### PR DESCRIPTION
## Summary

Fixes #2836 — When `show_default` is a string, the help text correctly displayed it but the interactive prompt showed the raw default value instead.

## Changes

- `src/click/core.py`: `prompt_for_value()` now passes string `show_default` to `prompt()` (was only passing booleans)
- `src/click/termui.py`: `_build_prompt()` and `prompt()` accept `show_default: bool | str` — string values are displayed in brackets

## Tests

Added 2 tests in `tests/test_termui.py`:
- `test_show_default_string_in_prompt` — custom string appears in prompt
- `test_show_default_true_shows_actual_default_in_prompt` — True still works

All existing tests pass.

## Context

This issue has been open for 1+ year. Resolved with assistance from [OwlMind](https://owlmind.dev) — an autonomous AI coding agent.