### PR TITLE
fix: handle empty args in HelpFormatter.write_usage

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,27 +158,31 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
-        if text_width >= (term_len(usage_prefix) + 20):
-            # The arguments will fit to the right of the prefix.
-            indent = " " * term_len(usage_prefix)
-            self.write(
-                wrap_text(
-                    args,
-                    text_width,
-                    initial_indent=usage_prefix,
-                    subsequent_indent=indent,
+        if args:
+            if text_width >= (term_len(usage_prefix) + 20):
+                # The arguments will fit to the right of the prefix.
+                indent = " " * term_len(usage_prefix)
+                self.write(
+                    wrap_text(
+                        args,
+                        text_width,
+                        initial_indent=usage_prefix,
+                        subsequent_indent=indent,
+                    )
                 )
-            )
+            else:
+                # The prefix is too long, put the arguments on the next line.
+                self.write(usage_prefix)
+                self.write("\n")
+                indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
+                self.write(
+                    wrap_text(
+                        args, text_width, initial_indent=indent, subsequent_indent=indent
+                    )
+                )
         else:
-            # The prefix is too long, put the arguments on the next line.
+            # No arguments provided, just write the usage prefix.
             self.write(usage_prefix)
-            self.write("\n")
-            indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
-            self.write(
-                wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
-                )
-            )
 
         self.write("\n")
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -366,3 +366,28 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_no_args():
+    """Test that write_usage outputs correctly when args is empty."""
+    # Regression test for https://github.com/pallets/click/issues/3360
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    actual = formatter.getvalue()
+    assert actual == "Usage: program \n"
+
+
+def test_help_formatter_write_usage_with_args():
+    """Test that write_usage works correctly with args provided."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program", "[OPTIONS] COMMAND [ARGS]...")
+    actual = formatter.getvalue()
+    assert actual == "Usage: program [OPTIONS] COMMAND [ARGS]...\n"
+
+
+def test_help_formatter_write_usage_custom_prefix():
+    """Test that write_usage respects custom prefix."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program", "[OPTIONS]", prefix="Usage: ")
+    actual = formatter.getvalue()
+    assert actual == "Usage: program [OPTIONS]\n"


### PR DESCRIPTION
## Summary

Fixes #3360 - Empty output from `HelpFormatter.write_usage` for a program without arguments.

When `HelpFormatter.write_usage()` is called with only a program name and no arguments, the output was empty (just a newline) instead of showing the expected usage line like `"Usage: program "`.

### Changes

- Modified `write_usage()` in `src/click/formatting.py` to handle the case when `args` is empty
- Added a condition to check if `args` is truthy before attempting to wrap the arguments text
- When `args` is empty, just writes the usage prefix directly
- Added three regression tests in `tests/test_formatting.py` to verify the fix

### Root Cause

The issue was that `wrap_text("", ...)` returns an empty string, so nothing was written when `args` was empty. The code was trying to wrap an empty string and getting nothing as a result.

### Test Plan

- [x] Run `pytest tests/test_formatting.py -v` - all tests pass
- [x] Run `pytest tests/` - all 1387 tests pass
- [x] Manual verification with reproduction script from issue

```python
import click

f = click.HelpFormatter()
f.write_usage("program")
print(f.getvalue())
# Expected: "Usage: program \n"
# Before fix: "\n"
# After fix: "Usage: program \n"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)