### PR TITLE
fix: suggest unshadowed help option name in UsageError hint

### DIFF
--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -78,8 +78,15 @@ class UsageError(ClickException):
             self.ctx is not None
             and self.ctx.command.get_help_option(self.ctx) is not None
         ):
+            # Use the first configured help option name that hasn't been
+            # shadowed by another parameter on this command. For example,
+            # if "-h" is used by a subcommand option, fall back to "--help".
+            _available = set(self.ctx.command.get_help_option_names(self.ctx))
+            _hint_option = next(
+                name for name in self.ctx.help_option_names if name in _available
+            )
             hint = _("Try '{command} {option}' for help.").format(
-                command=self.ctx.command_path, option=self.ctx.help_option_names[0]
+                command=self.ctx.command_path, option=_hint_option
             )
             hint = f"{hint}\n"
         if self.ctx is not None:


### PR DESCRIPTION
## Problem

When a subcommand defines an option that shadows the first configured help option name, `UsageError.show()` still suggests the shadowed name in its hint. Running the suggestion then fails with a confusing error.

**Example setup:**
```python
@click.group(context_settings={"help_option_names": ["-h", "--help"]})
def cli(): pass

@click.command()
@click.argument("required_arg")
@click.option("--host", "-h", default="localhost")
def foo(required_arg, host): ...

cli.add_command(foo)
```

**Before this fix:**
```
$ cli foo
Usage: cli foo [OPTIONS] REQUIRED_ARG
Try 'cli foo -h' for help.        ← -h is shadowed by --host!

Error: Missing argument 'REQUIRED_ARG'.

$ cli foo -h
Error: Option '-h' requires an argument.   ← confusing dead end
```

**After this fix:**
```
$ cli foo
Usage: cli foo [OPTIONS] REQUIRED_ARG
Try 'cli foo --help' for help.    ← correctly falls back to --help

Error: Missing argument 'REQUIRED_ARG'.
```

Closes #2790

## Solution

`Command.get_help_option_names(ctx)` already filters out option names shadowed by other parameters on the command (introduced in 8.1.8). `UsageError.show()` was not using this method — it was reading `ctx.help_option_names[0]` directly.

The fix iterates `ctx.help_option_names` in the user-defined order and selects the first name that `get_help_option_names()` reports as unshadowed:

```python
_available = set(self.ctx.command.get_help_option_names(self.ctx))
_hint_option = next(
    name for name in self.ctx.help_option_names if name in _available
)
```

Since `get_help_option(ctx)` is already confirmed non-None at this point, at least one name is guaranteed to be available.