### PR TITLE
feat: add timer context manager and time_it decorator

### DIFF
--- a/examples/time_it_demo.py
+++ b/examples/time_it_demo.py
@@ -1,0 +1,178 @@
+import time
+
+import click
+
+
+def demo_writing_a():
+    """写法 A：直接装饰命令函数
+
+    @click.command()
+    @click.time_it
+    def cmd1(): pass
+    """
+    @click.command()
+    @click.time_it
+    def cmd1():
+        click.echo("Running cmd1...")
+        time.sleep(0.05)
+        click.echo("cmd1 finished.")
+
+    click.echo("\n" + "=" * 50)
+    click.echo("写法 A：@click.command() 后接 @click.time_it")
+    click.echo("=" * 50)
+    from click.testing import CliRunner
+    runner = CliRunner()
+    result = runner.invoke(cmd1, [])
+    click.echo(result.output, nl=False)
+    if result.exception:
+        import traceback
+        traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+    return result.exit_code == 0
+
+
+def demo_writing_b():
+    """写法 B：带参数装饰命令函数
+
+    @click.command()
+    @click.time_it(name="custom")
+    def cmd2(): pass
+    """
+    @click.command()
+    @click.time_it(name="custom_timer")
+    def cmd2():
+        click.echo("Running cmd2...")
+        time.sleep(0.05)
+        click.echo("cmd2 finished.")
+
+    click.echo("\n" + "=" * 50)
+    click.echo("写法 B：@click.time_it(name=\"custom\")")
+    click.echo("=" * 50)
+    from click.testing import CliRunner
+    runner = CliRunner()
+    result = runner.invoke(cmd2, [])
+    click.echo(result.output, nl=False)
+    if result.exception:
+        import traceback
+        traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+    return result.exit_code == 0
+
+
+def demo_writing_c():
+    """写法 C：装饰已有 Command 对象
+
+    @click.time_it
+    @click.command()
+    def cmd3(): pass
+
+    注意：装饰器从下往上执行，所以 @click.command() 先执行，
+    创建 Command 对象，然后 @click.time_it 装饰这个 Command 对象。
+    """
+    @click.time_it
+    @click.command()
+    def cmd3():
+        click.echo("Running cmd3...")
+        time.sleep(0.05)
+        click.echo("cmd3 finished.")
+
+    click.echo("\n" + "=" * 50)
+    click.echo("写法 C：@click.time_it 后接 @click.command()")
+    click.echo("=" * 50)
+    from click.testing import CliRunner
+    runner = CliRunner()
+    result = runner.invoke(cmd3, [])
+    click.echo(result.output, nl=False)
+    if result.exception:
+        import traceback
+        traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+    return result.exit_code == 0
+
+
+def demo_timer_context_manager():
+    """演示 click.timer 上下文管理器的使用"""
+    click.echo("\n" + "=" * 50)
+    click.echo("演示 click.timer 上下文管理器")
+    click.echo("=" * 50)
+
+    click.echo("\n--- 演示 1: 基础 timer ---")
+    with click.timer():
+        time.sleep(0.05)
+
+    click.echo("\n--- 演示 2: 带名称的 timer ---")
+    with click.timer(name="my operation"):
+        time.sleep(0.05)
+
+    click.echo("\n--- 演示 3: 获取 elapsed 时间 ---")
+    with click.timer() as tm:
+        time.sleep(0.02)
+        click.echo(f"During: elapsed = {tm.elapsed:.4f}s")
+        time.sleep(0.02)
+    click.echo(f"After: elapsed = {tm.elapsed:.4f}s")
+
+    click.echo("\n--- 演示 4: 未 enter 时访问 elapsed 会抛出错误 ---")
+    tm = click.timer()
+    try:
+        _ = tm.elapsed
+    except RuntimeError as e:
+        click.echo(f"Expected error: {e}")
+
+
+@click.command()
+@click.option("--all", "-a", is_flag=True, help="Run all demos")
+@click.option("--a", "demo_a", is_flag=True, help="Run demo A")
+@click.option("--b", "demo_b", is_flag=True, help="Run demo B")
+@click.option("--c", "demo_c", is_flag=True, help="Run demo C")
+@click.option("--timer", is_flag=True, help="Run timer context manager demo")
+def cli(all, demo_a, demo_b, demo_c, timer):
+    """Demonstration of click.timer and click.time_it features.
+
+    This demo shows three ways to use @time_it decorator:
+
+    \b
+    写法 A：直接装饰命令函数
+        @click.command()
+        @click.time_it
+        def cmd1(): pass
+
+    \b
+    写法 B：带参数装饰命令函数
+        @click.command()
+        @click.time_it(name="custom")
+        def cmd2(): pass
+
+    \b
+    写法 C：装饰已有 Command 对象
+        @click.time_it
+        @click.command()
+        def cmd3(): pass
+    """
+    if not any([all, demo_a, demo_b, demo_c, timer]):
+        click.echo(cli.get_help(click.Context(cli)))
+        return
+
+    success = True
+
+    if all or demo_a:
+        if not demo_writing_a():
+            success = False
+
+    if all or demo_b:
+        if not demo_writing_b():
+            success = False
+
+    if all or demo_c:
+        if not demo_writing_c():
+            success = False
+
+    if all or timer:
+        demo_timer_context_manager()
+
+    click.echo("\n" + "=" * 50)
+    if success:
+        click.echo("所有演示执行成功！")
+    else:
+        click.echo("部分演示执行失败！")
+    click.echo("=" * 50)
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -25,6 +25,7 @@ from .decorators import option as option
 from .decorators import pass_context as pass_context
 from .decorators import pass_obj as pass_obj
 from .decorators import password_option as password_option
