### PR TITLE
fix: write_usage outputs usage line when args is empty

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,7 +158,9 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
-        if text_width >= (term_len(usage_prefix) + 20):
+        if not args:
+            self.write(usage_prefix.rstrip())
+        elif text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)
             self.write(

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -366,3 +366,24 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_write_usage_no_args():
+    """write_usage should output the usage line even when args is empty."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"
+
+
+def test_write_usage_with_args():
+    """write_usage should still work normally with arguments."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program", "FILE [OPTIONS]")
+    assert formatter.getvalue() == "Usage: program FILE [OPTIONS]\n"
+
+
+def test_write_usage_no_args_custom_prefix():
+    """write_usage with a custom prefix and no args."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program", prefix="Run: ")
+    assert formatter.getvalue() == "Run: program\n"


### PR DESCRIPTION
## Motivation

`HelpFormatter.write_usage("program")` with no `args` outputs an empty line instead of `Usage: program`. This affects CLI tools with commands that take no arguments (e.g. `exit`, `help`).

## The bug

`write_usage` passes `args=""` to `wrap_text()`, which returns `""` for empty input, dropping the `initial_indent` (which contains the usage prefix). The entire usage line vanishes.

## Fix

Handle the empty-args case before calling `wrap_text`: write `usage_prefix.rstrip()` directly. The `.rstrip()` removes the trailing space that is only needed to separate the prefix from arguments. All other behavior is unchanged.

## Tests

Added three tests in `tests/test_formatting.py`:
- `test_write_usage_no_args`: the bug case
- `test_write_usage_with_args`: regression check
- `test_write_usage_no_args_custom_prefix`: edge case with custom prefix

All 20 formatting tests pass.

Fixes #3360