### PR TITLE
Skip default evaluation and callbacks during resilient parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Version 8.3.3
 
 Unreleased
 
+-   Skip evaluation of parameter defaults and invocation of parameter callbacks
+    when :attr:`Context.resilient_parsing` is ``True``, such as during shell
+    completion. This matches the behavior documented for ``resilient_parsing``
+    and avoids side effects from expensive ``default=`` callables and ``callback``
+    functions while completing. :issue:`2614`
 -   Use :func:`shlex.split` to split pager and editor commands into ``argv``
     lists for :class:`subprocess.Popen`, removing ``shell=True``.
     :issue:`1026` :pr:`1477` :pr:`2775`

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2357,7 +2357,15 @@ class Parameter:
                 source = ParameterSource.DEFAULT_MAP
 
         if value is UNSET:
-            default_value = self.get_default(ctx)
+            # During resilient parsing (e.g. shell completion), skip evaluating
+            # the parameter's default. Calling a ``default`` callable could have
+            # unwanted side effects, and the documentation for
+            # :attr:`Context.resilient_parsing` states that default values are
+            # ignored in this mode.
+            if ctx.resilient_parsing:
+                default_value = UNSET
+            else:
+                default_value = self.get_default(ctx)
             if default_value is not UNSET:
                 value = default_value
                 source = ParameterSource.DEFAULT
@@ -2465,7 +2473,11 @@ class Parameter:
         if self.required and self.value_is_missing(value):
             raise MissingParameter(ctx=ctx, param=self)
 
-        if self.callback is not None:
+        # During resilient parsing (e.g. shell completion), skip invoking the
+        # parameter's callback. The documentation for
+        # :attr:`Context.resilient_parsing` states that parsing happens without
+        # any interactivity or callback invocation.
+        if self.callback is not None and not ctx.resilient_parsing:
             # Legacy case: UNSET is not exposed directly to the callback, but converted
             # to None.
             if value is UNSET:
@@ -3365,7 +3377,10 @@ class Option(Parameter):
         if self.is_flag and not self.required and self.is_bool_flag and value is UNSET:
             value = False
 
-            if self.callback is not None:
+            # Skip callback invocation during resilient parsing (e.g. shell
+            # completion) to match the documented behavior of
+            # :attr:`Context.resilient_parsing`.
+            if self.callback is not None and not ctx.resilient_parsing:
                 value = self.callback(ctx, self, value)
 
             return value

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -559,3 +559,50 @@ def test_files_closed(runner) -> None:
             assert not current_warnings, "There should be no warnings to start"
             _get_completions(cli, args=[], incomplete="")
             assert not current_warnings, "There should be no warnings after either"
+
+
+def test_default_callable_not_called_during_completion():
+    """A callable passed as ``default=`` must not be invoked while shell
+    completion is running, because ``resilient_parsing`` is set and the
+    documentation states that default values are ignored in that mode.
+    """
+    calls = []
+
+    def expensive_default():
+        calls.append("default")
+        return "value"
+
+    cli = Command("cli", params=[Option(["--foo"], default=expensive_default)])
+    _get_completions(cli, [], "-")
+    assert calls == []
+
+
+def test_callback_not_called_during_completion():
+    """A parameter ``callback`` must not fire while shell completion is
+    running, per the documented behavior of ``resilient_parsing``.
+    """
+    calls = []
+
+    def cb(ctx, param, value):
+        calls.append(value)
+        return value
+
+    cli = Command("cli", params=[Option(["--foo"], default="x", callback=cb)])
+    _get_completions(cli, [], "-")
+    assert calls == []
+
+
+def test_bool_flag_callback_not_called_during_completion():
+    """Boolean flag ``callback`` must not fire during shell completion."""
+    calls = []
+
+    def cb(ctx, param, value):
+        calls.append(value)
+        return value
+
+    cli = Command(
+        "cli",
+        params=[Option(["--flag/--no-flag"], default=False, callback=cb)],
+    )
+    _get_completions(cli, [], "-")
+    assert calls == []


### PR DESCRIPTION
During shell completion, ``Context.resilient_parsing`` is set to ``True``.
Its documentation states:

> if this flag is enabled then Click will parse without any interactivity
> or callback invocation. Default values will also be ignored.

However, ``Parameter.consume_value`` still evaluated a ``default=`` callable
and ``Parameter.process_value`` still invoked the parameter's ``callback``
while completion was running. This produced unwanted side effects during
tab-completion for callers that pass an expensive callable as ``default``
or attach a ``callback`` with side effects.

Now both paths check ``ctx.resilient_parsing`` and skip the default/callback,
matching the documented behavior. The ``_resolve_context`` docstring in
``shell_completion.py`` already said "it doesn't trigger input prompts or
callbacks" - this brings the implementation in line.

fixes #2614

### Changes

- ``Parameter.consume_value``: skip ``self.get_default(ctx)`` when
  ``ctx.resilient_parsing`` is ``True``.
- ``Parameter.process_value``: skip ``self.callback`` invocation when
  ``ctx.resilient_parsing`` is ``True``.
- ``Option.process_value``: same skip for the bool-flag early-return
  branch.
- Three tests in ``tests/test_shell_completion.py`` covering ``default=``
  callables, parameter ``callback``, and bool flag ``callback``.
- ``CHANGES.rst`` entry added under Unreleased.