### PR TITLE
Normalize multiline help in fish completion output

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -418,7 +418,12 @@ class FishComplete(ShellComplete):
 
     def format_completion(self, item: CompletionItem) -> str:
         if item.help:
-            return f"{item.type},{item.value}\t{item.help}"
+            help_ = " ".join(
+                part.strip() for part in item.help.splitlines() if part.strip()
+            )
+
+            if help_:
+                return f"{item.type},{item.value}\t{help_}"
 
         return f"{item.type},{item.value}"
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -370,6 +370,33 @@ def test_full_complete(runner, shell, env, expect):
     assert result.output == expect
 
 
+def test_fish_complete_multiline_help(runner):
+    cli = Command(
+        "cli",
+        params=[
+            Option(
+                ["--at"],
+                help="Attachment with explicit mimetype,\n--at image.jpg image/jpeg",
+            )
+        ],
+    )
+
+    result = runner.invoke(
+        cli,
+        env={
+            "_CLI_COMPLETE": "fish_complete",
+            "COMP_WORDS": "cli --",
+            "COMP_CWORD": "--",
+        },
+    )
+
+    assert (
+        result.output
+        == "plain,--at\tAttachment with explicit mimetype, --at image.jpg image/jpeg\n"
+        "plain,--help\tShow this message and exit.\n"
+    )
+
+
 @pytest.mark.parametrize(
     ("env", "expect"),
     [


### PR DESCRIPTION
## Summary
- normalize multi-line help text to a single line in fish completion output
- add an end-to-end regression test covering a multi-line option help string

## Why
Fish completion expects each completion entry to stay on one line. When Click includes a help string with embedded newlines, the generated completion output is split across lines and breaks the fish completion script.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_shell_completion.py -q`

Fixes #3043