### PR TITLE
Fix error message for unrecognised multi-char short options

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -482,7 +482,7 @@ class _OptionParser:
         # like "-foo" to be matched as long options.
         try:
             self._match_long_opt(norm_long_opt, explicit_value, state)
-        except NoSuchOption:
+        except NoSuchOption as long_opt_exc:
             # At this point the long option matching failed, and we need
             # to try with short options.  However there is a special rule
             # which says, that if we have a two character options prefix
@@ -490,7 +490,16 @@ class _OptionParser:
             # short option code and will instead raise the no option
             # error.
             if arg[:2] not in self._opt_prefixes:
-                self._match_short_opt(arg, state)
+                try:
+                    self._match_short_opt(arg, state)
+                except NoSuchOption as short_opt_exc:
+                    # If the error is about the first character, no valid
+                    # single-char options were found. Re-raise the long
+                    # option error, which has better context for
+                    # multi-character short options (e.g. ``-dbg``).
+                    if short_opt_exc.option_name == f"{arg[0]}{arg[1]}":
+                        raise long_opt_exc from None
+                    raise
                 return
 
             if not self.ignore_unknown_options:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,23 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option: {unknown_flag}" in result.output
 
 
+def test_multichar_short_option_wrong_value_error(runner):
+    """Multi-character short options like ``-dbg`` are stored as long
+    options internally. When an unrecognised option like ``-dbgwrong`` is
+    passed, the error should name the full argument, not just its first
+    character (``-d``)."""
+
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        pass
+
+    result = runner.invoke(cli, ["-dbgwrong"])
+    assert result.exception
+    assert "No such option: -dbgwrong" in result.output
+    assert "Did you mean -dbg?" in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Problem

When using multi-character short options like `-dbg` (which Click supports but doesn't document), passing an unrecognised argument such as `-dbgwrong` produces a misleading error:

```
No such option: -d
```

instead of the expected:

```
No such option: -dbgwrong
Did you mean -dbg?
```

This happens because multi-character short options are stored internally as long options. When `_match_long_opt` fails, the parser falls back to `_match_short_opt`, which iterates character-by-character and reports only the first character (`-d`) in the error.

Reported in #2779.

## Fix

In `_process_opts`, catch the `NoSuchOption` from `_match_short_opt`. If the error refers to the very first character (meaning no valid single-char options were consumed at all), re-raise the original long-option error instead — it contains the full argument name and the "Did you mean …?" suggestion.

## Test

Added `test_multichar_short_option_wrong_value_error` which registers `-dbg` as a flag, invokes the CLI with `-dbgwrong`, and asserts that the error names `-dbgwrong` and suggests `-dbg`.

All existing tests pass.