### PR TITLE
fix: guard default value comparison against types with strict __eq__

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3110,7 +3110,7 @@ class Option(Parameter):
                 )[1]
             elif self.is_bool_flag and not self.secondary_opts and not default_value:
                 default_string = ""
-            elif default_value == "":
+            elif isinstance(default_value, str) and default_value == "":
                 default_string = '""'
             else:
                 default_string = str(default_value)


### PR DESCRIPTION
## Problem

Fixes #3298

When a non-string default value (e.g. `semver.Version`) is used with an `@click.option`, Click tries to generate help text and compares the default value against an empty string using `==`. Types like `semver.Version` implement `__eq__` to only accept strings that parse as valid semver, so `Version(1,0,0) == ""` raises `ValueError`.

## Root Cause

In `core.py` line ~3113:
```python
elif default_value == "":
    default_string = "\"\""
```

This equality check is triggered for any type of default value, not just strings. For types with strict `__eq__` implementations, this crashes.

## Fix

Add an `isinstance(default_value, str)` guard before the `== ""` check, so non-string types fall through to the `str(default_value)` branch which works correctly for all types.

## Testing

```python
import click
from semver import Version

class SemverType(click.ParamType):
    name = "semver"
    def convert(self, value, param, ctx):
        if isinstance(value, Version):
            return value
        return Version.parse(value)

@click.command()
@click.option("--version", type=SemverType(), default=Version(1, 0, 0))
def cli(version):
    click.echo(f"Version: {version}")

# This now works without ValueError
from click.testing import CliRunner
runner = CliRunner()
result = runner.invoke(cli, ["--help"])
```

Existing test suite passes (331 passed; 1 pre-existing failure unrelated to this change).