### PR TITLE
docs: clarify Context.invoke behavior for required arguments

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -213,6 +213,12 @@ whereas {func}`Context.forward` fills in the arguments from the current
 command. Both accept the command as the first argument, and everything else
 is passed onwards as you would expect.
 
+When invoking commands this way, Click does not parse command-line input for
+the invoked command. That means required parameters are not validated the same
+way as shell invocation unless you provide values yourself. For example,
+calling `ctx.invoke(other_cmd)` without values for required arguments can pass
+`None` to the callback.
+
 Example:
 
 ```{eval-rst}


### PR DESCRIPTION
## Summary

Clarify docs for `Context.invoke` / `Context.forward` to explain behavior from #2801:

- invoking another command programmatically does **not** perform command-line parsing for that command
- required parameter validation is therefore different from shell invocation unless values are passed explicitly
- omitting required argument values in `ctx.invoke(...)` can result in `None` reaching the callback

## Why

Issue #2801 reports that invoking a command with required arguments from another command can still execute and receive `None`.

Maintainer feedback indicates this behavior is intended, but the docs for command invocation should make this explicit so users don't misinterpret it as a bug.

## Changes

File updated:

- `docs/advanced.md` ("Invoking Other Commands" section)

Added a concise note describing the parsing/validation difference and a concrete `ctx.invoke(other_cmd)` example outcome.

## Scope

- Documentation only
- No runtime behavior changes
- No API changes

Closes #2801
