### PR TITLE
Avoid hyphen breaks in usage option tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: click
 
+Version 8.3.4
+-------------
+
+Unreleased
+
+-   Prevent ``HelpFormatter.write_usage`` from wrapping hyphenated option tokens
+    at internal hyphens when a full token can fit on the next line. :issue:`3362`
+
 Version 8.3.3
 -------------
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,10 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: allow wrapping to occur after hyphens.
+
+    .. versionchanged:: 8.3.4
+        Added the ``break_on_hyphens`` parameter.
     """
     from ._textwrap import TextWrapper
 
@@ -61,6 +66,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -167,6 +173,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -176,7 +183,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -84,6 +84,32 @@ def test_wrapping_long_options_strings(runner):
     ]
 
 
+def test_usage_does_not_wrap_hyphenated_options_inside_token():
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    formatter = click.HelpFormatter(width=65)
+
+    formatter.write_usage("program", " ".join(options))
+
+    assert formatter.getvalue().splitlines() == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location --user-auth-token",
+        "               --auto-update-interval --force-overwrite-existing",
+        "               --network-timeout-seconds --debug-trace-enabled",
+    ]
+
+
 def test_wrapping_long_command_name(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
Fixes #3362

This prevents `HelpFormatter.write_usage` from wrapping hyphenated option tokens at internal hyphens when the full token can fit on the next line. It also adds a regression test and changelog entry.

Tests:
- `PYTHONPATH=src python -m pytest -q tests/test_formatting.py`
- `python -m ruff check src/click/formatting.py tests/test_formatting.py`
- `PYTHONPATH=src python -m pytest -q`