### PR TITLE
fix: write empty args in usage line without trailing space

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -161,26 +161,30 @@ class HelpFormatter:
         if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)
-            self.write(
-                wrap_text(
-                    args,
-                    text_width,
-                    initial_indent=usage_prefix,
-                    subsequent_indent=indent,
+            if args:
+                self.write(
+                    wrap_text(
+                        args,
+                        text_width,
+                        initial_indent=usage_prefix,
+                        subsequent_indent=indent,
+                    )
                 )
-            )
+            else:
+                self.write(usage_prefix)
+            self.write("\n")
         else:
             # The prefix is too long, put the arguments on the next line.
             self.write(usage_prefix)
             self.write("\n")
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
-            self.write(
-                wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+            if args:
+                self.write(
+                    wrap_text(
+                        args, text_width, initial_indent=indent, subsequent_indent=indent
+                    )
                 )
-            )
-
-        self.write("\n")
+            self.write("\n")
 
     def write_heading(self, heading: str) -> None:
         """Writes a heading into the buffer."""


### PR DESCRIPTION
## Fixes pallets/click#3360

When `HelpFormatter.write_usage()` is called with no args (empty string), it was passing the empty `args` string to `wrap_text()` which, with a non-empty `initial_indent` (the usage prefix like `'Usage: program '`), returns just `' \n'` — a line with a leading space followed by newline.

**Before:** `write_usage('program', '')` → `'Usage: program \n'` (trailing space before newline)

**After:** `write_usage('program', '')` → `'Usage: program\n'`

### Root cause
`wrap_text('', initial_indent='Usage: program ')` evaluates the empty string as whitespace-only and returns `' \n'`.

### Fix
When `args` is empty, write the `usage_prefix` directly (without calling `wrap_text`), then the newline.

I used AI assistance to develop this PR.