### PR TITLE
Fix #2779: Wrong error message when wrong multicharacter short opti...

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -401,6 +401,18 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
+
+                # If a registered single-dash long option (like -dbg)
+                # is a prefix of the original argument, report the
+                # error using the full argument instead of just the
+                # single character that failed to match.
+                norm_arg = _normalize_opt(arg, self.ctx)
+                for long_opt_name in self._long_opt:
+                    if norm_arg.startswith(long_opt_name) and len(
+                        long_opt_name
+                    ) > len(opt):
+                        raise NoSuchOption(norm_arg, ctx=self.ctx)
+
                 raise NoSuchOption(opt, ctx=self.ctx)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,26 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_multicharacter_short_option_wrong_option_error(runner):
+    """When a wrong multi-character short option like -dbgwrong is passed,
+    the error should reference the full argument, not just the first char."""
+
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        click.echo(f"dbg={dbg}")
+
+    # Correct usage should work.
+    result = runner.invoke(cli, ["-dbg"])
+    assert not result.exception
+    assert "dbg=True" in result.output
+
+    # Wrong option should mention the full argument, not just '-d'.
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exit_code != 0
+    assert "No such option: -dbgwrong" in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Summary
Fix the error message when an invalid multi-character single-dash option is passed. Previously, `-dbgwrong` would report `No such option: -d` because the parser tried to match each character individually as a short option. Now it correctly reports `No such option: -dbgwrong`.

## Changes
- In `_match_short_opt` in `parser.py`, when a character fails to match a short option, check if any registered single-dash long option (e.g. `-dbg`) is a prefix of the original argument. If so, raise `NoSuchOption` with the full argument string instead of just the single unmatched character.
- Added test verifying that `-dbg` (correct usage) still works and that `-dbgwrong` produces an error message referencing the full argument.

## Testing
- `pytest tests/test_options.py::test_multicharacter_short_option_wrong_option_error` passes
- Existing option-related tests remain green

Closes #2779