### PR TITLE
fix: reject NaN values in FloatRange

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -648,6 +648,22 @@ class FloatRange(_NumberRangeBase, FloatParamType):
         if (min_open or max_open) and clamp:
             raise TypeError("Clamping is not supported for open bounds.")
 
+    def convert(
+        self, value: t.Any, param: Parameter | None, ctx: Context | None
+    ) -> t.Any:
+        import math
+
+        rv = super().convert(value, param, ctx)
+
+        if math.isnan(rv):
+            self.fail(
+                _("{value} is not a valid number.").format(value=rv),
+                param,
+                ctx,
+            )
+
+        return rv
+
     def _clamp(self, bound: float, dir: t.Literal[1, -1], open: bool) -> float:
         if not open:
             return bound

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -51,6 +51,24 @@ def test_range_fail(type, value, expect):
     assert expect in exc_info.value.message
 
 
+@pytest.mark.parametrize(
+    ("type",),
+    [
+        (click.FloatRange(0.0, 1.0),),
+        (click.FloatRange(0.5, 1.5),),
+        (click.FloatRange(max=1.5),),
+        (click.FloatRange(),),
+        (click.FloatRange(0.0, 1.0, clamp=True),),
+        (click.FloatRange(0.0, 1.0, min_open=True),),
+    ],
+)
+def test_float_range_rejects_nan(type):
+    """FloatRange should reject NaN values since NaN is not a valid number
+    and NaN comparisons are always False, bypassing range checks."""
+    with pytest.raises(click.BadParameter, match="not a valid number"):
+        type.convert("nan", None, None)
+
+
 def test_float_range_no_clamp_open():
     with pytest.raises(TypeError):
         click.FloatRange(0, 1, max_open=True, clamp=True)


### PR DESCRIPTION
Fixes #3347

`FloatRange` currently accepts NaN because NaN comparisons (`NaN < min`, `NaN > max`) always return `False`, causing the range check to pass. This bypasses validation entirely, including `clamp=True` mode.

The fix adds a `math.isnan` check in `FloatRange.convert` before returning the value. NaN is not a valid number for any range, so it should always be rejected.

**Change summary:**
- Override `convert` in `FloatRange` to check for NaN after calling `super().convert()`
- Fail with "nan is not a valid number" if detected
- 6 new test cases covering bounded, unbounded, clamped, and open-bound FloatRange configurations

All 1391 tests pass.