### PR TITLE
Fix #2614: skip callable defaults under resilient_parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,17 @@
 .. currentmodule:: click
 
+Version 8.3.3
+--------------
+
+Unreleased
+
+-   Skip invoking callable ``default`` values during resilient parsing,
+    which the ``Context.resilient_parsing`` docstring already documents
+    ("parse without any interactivity or callback invocation"). Restores
+    snappy tab-completion for commands that rely on expensive callable
+    defaults. :issue:`2614`
+
+
 Version 8.3.2
 --------------
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2332,7 +2332,16 @@ class Parameter:
                 source = ParameterSource.DEFAULT_MAP
 
         if value is UNSET:
-            default_value = self.get_default(ctx)
+            # Under resilient parsing (tab-completion, help rendering),
+            # honor the ``Context.resilient_parsing`` docstring's
+            # "parse without any interactivity or callback invocation"
+            # contract for callable defaults. Passing ``call=False``
+            # returns the callable uninvoked, which keeps completion
+            # snappy for commands that use expensive callable defaults.
+            # See #2614.
+            default_value = self.get_default(
+                ctx, call=not ctx.resilient_parsing
+            )
             if default_value is not UNSET:
                 value = default_value
                 source = ParameterSource.DEFAULT

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -780,3 +780,54 @@ def test_propagate_opt_prefixes():
     ctx = click.Context(click.Command("test2"), parent=parent)
 
     assert ctx._opt_prefixes == {"-", "--", "!"}
+
+
+def test_resilient_parsing_skips_callable_default():
+    """A callable ``default`` must not be invoked when
+    ``ctx.resilient_parsing`` is True. The public docstring on
+    :class:`Context.resilient_parsing` promises "Click will parse
+    without any interactivity or callback invocation" — this covers
+    the callable-default form of callback invocation. Regression test
+    for #2614.
+    """
+    call_count = {"n": 0}
+
+    def expensive_default():
+        call_count["n"] += 1
+        return "computed"
+
+    @click.command()
+    @click.option("--name", default=expensive_default)
+    def cli(name):
+        click.echo(name)
+
+    # Under resilient_parsing, the callable must not fire.
+    with click.Context(cli, resilient_parsing=True) as ctx:
+        cli.parse_args(ctx, [])
+    assert call_count["n"] == 0
+
+    # Sanity: the same command under normal parsing still invokes
+    # the callable exactly once (regression guard — the fix must not
+    # change non-resilient behaviour).
+    with click.Context(cli, resilient_parsing=False) as ctx:
+        cli.parse_args(ctx, [])
+    assert call_count["n"] == 1
+
+
+def test_resilient_parsing_preserves_non_callable_default():
+    """The fix scopes only the *invocation of callable defaults* —
+    non-callable defaults must still resolve normally under
+    ``resilient_parsing``. Keeps the fix's scope narrow and makes the
+    out-of-scope "ignore defaults entirely" interpretation a separate
+    future change rather than a silent side-effect of this one.
+    """
+
+    @click.command()
+    @click.option("--name", default="static")
+    def cli(name):
+        click.echo(name)
+
+    with click.Context(cli, resilient_parsing=True) as ctx:
+        cli.parse_args(ctx, [])
+        # Value is resolved into ctx.params.
+        assert ctx.params.get("name") == "static"

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -559,3 +559,28 @@ def test_files_closed(runner) -> None:
             assert not current_warnings, "There should be no warnings to start"
             _get_completions(cli, args=[], incomplete="")
             assert not current_warnings, "There should be no warnings after either"
+
+
+def test_callable_default_not_invoked_during_completion():
+    """Shell completion sets ``resilient_parsing=True`` internally.
+    A callable ``default`` on an unrelated option must not fire while
+    completing arguments — the performance bug reported in #2614.
+    """
+    call_count = {"n": 0}
+
+    def expensive_default():
+        call_count["n"] += 1
+        return "computed"
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--name"], default=expensive_default),
+            Option(["-t", "--test"]),
+        ],
+    )
+
+    # Walk the shell-completion path the same way other tests in this
+    # file do. The callable default on --name must not be invoked.
+    _get_words(cli, [], "-")
+    assert call_count["n"] == 0


### PR DESCRIPTION
The Context.resilient_parsing docstring promises "Click will parse without any interactivity or callback invocation. Default values will also be ignored." In practice, callable defaults were still invoked during resilient parsing — making tab-completion slow for commands that rely on expensive callable defaults.

Gate callable-default invocation on `not ctx.resilient_parsing` in Parameter.consume_value. The existing `call=False` codepath in Parameter.get_default already handles the uninvoked-callable case; this change routes resilient parsing through it.

Scope is deliberately narrow — only callable invocation is gated. Non-callable defaults still resolve normally under resilient parsing (tested). This leaves the broader "ignore defaults entirely" interpretation of the docstring to a future change, if wanted, so this fix lands without changing behavior for any code that depends on default presence in resilient mode.

Tests added:
- tests/test_context.py::test_resilient_parsing_skips_callable_default (fix + non-resilient regression guard)
- tests/test_context.py::test_resilient_parsing_preserves_non_callable_default (scope guard: static defaults still resolve)
- tests/test_shell_completion.py::test_callable_default_not_invoked_during_completion (end-to-end via ShellComplete)

No existing tests referenced resilient_parsing in the tests/ tree prior to this change, so no encoded behavior is contradicted. Full suite passes (1387 passed, 22 skipped, 1 xfailed).

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
