### PR TITLE
fix: show usage line when HelpFormatter.write_usage has no args

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -155,7 +155,14 @@ class HelpFormatter:
         if prefix is None:
             prefix = f"{_('Usage:')} "
 
-        usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
+        usage_prefix = f"{prefix:>{self.current_indent}}{prog}"
+
+        if not args:
+            self.write(usage_prefix)
+            self.write("\n")
+            return
+
+        usage_prefix = f"{usage_prefix} "
         text_width = self.width - self.current_indent
 
         if text_width >= (term_len(usage_prefix) + 20):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -366,3 +366,9 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_no_args():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"


### PR DESCRIPTION
## Summary
- fix `HelpFormatter.write_usage` to emit a usage line when `args` is empty
- preserve existing wrapping behavior when args are present
- add a regression test for `write_usage("program")`

## Verification
- `PYTHONPATH=src python -m pytest tests/test_formatting.py -k "write_usage_no_args or help_formatter_write_text"`
- `PYTHONPATH=src python -m pytest tests/test_formatting.py`

Fixes #3360