### PR TITLE
fix: use os.startfile on Windows instead of subprocess start

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -700,17 +700,22 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
         if locate:
             url = _unquote_file(url)
             args = ["explorer", f"/select,{url}"]
+            try:
+                return subprocess.call(args)
+            except OSError:
+                # Command not found
+                return 127
         else:
-            args = ["start"]
-            if wait:
-                args.append("/WAIT")
-            args.append("")
-            args.append(url)
-        try:
-            return subprocess.call(args)
-        except OSError:
-            # Command not found
-            return 127
+            try:
+                os.startfile(url)  # type: ignore[attr-defined]
+                return 0
+            except OSError:
+                if url.startswith(("http://", "https://")) and not wait:
+                    import webbrowser
+
+                    webbrowser.open(url)
+                    return 0
+                return 1
     elif CYGWIN:
         if locate:
             url = _unquote_file(url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -746,3 +746,19 @@ def test_make_default_short_help(value, max_length, alter, expect):
 
     out = click.utils.make_default_short_help(value, max_length)
     assert out == expect
+
+
+def test_open_url_windows_uses_startfile(monkeypatch):
+    """On Windows, open_url should use os.startfile instead of subprocess
+    to avoid depending on the shell built-in 'start' command."""
+    from click._termui_impl import open_url, WIN
+
+    if not WIN:
+        pytest.skip("Windows-only test")
+
+    called_with = []
+    monkeypatch.setattr(os, "startfile", lambda url: called_with.append(url))
+
+    result = open_url("https://example.com")
+    assert result == 0
+    assert called_with == ["https://example.com"]


### PR DESCRIPTION
## Problem

`click.launch("https://example.com")` fails on Windows with `[WinError 2] The system cannot find the file specified` since version 8.1.8.

This is because `start` is a Windows shell built-in command, not an executable file. The migration from `os.system()` to `subprocess.call()` in #1477 broke this — `subprocess.call(["start", ...])` requires `shell=True` to work, but the maintainers correctly don't want to use `shell=True`.

## Fix

Replace `subprocess.call(["start", ...])` with `os.startfile()`, which is the native Python API for opening files and URLs on Windows. It calls the Windows `ShellExecuteW` API directly without needing a shell.

- **Non-locate case**: Uses `os.startfile(url)` directly
- **Locate case**: Keeps `subprocess.call(["explorer", "/select,..."])` (explorer.exe is a real executable)
- **Fallback**: If `os.startfile` fails with `OSError`, falls back to `webbrowser.open()` for HTTP(S) URLs (same pattern as the Linux/xdg-open fallback)

## Test

Added `test_open_url_windows_uses_startfile` — monkeypatches `os.startfile` and verifies it's called with the URL.

Fixes #2868