### PR TITLE
Fix launch() with locate=True for paths containing spaces on Windows

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -699,7 +699,7 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
     elif WIN:
         if locate:
             url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            args = ["explorer", f'/select,"{url}"']
         else:
             args = ["start"]
             if wait:


### PR DESCRIPTION
## Problem

On Windows, `click.launch(path, locate=True)` builds the command:
```
explorer /select,C:\My Documents\file.txt
```

When the path contains spaces, Windows Explorer misinterprets it and opens the wrong location or fails silently.

## Solution

Wrap the path in double quotes:
```python
args = ["explorer", f'/select,"{url}"']
```

Previous attempt in #3216 was closed without merging.

Fixes #2994