### PR TITLE
Preserve multichar option name in parser errors

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -490,6 +490,19 @@ class _OptionParser:
             # short option code and will instead raise the no option
             # error.
             if arg[:2] not in self._opt_prefixes:
+                multichar_opt = max(
+                    (
+                        opt
+                        for opt in self._long_opt
+                        if _split_opt(opt)[0] == arg[:1] and arg.startswith(opt)
+                    ),
+                    default=None,
+                    key=len,
+                )
+
+                if multichar_opt is not None and multichar_opt != arg:
+                    raise NoSuchOption(multichar_opt, ctx=self.ctx)
+
                 self._match_short_opt(arg, state)
                 return
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,17 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_unknown_multichar_short_option_reports_full_option(runner):
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        pass
+
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exception
+    assert "No such option: -dbg" in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Summary
- preserve the longest matching multichar single-dash option when long-option matching falls through
- avoid degrading `-dbgwrong` into a misleading `-d` parser error
- add a regression test covering the reported behavior

## Testing
- `PYTHONPATH=src ./.venv311/bin/python -m pytest -q tests/test_options.py -k "unknown_options or multichar_short_option_reports_full_option"`
- direct CliRunner repro now reports `No such option: -dbg`

Closes #2779