### PR TITLE
docs: clarify show_default boolean wording

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -125,7 +125,7 @@ To control the appearance of defaults pass `show_default`.
     invoke(dots, args=['--help'])
 ```
 
-For single option boolean flags, the default remains hidden if the default value is False, even if show default is set to true.
+For single option boolean flags, the default remains hidden if the default value is `False`, even if `show_default` is set to `True`.
 
 ```{eval-rst}
 .. click:example::


### PR DESCRIPTION
## Summary
- clarify the wording around boolean defaults in `docs/documentation.md`
- format `False`, `show_default`, and `True` as inline code for consistency with the surrounding docs

## Why
This sentence describes code-level values and an option name, so rendering them as inline code makes the guidance easier to scan and more consistent with the rest of the page.

## Testing
- docs-only change

AI-assisted: yes