+from .decorators import time_it as time_it
 from .decorators import version_option as version_option
 from .exceptions import Abort as Abort
 from .exceptions import BadArgumentUsage as BadArgumentUsage
@@ -70,6 +71,7 @@ from .utils import get_app_dir as get_app_dir
 from .utils import get_binary_stream as get_binary_stream
 from .utils import get_text_stream as get_text_stream
 from .utils import open_file as open_file
+from .utils import timer as timer
 
 
 def __getattr__(name: str) -> object:

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -13,6 +13,7 @@ from .core import Option
 from .core import Parameter
 from .globals import get_current_context
 from .utils import echo
+from .utils import timer
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
@@ -549,3 +550,99 @@ def help_option(*param_decls: str, **kwargs: t.Any) -> t.Callable[[FC], FC]:
     kwargs.setdefault("callback", show_help)
 
     return option(*param_decls, **kwargs)
+
+
+@t.overload
+def time_it(f: FC) -> FC: ...
+
+
+@t.overload
+def time_it(
+    name_or_func: str | None = None,
+    *,
+    name: str | None = None,
+    file: t.IO[t.Any] | None = None,
+    nl: bool = True,
+    color: bool | None = None,
+) -> t.Callable[[FC], FC]: ...
+
+
+def time_it(
+    name_or_func: str | FC | None = None,
+    *,
+    name: str | None = None,
+    file: t.IO[t.Any] | None = None,
+    nl: bool = True,
+    color: bool | None = None,
+) -> FC | t.Callable[[FC], FC]:
+    """Decorator that measures and prints the execution time of a command or function.
+
+    This decorator wraps the decorated function or command and measures the
+    elapsed time when it is executed. The result is printed using Click's
+    :func:`~click.echo` function.
+
+    Example usage::
+
+        @click.command()
+        @click.time_it
+        def my_command():
+            # code to measure
+            pass
+
+        @click.command()
+        @click.time_it("Long operation")
+        def another_command():
+            # code to measure
+            pass
+
+        @click.command()
+        @click.time_it(name="Custom", file=sys.stderr)
+        def yet_another():
+            # code to measure, output to stderr
+            pass
+
+    :param name_or_func: Either a function to decorate, or a name for the timer.
+        This parameter exists for backwards compatibility. Prefer the ``name``
+        keyword argument when not decorating directly.
+    :param name: The name for the timer. If provided, takes precedence over
+        ``name_or_func``.
+    :param file: The file to write the output to. Defaults to stdout.
+    :param nl: Whether to print a newline after the message.
+    :param color: Whether to use ANSI colors for the output.
+    """
+    func: FC | None = None
+    final_name: str | None = None
+
+    if callable(name_or_func):
+        func = t.cast(FC, name_or_func)
+    else:
+        final_name = t.cast(str | None, name_or_func)
+
+    if name is not None:
+        final_name = name
+
+    def decorator(f: FC) -> FC:
+        if isinstance(f, Command):
+            original_invoke = f.invoke
+
+            def timed_invoke(ctx: Context) -> t.Any:
+                nonlocal final_name
+                timer_name = final_name if final_name is not None else ctx.info_name
+                with timer(timer_name, file=file, nl=nl, color=color):
+                    return original_invoke(ctx)
+
+            f.invoke = timed_invoke
+            return f
+        else:
+            def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+                nonlocal final_name
+                timer_name = final_name if final_name is not None else f.__name__
+                with timer(timer_name, file=file, nl=nl, color=color):
+                    return f(*args, **kwargs)
+
+            return t.cast(FC, update_wrapper(wrapper, f))
+
+    if func is not None:
+        return decorator(func)
+
+    return decorator

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -4,7 +4,9 @@ import collections.abc as cabc
 import os
 import re
 import sys
