### PR TITLE
Mark invoke_without_command subcommands optional in help

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1585,6 +1585,10 @@ class Group(Command):
         if subcommand_metavar is None:
             if chain:
                 subcommand_metavar = "COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]..."
+                if invoke_without_command:
+                    subcommand_metavar = f"[{subcommand_metavar}]"
+            elif invoke_without_command:
+                subcommand_metavar = "[COMMAND] [ARGS]..."
             else:
                 subcommand_metavar = "COMMAND [ARGS]..."
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -299,6 +299,21 @@ def test_invoked_subcommand(runner):
     assert result.output == "no subcommand, use default\nin subcommand\n"
 
 
+def test_invoke_without_command_help_marks_subcommand_optional(runner):
+    @click.group(invoke_without_command=True)
+    def cli():
+        pass
+
+    @cli.command()
+    def sync():
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+
+    assert not result.exception
+    assert result.output.startswith("Usage: cli [OPTIONS] [COMMAND] [ARGS]...")
+
+
 def test_aliased_command_canonical_name(runner):
     class AliasedGroup(click.Group):
         def get_command(self, ctx, cmd_name):


### PR DESCRIPTION
## Summary
- show the subcommand as optional in group help when `invoke_without_command=True`
- add a regression test for the `--help` output

## Why
If a group can be invoked without a subcommand, the usage line should reflect that. Today Click still shows `COMMAND [ARGS]...` as if a subcommand were required.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_commands.py tests/test_chain.py tests/test_formatting.py -q`

Fixes #3059