### PR TITLE
fix: handle spaces in paths for launch(locate=True) on Windows

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -699,7 +699,7 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
     elif WIN:
         if locate:
             url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            args = f'explorer /select,"{url}"'
         else:
             args = ["start"]
             if wait:


### PR DESCRIPTION
Fixes #2994

On Windows, `launch(path, locate=True)` passes the explorer command as a list:

```python
args = ["explorer", f"/select,{url}"]
```

`subprocess.call` joins list args with spaces, so a path like `C:\my folder\file.txt` gets split at the space and explorer opens the wrong location.

Changed to pass a single string with the path quoted so it works with spaces.