### PR TITLE
Fix Path bytes dash check under Python bytes warnings

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -973,7 +973,13 @@ class Path(ParamType):
     ) -> str | bytes | os.PathLike[str]:
         rv = value
 
-        is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
+        if self.file_okay and self.allow_dash:
+            if isinstance(rv, bytes):
+                is_dash = rv == b"-"
+            else:
+                is_dash = rv == "-"
+        else:
+            is_dash = False
 
         if not is_dash:
             if self.resolve_path:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -110,8 +110,7 @@ def test_path_type(runner, cls, expect):
 
 def test_path_bytes_dash_no_byteswarning():
     code = (
-        "from click.types import Path; "
-        "Path(allow_dash=True).convert(b'-', None, None)"
+        "from click.types import Path; Path(allow_dash=True).convert(b'-', None, None)"
     )
 
     result = subprocess.run(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -109,12 +109,17 @@ def test_path_type(runner, cls, expect):
 
 
 def test_path_bytes_dash_no_byteswarning():
+    code = (
+        "from click.types import Path; "
+        "Path(allow_dash=True).convert(b'-', None, None)"
+    )
+
     result = subprocess.run(
         [
             sys.executable,
             "-bb",
             "-c",
-            "from click.types import Path; Path(allow_dash=True).convert(b'-', None, None)",
+            code,
         ],
         cwd=pathlib.Path(__file__).resolve().parents[1],
         env={**os.environ, "PYTHONPATH": "src"},

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,8 @@
 import os.path
 import pathlib
 import platform
+import subprocess
+import sys
 import tempfile
 
 import pytest
@@ -104,6 +106,23 @@ def test_path_type(runner, cls, expect):
     result = runner.invoke(cli, ["a/b/c.txt"], standalone_mode=False)
     assert result.exception is None
     assert result.return_value == expect
+
+
+def test_path_bytes_dash_no_byteswarning():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-bb",
+            "-c",
+            "from click.types import Path; Path(allow_dash=True).convert(b'-', None, None)",
+        ],
+        cwd=pathlib.Path(__file__).resolve().parents[1],
+        env={**os.environ, "PYTHONPATH": "src"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _symlinks_supported():


### PR DESCRIPTION
## Summary
- avoid comparing  and  when checking whether a  value is the special dash path
- add a regression test that runs the conversion under Python 

Fixes #2877.