+import time
 import typing as t
+from contextlib import AbstractContextManager
 from functools import update_wrapper
 from types import ModuleType
 from types import TracebackType
@@ -628,3 +630,103 @@ def _expand_args(
             out.extend(matches)
 
     return out
+
+
+class timer(AbstractContextManager["timer"]):
+    """A context manager for measuring execution time of code blocks.
+
+    This context manager measures the elapsed time of code executed within
+    its context and optionally prints a formatted message with the result.
+
+    Example usage::
+
+        from click import timer
+
+        with timer():
+            # code to measure
+            ...
+
+        with timer("Operation") as t:
+            # code to measure
+            ...
+        print(f"Elapsed: {t.elapsed} seconds")
+
+    :param name: Optional name for the operation being timed.
+    :param file: The file to write the output to. Defaults to stdout.
+    :param nl: Whether to print a newline after the message.
+    :param color: Whether to use ANSI colors for the output.
+    """
+
+    def __init__(
+        self,
+        name: str | None = None,
+        file: t.IO[t.Any] | None = None,
+        nl: bool = True,
+        color: bool | None = None,
+    ) -> None:
+        self.name = name
+        self.file = file
+        self.nl = nl
+        self.color = color
+        self.start_time: float | None = None
+        self.end_time: float | None = None
+
+    def __enter__(self) -> "timer":
+        self.start_time = time.perf_counter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.end_time = time.perf_counter()
+        if self.start_time is not None:
+            self._print_result()
+
+    @property
+    def elapsed(self) -> float:
+        """The elapsed time in seconds.
+
+        :raises RuntimeError: if the timer has not been started (not entered
+            in a with block).
+        """
+        if self.start_time is None:
+            raise RuntimeError("timer has not been started")
+        end = self.end_time if self.end_time is not None else time.perf_counter()
+        return end - self.start_time
+
+    def _format_time(self, seconds: float) -> str:
+        """Format the elapsed time in a human-readable way.
+
+        - < 1ms: format as microseconds
+        - 1ms - 1s: format as milliseconds
+        - 1s - 60s: format as seconds with 3 decimal places
+        - >= 60s: format as minutes and seconds
+        """
+        if seconds < 0.001:
+            return f"{seconds * 1_000_000:.2f} us"
+        elif seconds < 1.0:
+            return f"{seconds * 1_000:.2f} ms"
+        elif seconds < 60.0:
+            return f"{seconds:.3f} s"
+        else:
+            minutes = int(seconds // 60)
+            seconds_remainder = seconds % 60
+            return f"{minutes}m {seconds_remainder:.3f}s"
+
+    def _print_result(self) -> None:
+        """Print the formatted result to the specified file."""
+        if self.start_time is None or self.end_time is None:
+            return
+
+        elapsed = self.end_time - self.start_time
+        formatted = self._format_time(elapsed)
+
+        if self.name:
+            message = f"'{self.name}' finished in {formatted}"
+        else:
+            message = f"Finished in {formatted}"
+
+        echo(message, file=self.file, nl=self.nl, color=self.color)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -573,3 +573,144 @@ def test_abort_exceptions_with_disabled_standalone_mode(runner, exc):
     assert rv.exit_code == 1
     assert isinstance(rv.exception.__cause__, exc)
     assert rv.exception.__cause__.args == ("catch me!",)
+
+
+class TestTimer:
+    """Tests for the timer context manager."""
+
+    def test_timer_measures_elapsed_time(self):
+        import time
+
+        with click.timer() as t:
+            time.sleep(0.05)
+
+        assert t.elapsed >= 0.05
+        assert t.start_time is not None
+        assert t.end_time is not None
+
+    def test_timer_with_name_outputs_message(self, capsys):
+        tm = click.timer(name="test operation")
+        tm.__enter__()
+        tm.__exit__(None, None, None)
+
+        captured = capsys.readouterr()
+        assert "'test operation' finished in" in captured.out
+
+    def test_timer_format_time(self):
+        tm = click.timer()
+
+        assert "us" in tm._format_time(0.0005)
+        assert "ms" in tm._format_time(0.5)
+        assert "s" in tm._format_time(5.0)
+        assert "m" in tm._format_time(65.5)
+
+    def test_timer_elapsed_during_execution(self):
+        import time
+
+        with click.timer() as tm:
+            time.sleep(0.01)
+            elapsed_during = tm.elapsed
+            time.sleep(0.01)
+
+        assert elapsed_during >= 0.01
+        assert tm.elapsed >= 0.02
+
+    def test_timer_not_entered(self):
+        tm = click.timer()
+        assert tm.start_time is None
+        assert tm.end_time is None
+        with pytest.raises(RuntimeError, match="timer has not been started"):
+            _ = tm.elapsed
+
+
+class TestTimeItDecorator:
+    """Tests for the time_it decorator."""
+
+    def test_time_it_on_command(self, runner):
+        @click.command()
+        @click.time_it
+        def cli():
+            click.echo("done")
+
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "done" in result.output
+        assert "'cli' finished in" in result.output
+
+    def test_time_it_with_custom_name(self, runner):
+        @click.command()
+        @click.time_it("my custom name")
+        def cli():
+            click.echo("done")
+
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "'my custom name' finished in" in result.output
+
+    def test_time_it_with_keyword_arguments(self, runner):
+        @click.command()
+        @click.time_it(name="custom_name", nl=False)
+        def cli():
+            click.echo("done")
+
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "done" in result.output
+        assert "'custom_name' finished in" in result.output
+
+    def test_time_it_preserves_command_functionality(self, runner):
+        @click.command()
+        @click.option("--name", default="world")
+        @click.time_it
+        def cli(name):
+            click.echo(f"Hello, {name}!")
+
+        result = runner.invoke(cli, ["--name", "Alice"])
+        assert result.exit_code == 0
+        assert "Hello, Alice!" in result.output
+        assert "'cli' finished in" in result.output
+
+    def test_time_it_on_regular_function(self):
+        @click.time_it
+        def slow_function(x, y):
+            return x + y
+
+        result = slow_function(1, 2)
+        assert result == 3
+
+    def test_time_it_on_regular_function_with_name(self, capsys):
+        @click.time_it("my func")
+        def add(x, y):
+            return x + y
+
+        result = add(1, 2)
+        assert result == 3
+        captured = capsys.readouterr()
+        assert "'my func' finished in" in captured.out
+
+    def test_time_it_decorator_order_matters(self, runner):
+        @click.time_it
+        @click.command()
+        def cli():
+            click.echo("done")
+
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "done" in result.output
+        assert "'cli' finished in" in result.output
+
+    def test_time_it_with_group(self, runner):
+        @click.group()
+        @click.time_it
+        def cli():
+            click.echo("group")
+
+        @cli.command()
+        def sub():
+            click.echo("subcommand")
+
+        result = runner.invoke(cli, ["sub"])
+        assert result.exit_code == 0
+        assert "group" in result.output
+        assert "subcommand" in result.output
+        assert "'cli' finished in" in result.output


### PR DESCRIPTION
- Add `timer` context manager to `utils.py` for measuring elapsed time with formatted output (us/ms/s/min) and RuntimeError when accessed before entering context
- Add `time_it` decorator to `decorators.py` supporting both @time_it and @time_it(name=...) usage patterns on commands and regular functions
- Export timer and time_it from click.__init__
- Add 13 unit tests covering both features (all passing)
- Add examples/time_it_demo.py demonstrating all three decorator patterns and timer usage

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
