### PR TITLE
fix(#3360): Empty output from `HelpFormatter.write_usage` for a program without arguments

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -155,7 +155,13 @@ class HelpFormatter:
         if prefix is None:
             prefix = f"{_('Usage:')} "
 
-        usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
+        usage_prefix = f"{prefix:>{self.current_indent}}{prog}"
+        if not args:
+            self.write(usage_prefix)
+            self.write("\n")
+            return
+
+        usage_prefix = f"{usage_prefix} "
         text_width = self.width - self.current_indent
 
         if text_width >= (term_len(usage_prefix) + 20):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,6 +1,12 @@
 import click
 
 
+def test_write_usage_without_args():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"
+
+
 def test_basic_functionality(runner):
     @click.command()
     def cli():


### PR DESCRIPTION
## Summary

Fixes #3360 - _Empty output from `HelpFormatter.write_usage` for a program without arguments_

## Spec

When `click.HelpFormatter.write_usage()` is called without any `args`, it should still emit a usage line containing the program name instead of returning an empty line.

## Work Breakdown

- [x] Add a regression test covering `HelpFormatter.write_usage("program")` with no args.
- [x] Update `HelpFormatter.write_usage()` to emit the usage prefix even when `args` is empty.

## Notes

_None._

## Validation

- [x] `.venv\Scripts\python -m pytest tests/test_formatting.py -q`
