### PR TITLE
Fix duplicated word in UNPROCESSED docstring

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1177,7 +1177,7 @@ def convert_type(ty: t.Any | None, default: t.Any | None = None) -> ParamType:
 #:
 #: For path related uses the :class:`Path` type is a better choice but
 #: there are situations where an unprocessed type is useful which is why
-#: it is is provided.
+#: it is provided.
 #:
 #: .. versionadded:: 4.0
 UNPROCESSED = UnprocessedParamType()


### PR DESCRIPTION

**Repo:** pallets/click (⭐ 16000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Remove a duplicated `is` in the Sphinx doc comment attached to the
`UNPROCESSED` parameter type in `src/click/types.py`. The comment read
"it is is provided" and now reads "it is provided".

## Why
The stray duplicated word shows up verbatim in the rendered API docs
for `click.UNPROCESSED`, so it is a small but user-visible typo in
public documentation. A grep across `src/`, `docs/`, and `tests/` for
common duplicated-word patterns surfaced this as the only hit.

## Testing
No behavior change. The edit only touches a `#:` doc comment used by
Sphinx autodoc. Verified by diff inspection and by re-running the
repeated-word grep, which no longer matches.

## Risk
Low — comment-only change, no code paths touched.
