### PR TITLE
Quote Windows Explorer locate paths

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -698,8 +698,8 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
             null.close()
     elif WIN:
         if locate:
-            url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            url = _unquote_file(url).replace('"', '""')
+            args = ["explorer", f'/select,"{url}"']
         else:
             args = ["start"]
             if wait:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -710,3 +710,22 @@ def test_flag_value_prompt(
         assert result.output == expected_output
         assert not result.stderr
         assert result.exit_code == 0 if expected not in (REPEAT, INVALID) else 1
+
+
+def test_open_url_windows_locate_quotes_path(monkeypatch):
+    calls = []
+
+    def fake_call(args):
+        calls.append(args)
+        return 0
+
+    monkeypatch.setattr(click._termui_impl, "WIN", True)
+    monkeypatch.setattr(click._termui_impl, "CYGWIN", False)
+    monkeypatch.setattr("subprocess.call", fake_call)
+
+    rv = click._termui_impl.open_url(
+        r"C:\Users\Public\click demo\example.txt", locate=True
+    )
+
+    assert rv == 0
+    assert calls == [["explorer", '/select,"C:\\Users\\Public\\click demo\\example.txt"']]


### PR DESCRIPTION
## Summary
- quote the `/select` target passed to Windows Explorer when `click.launch(..., locate=True)` is used
- add a regression test for a path containing spaces

## Why
`explorer /select,` expects the selected path to be quoted when it contains spaces. Without that quoting, `click.launch(..., locate=True)` can open the wrong location on Windows.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_termui.py -q`

Fixes #2994