### PR TITLE
Report full arg when single-dash token isn't a short flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 .. currentmodule:: click
 
+Unreleased
+----------
+
+-   Report the full argument (and close-match suggestion) when a
+    single-dash token looks like a typo of a multi-character option
+    (``-dbgwrong`` for ``-dbg``) instead of greedily splitting it into
+    single-char shorts. Short-option combining (``-abc``) is unaffected.
+    :issue:`2779`
+
+
 Version 8.3.2
 --------------
 

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -482,7 +482,7 @@ class _OptionParser:
         # like "-foo" to be matched as long options.
         try:
             self._match_long_opt(norm_long_opt, explicit_value, state)
-        except NoSuchOption:
+        except NoSuchOption as long_exc:
             # At this point the long option matching failed, and we need
             # to try with short options.  However there is a special rule
             # which says, that if we have a two character options prefix
@@ -490,7 +490,21 @@ class _OptionParser:
             # short option code and will instead raise the no option
             # error.
             if arg[:2] not in self._opt_prefixes:
-                self._match_short_opt(arg, state)
+                # Only dispatch to short-option splitting when the first
+                # character after the prefix is actually a registered
+                # short option. Otherwise the arg looks like a typo of a
+                # (single-dash) long option and should be reported
+                # verbatim, so the user sees e.g. ``No such option:
+                # -dbgwrong`` instead of the confusing ``No such option:
+                # -d``.
+                prefix = arg[0]
+                first = _normalize_opt(f"{prefix}{arg[1:2]}", self.ctx)
+                if first in self._short_opt:
+                    self._match_short_opt(arg, state)
+                    return
+                if not self.ignore_unknown_options:
+                    raise long_exc
+                state.largs.append(arg)
                 return
 
             if not self.ignore_unknown_options:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,43 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_unknown_multichar_short_option_reports_full_arg(runner):
+    """A typo of a multi-character single-dash option should be reported
+    verbatim, not greedily split into unknown single-char shorts.
+
+    Regression for https://github.com/pallets/click/issues/2779.
+    """
+    cli = click.Command("cli", params=[click.Option(["-dbg"], is_flag=True)])
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exception
+    assert "No such option: -dbgwrong" in result.output
+    # The close-match suggestion should also appear.
+    assert "-dbg" in result.output
+
+
+def test_short_option_combining_still_works(runner):
+    """Regression guard: ``-abc`` with ``-a``, ``-b``, ``-c`` registered as
+    single-char flags should still be treated as combined shorts, and the
+    first unknown char in the group should still be the one reported."""
+    cli = click.Command(
+        "cli",
+        params=[
+            click.Option(["-a"], is_flag=True),
+            click.Option(["-b"], is_flag=True),
+            click.Option(["-c"], is_flag=True),
+        ],
+    )
+    # All registered: succeeds.
+    result = runner.invoke(cli, ["-abc"])
+    assert result.exit_code == 0
+
+    # Middle-of-group unknown char: still reports that char, not the
+    # whole group.
+    result = runner.invoke(cli, ["-abZ"])
+    assert result.exception
+    assert "No such option: -Z" in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Summary

When a user defines a multi-character single-dash option (e.g. `-dbg`) and mistypes it as `-dbgwrong`, click currently reports:

```
Error: No such option: -d
```

because long-option matching fails, the code falls back to `_match_short_opt`, which greedy-splits the argument character by character and stops at the first unknown single char.

This PR makes the fallback only kick in when the first character after the prefix is actually registered as a short option. Otherwise the original `NoSuchOption` is re-raised with the full argument, which also lets the existing close-match machinery suggest the right option:

```
Error: No such option: -dbgwrong Did you mean -dbg?
```

## What's unchanged

Short-option combining still works exactly the same:

- `-abc` where `-a`, `-b`, `-c` are all registered flags → combined, all three enabled
- `-abZ` where `-a`, `-b` registered but `-Z` isn't → still reports `No such option: -Z` (first char IS registered, so the split path runs, and the specific bad char gets named)

## Tests

Added two regression tests in `tests/test_options.py`:

1. `test_unknown_multichar_short_option_reports_full_arg` — guards the #2779 scenario
2. `test_short_option_combining_still_works` — guards that `-abc`-style combining isn't regressed

Full suite passes: `1386 passed, 22 skipped, 30000 deselected, 1 xfailed`.

## Changelog

Added an entry under an `Unreleased` section. Happy to move it under whichever future release number the maintainers prefer.

Fixes #2779