### PR TITLE
fix: keep write_usage output for commands without args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: click
 
+Version 8.3.3
+--------------
+
+-   Fix ``HelpFormatter.write_usage()`` dropping the usage line when called
+    without any arguments. :issue:`3360`
+
 Version 8.3.2
 --------------
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -155,7 +155,14 @@ class HelpFormatter:
         if prefix is None:
             prefix = f"{_('Usage:')} "
 
-        usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
+        usage_prefix = f"{prefix:>{self.current_indent}}{prog}"
+
+        if not args:
+            self.write(usage_prefix)
+            self.write("\n")
+            return
+
+        usage_prefix = f"{usage_prefix} "
         text_width = self.width - self.current_indent
 
         if text_width >= (term_len(usage_prefix) + 20):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -366,3 +366,9 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_without_args():
+    formatter = click.formatting.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"


### PR DESCRIPTION
Fixes #3360

`HelpFormatter.write_usage()` routed empty `args` through the text wrapper, which produced an empty line and dropped the usage prefix entirely. Handle the no-args case directly so `Usage: <prog>` still renders for internal commands that take no arguments.

This adds a regression test for `HelpFormatter.write_usage("program")` and updates `CHANGES.rst`.

## Verification
- `PYTHONPATH=src .venv/bin/pytest tests/test_formatting.py -q`