### PR TITLE
fix: show custom error messages when hide_input=True

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -177,10 +177,7 @@ def prompt(
         try:
             result = value_proc(value)
         except UsageError as e:
-            if hide_input:
-                echo(_("Error: The value you entered was invalid."), err=err)
-            else:
-                echo(_("Error: {e.message}").format(e=e), err=err)
+            echo(_("Error: {e.message}").format(e=e), err=err)
             continue
         if not confirmation_prompt:
             return result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -746,3 +746,30 @@ def test_make_default_short_help(value, max_length, alter, expect):
 
     out = click.utils.make_default_short_help(value, max_length)
     assert out == expect
+
+
+def test_hide_input_shows_custom_error(runner):
+    """With hide_input=True, custom error messages from type validation
+    should still be displayed, not swallowed by a generic message."""
+
+    class StrictPassword(click.ParamType):
+        name = "password"
+
+        def convert(self, value, param, ctx):
+            if len(value) < 8:
+                self.fail("Password must be at least 8 characters", param, ctx)
+            return value
+
+    @click.command()
+    @click.option(
+        "--pw",
+        prompt=True,
+        hide_input=True,
+        type=StrictPassword(),
+    )
+    def cmd(pw):
+        click.echo(f"OK:{pw}")
+
+    result = runner.invoke(cmd, input="short\nlong_enough_pw\n")
+    assert "Password must be at least 8 characters" in result.output
+    assert "OK:long_enough_pw" in result.output


### PR DESCRIPTION
## Problem

When using `hide_input=True` with a custom type that raises `BadParameter` (via `self.fail()`), the custom error message is swallowed and replaced with a generic `"Error: The value you entered was invalid."`.

This is because `termui.py` has an explicit branch that replaces any `UsageError` message with a hardcoded string when `hide_input=True`:

```python
except UsageError as e:
    if hide_input:
        echo("Error: The value you entered was invalid.")  # custom message lost!
    else:
        echo(f"Error: {e.message}")  # custom message shown
```

### Reproduction

```python
class StrictPassword(click.ParamType):
    name = "password"
    def convert(self, value, param, ctx):
        if len(value) < 8:
            self.fail("Password must be at least 8 characters", param, ctx)
        return value

@click.command()
@click.option("--pw", prompt=True, hide_input=True, type=StrictPassword())
def cmd(pw): ...
```

Entering "short" shows: `Error: The value you entered was invalid.`
Expected: `Error: Password must be at least 8 characters`

## Fix

Remove the `hide_input` branch in the `UsageError` handler — always show the actual error message. The `hide_input` flag should only affect whether the **input value** is echoed during typing, not whether the developer's custom validation error messages are displayed.

Custom error messages are written by the developer and don't contain the secret input value, so there's no security reason to suppress them.

## Test

Added `test_hide_input_shows_custom_error` — verifies custom error messages from type validation are shown even when `hide_input=True`.

Fixes #2809