### PR TITLE
Resolve inferred distribution names in version_option

### DIFF
--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -434,8 +434,9 @@ def version_option(
     ``package_name``.
 
     If ``package_name`` is not provided, Click will try to detect it by
-    inspecting the stack frames. This will be used to detect the
-    version, so it must match the name of the installed package.
+    inspecting the stack frames. If the top-level import package name
+    differs from the installed distribution name, Click will fall back
+    to :func:`importlib.metadata.packages_distributions` when possible.
 
     :param version: The version number to show. If not provided, Click
         will try to detect it.
@@ -464,7 +465,9 @@ def version_option(
     if message is None:
         message = _("%(prog)s, version %(version)s")
 
-    if version is None and package_name is None:
+    inferred_package_name = version is None and package_name is None
+
+    if inferred_package_name:
         frame = inspect.currentframe()
         f_back = frame.f_back if frame is not None else None
         f_globals = f_back.f_globals if f_back is not None else None
@@ -487,6 +490,7 @@ def version_option(
 
         nonlocal prog_name
         nonlocal version
+        nonlocal package_name
 
         if prog_name is None:
             prog_name = ctx.find_root().info_name
@@ -497,10 +501,26 @@ def version_option(
             try:
                 version = importlib.metadata.version(package_name)
             except importlib.metadata.PackageNotFoundError:
-                raise RuntimeError(
-                    f"{package_name!r} is not installed. Try passing"
-                    " 'package_name' instead."
-                ) from None
+                if inferred_package_name:
+                    distribution_names = (
+                        importlib.metadata.packages_distributions().get(
+                            package_name, ()
+                        )
+                    )
+
+                    if len(distribution_names) == 1:
+                        package_name = distribution_names[0]
+
+                        try:
+                            version = importlib.metadata.version(package_name)
+                        except importlib.metadata.PackageNotFoundError:
+                            pass
+
+                if version is None:
+                    raise RuntimeError(
+                        f"{package_name!r} is not installed. Try passing"
+                        " 'package_name' instead."
+                    ) from None
 
         if version is None:
             raise RuntimeError(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -90,6 +90,47 @@ def test_deprecated_prompt(runner):
         click.Option(["--a"], prompt=True, deprecated=True)
 
 
+def test_version_option_uses_distribution_name(runner, monkeypatch):
+    import importlib.metadata
+    import types
+
+    import click.decorators as decorators
+
+    looked_up_names = []
+
+    class FakeFrame:
+        f_back = types.SimpleNamespace(
+            f_globals={"__name__": "mim.cli", "__package__": "mim"}
+        )
+
+    def fake_version(name: str) -> str:
+        looked_up_names.append(name)
+
+        if name == "mim":
+            raise importlib.metadata.PackageNotFoundError(name)
+
+        assert name == "openmim"
+        return "1.2.3"
+
+    monkeypatch.setattr(decorators.inspect, "currentframe", lambda: FakeFrame())
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "packages_distributions",
+        lambda: {"mim": ["openmim"]},
+    )
+
+    @click.command()
+    @click.version_option()
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert result.output == "cli, version 1.2.3\n"
+    assert looked_up_names == ["mim", "openmim"]
+
+
 def test_invalid_nargs(runner):
     with pytest.raises(TypeError, match="nargs=-1 is not supported for options."):
 


### PR DESCRIPTION
## Summary
- fall back from the inferred top-level import package name to its installed distribution name when resolving `version_option()` automatically
- keep the existing explicit `package_name=` behavior unchanged
- add a regression test covering a module name that differs from its distribution name

## Root cause
`version_option()` infers a package name from the calling module and passes it directly to `importlib.metadata.version()`. That works when the import package name and distribution name match, but it fails for packages where they differ, such as `mim` and `openmim`.

## Testing
- `$env:PYTHONPATH='src'; python -m pytest tests/test_options.py -k version_option_uses_distribution_name -vv`
- `$env:PYTHONPATH='src'; python -m pytest tests/test_options.py -vv`

Fixes #2331.
