### PR TITLE
fix: pass shell=True to subprocess.call on Windows for URL launching

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -707,7 +707,7 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
             args.append("")
             args.append(url)
         try:
-            return subprocess.call(args)
+            return subprocess.call(args, shell=True)
         except OSError:
             # Command not found
             return 127


### PR DESCRIPTION
On Windows, `start` is a shell built-in command (handled by cmd.exe), not a standalone executable. When `subprocess.call()` is invoked without `shell=True`, it cannot find the `start` command, causing URL opening to fail for non-local URLs (e.g. `click.launch("http://example.org")`).

This adds `shell=True` to the `subprocess.call()` call in the Windows branch of `open_url()`, which is consistent with how Windows shell built-ins must be invoked.

Fixes #3164