### PR TITLE
Show default string in prompt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,9 @@ Unreleased
     ``pytest-xdist`` to detect test pollution and race conditions. :pr:`3151`
 -   Add contributor documentation for running stress tests, randomized
     parallel tests, and Flask smoke tests. :pr:`3151` :pr:`3177`
--   Add support for custom ``show_default`` string in prompts. :pr:`460a142`
+-   Show custom ``show_default`` string in prompts, matching the existing
+    help text behavior. :issue:`2836` :pr:`2837` :pr:`3165` :pr:`3262` :pr:`3280`
+    :pr:`3328``
 
 Version 8.3.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Unreleased
     ``pytest-xdist`` to detect test pollution and race conditions. :pr:`3151`
 -   Add contributor documentation for running stress tests, randomized
     parallel tests, and Flask smoke tests. :pr:`3151` :pr:`3177`
+-   Add support for custom ``show_default`` string in prompts. :pr:`460a142`
 
 Version 8.3.2
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3164,10 +3164,10 @@ class Option(Parameter):
                 default = bool(default)
             return confirm(self.prompt, default)
 
-        # If show_default is set to True/False, provide this to `prompt` as well. For
-        # non-bool values of `show_default`, we use `prompt`'s default behavior
+        # If show_default is given, provide this to `prompt` as well,
+        # otherwise we use `prompt`'s default behavior
         prompt_kwargs: t.Any = {}
-        if isinstance(self.show_default, bool):
+        if self.show_default is not None:
             prompt_kwargs["show_default"] = self.show_default
 
         return prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -60,7 +60,7 @@ def hidden_prompt_func(prompt: str) -> str:
 def _build_prompt(
     text: str,
     suffix: str,
-    show_default: bool = False,
+    show_default: bool | str = False,
     default: t.Any | None = None,
     show_choices: bool = True,
     type: ParamType | None = None,
@@ -68,6 +68,8 @@ def _build_prompt(
     prompt = text
     if type is not None and show_choices and isinstance(type, Choice):
         prompt += f" ({', '.join(map(str, type.choices))})"
+    if isinstance(show_default, str):
+        default = f"({show_default})"
     if default is not None and show_default:
         prompt = f"{prompt} [{_format_default(default)}]"
     return f"{prompt}{suffix}"
@@ -88,7 +90,7 @@ def prompt(
     type: ParamType | t.Any | None = None,
     value_proc: t.Callable[[str], t.Any] | None = None,
     prompt_suffix: str = ": ",
-    show_default: bool = True,
+    show_default: bool | str = True,
     err: bool = False,
     show_choices: bool = True,
 ) -> t.Any:
@@ -112,12 +114,17 @@ def prompt(
                        convert a value.
     :param prompt_suffix: a suffix that should be added to the prompt.
     :param show_default: shows or hides the default value in the prompt.
+                         If this value is a string, it shows that string
+                         in parentheses instead of the actual value.
     :param err: if set to true the file defaults to ``stderr`` instead of
                 ``stdout``, the same as with echo.
     :param show_choices: Show or hide choices if the passed type is a Choice.
                          For example if type is a Choice of either day or week,
                          show_choices is true and text is "Group by" then the
                          prompt will be "Group by (day, week): ".
+
+    .. versionadded:: 8.2
+        ``show_default`` can be a custom string.
 
     .. versionchanged:: 8.3.1
         A space is no longer appended to the prompt.

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -123,8 +123,9 @@ def prompt(
                          show_choices is true and text is "Group by" then the
                          prompt will be "Group by (day, week): ".
 
-    .. versionadded:: 8.2
-        ``show_default`` can be a custom string.
+    .. versionchanged:: 8.3.3
+        ``show_default`` can be a string to show a custom value instead
+        of the actual default, matching the help text behavior.
 
     .. versionchanged:: 8.3.1
         A space is no longer appended to the prompt.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1259,6 +1259,19 @@ def test_show_default_string(runner):
     assert "[default: (unlimited)]" in message
 
 
+def test_string_show_default_shows_custom_string_in_prompt(runner):
+    @click.command()
+    @click.option(
+        "--arg1", show_default="custom", prompt=True, default="my-default-value"
+    )
+    def cmd(arg1):
+        pass
+
+    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
+    assert "(custom)" in result.output
+    assert "my-default-value" not in result.output
+
+
 class _StrictEq:
     """Object whose ``__eq__`` raises on string comparison (like semver.Version)."""
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -717,6 +717,19 @@ def test_false_show_default_cause_no_default_display_in_prompt(runner):
     assert "my-default-value" not in result.output
 
 
+def test_string_show_default_shows_custom_string_in_prompt(runner):
+    @click.command()
+    @click.option(
+        "--arg1", show_default="custom", prompt=True, default="my-default-value"
+    )
+    def cmd(arg1):
+        pass
+
+    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
+    assert "(custom)" in result.output
+    assert "my-default-value" not in result.output
+
+
 REPEAT = object()
 """Sentinel value to indicate that the prompt is expected to be repeated.
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -9,6 +9,7 @@ import pytest
 import click._termui_impl
 from click._compat import WIN
 from click._termui_impl import Editor
+from click._utils import UNSET
 from click.exceptions import BadParameter
 from click.exceptions import MissingParameter
 
@@ -717,17 +718,56 @@ def test_false_show_default_cause_no_default_display_in_prompt(runner):
     assert "my-default-value" not in result.output
 
 
-def test_string_show_default_shows_custom_string_in_prompt(runner):
-    @click.command()
-    @click.option(
-        "--arg1", show_default="custom", prompt=True, default="my-default-value"
-    )
-    def cmd(arg1):
-        pass
+@pytest.mark.parametrize(
+    ("show_default", "default", "user_input", "in_prompt", "not_in_prompt"),
+    [
+        # Regular string replaces the actual default in the prompt.
+        ("custom", "actual", "\n", "(custom)", "actual"),
+        # String with spaces.
+        ("custom label", "actual", "\n", "(custom label)", "actual"),
+        # Unicode characters.
+        ("∞", "0", "\n", "(∞)", None),
+        # Numeric default: custom string hides the number.
+        ("unlimited", 42, "\n", "(unlimited)", "42"),
+        # Explicit default=None: custom string still appears, must provide input.
+        ("computed at runtime", None, "value\n", "(computed at runtime)", None),
+        # No default kwarg at all (internal UNSET sentinel): same as None.
+        ("computed at runtime", UNSET, "value\n", "(computed at runtime)", None),
+        # Empty string is falsy: suppresses any default display.
+        ("", "actual", "\n", None, "actual"),
+    ],
+    ids=[
+        "simple-string",
+        "string-with-spaces",
+        "unicode",
+        "numeric-default",
+        "default-is-none",
+        "default-is-unset",
+        "empty-string-is-falsy",
+    ],
+)
+def test_string_show_default_in_prompt(
+    runner, show_default, default, user_input, in_prompt, not_in_prompt
+):
+    """When show_default is a string, the prompt should display that
+    string in parentheses instead of the actual default value,
+    matching the help text behavior. See pallets/click#2836."""
 
-    result = runner.invoke(cmd, input="my-input", standalone_mode=False)
-    assert "(custom)" in result.output
-    assert "my-default-value" not in result.output
+    option_kwargs = {"show_default": show_default, "prompt": True}
+    if default is not UNSET:
+        option_kwargs["default"] = default
+
+    @click.command()
+    @click.option("--arg1", **option_kwargs)
+    def cmd(arg1):
+        click.echo(arg1)
+
+    result = runner.invoke(cmd, input=user_input, standalone_mode=False)
+    prompt_line = result.output.split("\n")[0]
+    if in_prompt is not None:
+        assert in_prompt in prompt_line
+    if not_in_prompt is not None:
+        assert not_in_prompt not in prompt_line
 
 
 REPEAT = object()


### PR DESCRIPTION
This PR build-up on #2837 (original contributor deleted its fork) and #3165 (revival based on AI slop) to use the value of `show_default` in prompt if the latter is a string. Which aligns the display with the help screen.

Also adds a lot of unit tests for edge-cases for default prompt displaying.

This closes #2836.