### PR TITLE
Fix HelpFormatter.write_usage with no args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,16 @@
 .. currentmodule:: click
 
+Version 8.3.4
+-------------
+
+Unreleased
+
+-   Fix :meth:`HelpFormatter.write_usage` to write the usage prefix when called
+    with no ``args``. Previously, an empty string was passed through
+    :func:`wrap_text`, which dropped the ``initial_indent`` and produced a
+    blank line. :issue:`3360`
+
+
 Version 8.3.3
 -------------
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,6 +158,13 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
+        if not args:
+            # Without args, ``wrap_text`` would drop the ``initial_indent``
+            # because the text is empty, so write the prefix directly.
+            self.write(usage_prefix.rstrip())
+            self.write("\n")
+            return
+
         if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -366,3 +366,22 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_no_args():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"
+
+
+def test_help_formatter_write_usage_no_args_custom_prefix():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program", prefix="Try: ")
+    assert formatter.getvalue() == "Try: program\n"
+
+
+def test_help_formatter_write_usage_no_args_indented():
+    formatter = click.HelpFormatter()
+    formatter.current_indent = 10
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "   Usage: program\n"


### PR DESCRIPTION
Closes #3360.

When `HelpFormatter.write_usage` is called without an `args` value, the resulting output is a single blank line instead of the expected `Usage: <prog>` line. This happens because `wrap_text("", initial_indent=usage_prefix, ...)` ends up calling `textwrap.TextWrapper.fill("")`, which returns `""` and discards `initial_indent`.

This short-circuits the empty-args path and writes the usage prefix directly. The trailing space added between `prog` and `args` is `rstrip`-ped before the newline so the output is exactly `Usage: <prog>
`.

### Reproducer (from #3360)

```python
import click
f = click.HelpFormatter()
f.write_usage("program")
print(f.getvalue())
```

- Before: empty line
- After: `Usage: program`

### Tests

Added three tests in `tests/test_formatting.py`:

- `test_help_formatter_write_usage_no_args` — default prefix.
- `test_help_formatter_write_usage_no_args_custom_prefix` — custom prefix preserved.
- `test_help_formatter_write_usage_no_args_indented` — indent applied via the `prefix:>{indent}` format spec is preserved (`rstrip` only strips trailing whitespace).

`pytest -x -q` passes (1389 passed, 73 skipped, 1 xfailed).