### PR TITLE
Fix empty HelpFormatter.write_usage output without args

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -156,6 +156,12 @@ class HelpFormatter:
             prefix = f"{_('Usage:')} "
 
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
+
+        if not args:
+            self.write(usage_prefix.rstrip())
+            self.write("\n")
+            return
+
         text_width = self.width - self.current_indent
 
         if text_width >= (term_len(usage_prefix) + 20):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -230,6 +230,12 @@ def test_formatting_usage_error_no_help(runner):
     ]
 
 
+def test_write_usage_without_args():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"
+
+
 def test_formatting_usage_custom_help(runner):
     @click.command(context_settings=dict(help_option_names=["--man"]))
     @click.argument("arg")


### PR DESCRIPTION
## Summary
- preserve the usage line when `HelpFormatter.write_usage()` is called without arguments
- avoid emitting an empty wrapped line for the no-args case
- add a regression test covering `formatter.write_usage("program")`

Closes #3360.

## Validation
- reproduced with `python -c` against `src/` before the change (`repr(f.getvalue()) == "\n"`)
- `uv run pytest tests/test_formatting.py`