### PR TITLE
Fix #2779: Show full option name in error for multicharacter short options

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,7 +401,9 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(_normalize_opt(arg, self.ctx), ctx=self.ctx)  # Fix #2779
+                raise NoSuchOption(
+                    _normalize_opt(arg, self.ctx), ctx=self.ctx
+                )  # Fix #2779
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,7 +401,7 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(opt, ctx=self.ctx)
+                raise NoSuchOption(_normalize_opt(arg, self.ctx), ctx=self.ctx)  # Fix #2779
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.


### PR DESCRIPTION
Fixes #2779

## Problem
When passing a wrong multicharacter short option like `-dbgwrong`, the error message incorrectly shows:
```
No such option: -d
```
instead of the full option name:
```
No such option: -dbgwrong
```

## Root Cause
In `_match_short_opt()`, the function iterates through each character of the argument and raises `NoSuchOption` with just the first invalid character, not the original argument.

## Solution
Modified `src/click/parser.py` to report the full original argument when raising `NoSuchOption`:
```python
# Before:
raise NoSuchOption(opt, ctx=self.ctx)  # opt is just "-d"

# After:
raise NoSuchOption(_normalize_opt(arg, self.ctx), ctx=self.ctx)  # arg is "-dbgwrong"
```

## Testing
- Manual testing with various multicharacter short options
- All existing tests should pass

## Impact
- Improves error message accuracy
- Better user experience when debugging command-line options
- No breaking changes to API

---
*This PR was created with AI assistance. The fix is minimal and focused on the reported issue.*
