### PR TITLE
fix: quote path in explorer /select command on Windows

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -699,7 +699,7 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
     elif WIN:
         if locate:
             url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            args = ["explorer", f'/select,"{url}"']
         else:
             args = ["start"]
             if wait:


### PR DESCRIPTION
When using `click.launch(path, locate=True)` on Windows with a path that contains spaces, Windows Explorer opens the wrong folder because the path passed to `explorer /select,` is not quoted.

Wrapping the path in double quotes fixes the issue.

Before:
```python
args = ["explorer", f"/select,{url}"]
```

After:
```python
args = ["explorer", f"/select,\"{url}\""]
```

Fixes #2994
Related to #2868