### PR TITLE
Fix BytesWarning in Path.convert when comparing bytes and str

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -973,7 +973,12 @@ class Path(ParamType):
     ) -> str | bytes | os.PathLike[str]:
         rv = value
 
-        is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
+        is_dash = (
+            self.file_okay
+            and self.allow_dash
+            and isinstance(rv, (bytes, str))
+            and rv in (b"-", "-")
+        )
 
         if not is_dash:
             if self.resolve_path:


### PR DESCRIPTION
When allow_dash=True and rv is bytes, the check `rv in (b"-", "-")` raises BytesWarning under `-bb` mode because Python compares bytes against str.

Fix by adding an isinstance check before the containment test so that bytes rv is only compared against bytes "-" and str rv against str "-".

Fixes #2877