### PR TITLE
Fix BytesWarning in Path.convert when allow_dash=True and rv is bytes

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -973,7 +973,11 @@ class Path(ParamType):
     ) -> str | bytes | os.PathLike[str]:
         rv = value
 
-        is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
+        is_dash = (
+            self.file_okay
+            and self.allow_dash
+            and (rv == "-" if isinstance(rv, str) else rv == b"-")
+        )
 
         if not is_dash:
             if self.resolve_path:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -216,6 +216,10 @@ def test_path_surrogates(tmp_path, monkeypatch):
     path.unlink()
 
 
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 @pytest.mark.parametrize(
     "type",
     [
@@ -235,9 +239,13 @@ def test_file_surrogates(type, tmp_path):
         type.convert(path, None, None)
 
 
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 def test_file_error_surrogates():
     message = FileError(filename="\udcff").format_message()
-    assert message == "Could not open file '�': unknown error"
+    assert message == "Could not open file '\udcff': unknown error"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
When allow_dash=True and rv is bytes, the check `rv in (b"-", "-")` raises BytesWarning under `-bb` mode because Python compares bytes against str.

Fix by checking the type of rv before comparison so bytes rv is only compared against bytes "-" and str rv against str "-".

Fixes #2877