### PR TITLE
Add skipif markers to test_file_surrogates and test_file_error_surrogates

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -216,6 +216,10 @@ def test_path_surrogates(tmp_path, monkeypatch):
     path.unlink()
 
 
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 @pytest.mark.parametrize(
     "type",
     [
@@ -235,9 +239,13 @@ def test_file_surrogates(type, tmp_path):
         type.convert(path, None, None)
 
 
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 def test_file_error_surrogates():
     message = FileError(filename="\udcff").format_message()
-    assert message == "Could not open file '�': unknown error"
+    assert message == "Could not open file '\udcff': unknown error"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Add `@pytest.mark.skipif` for `_non_utf8_filenames_supported()` to match the pattern used by `test_path_surrogates`. This prevents test failures on filesystems that don't support non-UTF-8 filenames.

Fixes #2634