### PR TITLE
Use a private duplicate of stdout/stderr fd in CliRunner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,19 @@
 .. currentmodule:: click
 
+Version 8.3.4
+-------------
+
+Unreleased
+
+-   ``CliRunner`` now exposes a private duplicate of the original ``stdout``
+    and ``stderr`` file descriptors via ``fileno()`` instead of the
+    descriptors themselves. Code under test that calls ``os.dup2`` over the
+    fd from ``sys.stdout.fileno()`` (e.g. logging tees, build tools,
+    subprocess wrappers) no longer overwrites the host process's real
+    ``stdout``/``stderr``, so outer harnesses such as ``pytest`` capture
+    keep working. :issue:`3384`
+
+
 Version 8.3.3
 -------------
 

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -107,11 +107,20 @@ class _NamedTextIOWrapper(io.TextIOWrapper):
     An optional ``original_fd`` preserves the file descriptor of the
     stream being replaced, so that C-level consumers that call
     :meth:`fileno` (``faulthandler``, ``subprocess``, ...) still work.
-    Inspired by pytest's ``capsys``/``capfd`` split: see :doc:`/testing`
-    for details.
+    Callers should pass a private duplicate (``os.dup``) of the
+    underlying fd: that way, code that performs ``os.dup2`` over the
+    value returned by :meth:`fileno` redirects only the duplicate and
+    does not clobber the surrounding process's stdout/stderr (e.g.
+    pytest's fd-based capture). Inspired by pytest's ``capsys`` /
+    ``capfd`` split: see :doc:`/testing` for details.
 
     .. versionchanged:: 8.3.3
         Added ``original_fd`` parameter and :meth:`fileno` override.
+
+    .. versionchanged:: 8.3.4
+        ``CliRunner`` now passes a private duplicate of the original
+        fd, so user code performing ``os.dup2`` on the returned value
+        no longer clobbers the host process's stdout/stderr.
     """
 
     def __init__(
@@ -360,14 +369,25 @@ class CliRunner:
         # valid fd from the redirected streams. The original streams
         # may themselves lack a fileno() (e.g. when CliRunner is used
         # inside pytest's capsys), so we fall back to -1.
-        def _safe_fileno(stream: t.IO[t.Any]) -> int:
+        #
+        # We expose a duplicate (``os.dup``) rather than the underlying
+        # fd directly. This is the same isolation pytest's ``capfd``
+        # uses: if the invoked command performs ``os.dup2`` over the fd
+        # returned by ``fileno()`` it only redirects our private copy,
+        # not the original (which an outer harness like pytest may be
+        # capturing). The duplicate is closed when isolation exits.
+        def _safe_dup_fileno(stream: t.IO[t.Any]) -> int:
             try:
-                return stream.fileno()
+                fd = stream.fileno()
             except (AttributeError, io.UnsupportedOperation):
                 return -1
+            try:
+                return os.dup(fd)
+            except OSError:
+                return -1
 
-        old_stdout_fd = _safe_fileno(old_stdout)
-        old_stderr_fd = _safe_fileno(old_stderr)
+        old_stdout_fd = _safe_dup_fileno(old_stdout)
+        old_stderr_fd = _safe_dup_fileno(old_stderr)
 
         if self.echo_stdin:
             bytes_input = echo_input = t.cast(
@@ -514,6 +534,12 @@ class CliRunner:
             sys.stdout = old_stdout
             sys.stderr = old_stderr
             sys.stdin = old_stdin
+            for dup_fd in (old_stdout_fd, old_stderr_fd):
+                if dup_fd >= 0:
+                    try:
+                        os.close(dup_fd)
+                    except OSError:
+                        pass
             termui.visible_prompt_func = old_visible_prompt_func
             termui.hidden_prompt_func = old_hidden_prompt_func
             termui._getchar = old__getchar_func

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -545,3 +545,37 @@ def test_faulthandler_enable(runner):
     result = runner.invoke(cli, ["--flag", True])
     assert result.exit_code == 0, result.output
     assert "Finished executing main function." in result.output
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX fd semantics only")
+def test_dup2_over_stdout_fd_does_not_leak(runner):
+    """``os.dup2`` over ``sys.stdout.fileno()`` inside ``CliRunner`` must not
+    overwrite the host process's stdout fd. The runner exposes a private
+    duplicate of the original fd, so user code (logging tees, subprocess
+    wrappers, etc.) only redirects its own copy. This isolation matches
+    pytest's ``capfd`` model and prevents breaking outer fd-based capture.
+
+    Reproduce: https://github.com/pallets/click/issues/3384
+    """
+
+    @click.command()
+    def cli():
+        stdout_fd = sys.stdout.fileno()
+        # The fd CliRunner returns is a duplicate, not the host's
+        # stdout. Confirm by redirecting it to an os.pipe -- the host
+        # stdout (fd captured by the test runner) must be unaffected.
+        r, w = os.pipe()
+        try:
+            os.dup2(w, stdout_fd)
+        finally:
+            os.close(w)
+            os.close(r)
+        click.echo("hello")
+
+    host_stdout_fd = os.dup(1)
+    try:
+        result = runner.invoke(cli)
+    finally:
+        os.close(host_stdout_fd)
+    assert result.exit_code == 0, result.output
+    assert "hello" in result.output


### PR DESCRIPTION
fixes #3384

## Summary

Click 8.3.3 (#3244) started exposing the original stream's file descriptor via `_NamedTextIOWrapper.fileno()`, so that C-level consumers like `faulthandler` and `subprocess` could obtain a real fd from `sys.stdout` / `sys.stderr` inside `CliRunner` isolation.

That regressed any command that performs `os.dup2` against the value returned by `sys.stdout.fileno()` — logging tees, build tools, subprocess wrappers, etc. The redirect happens on the host process's real stdout fd, which clobbers any outer fd-based capture (most notably pytest's `capfd`/`capsys` capture pipe). The reporter's repro fails during pytest's own teardown with `OSError: [Errno 29] Illegal seek` because pytest tries to `seek(0)` on the tmpfile that has just been overwritten with a non-seekable pipe.

This mirrors how pytest itself handles the same problem in `capfd`: `os.dup` the original fd inside `CliRunner` and expose the **duplicate** via `fileno()`. `os.dup2` against the duplicate redirects only this private copy, so the host's stdout/stderr — and any capture installed on top of it — stays intact. The duplicates are closed when the isolation context exits.

The semantics from #3244 are preserved: `faulthandler.enable()`, `subprocess`, signal handlers, and similar C-level consumers still get a valid, terminal-bound fd.

## Repro

The repro from the issue passes after this change:

```python
import io, os, sys
import click
from click.testing import CliRunner

@click.command()
def cmd():
    stdout_fd = sys.stdout.fileno()
    r, w = os.pipe()
    os.dup2(w, stdout_fd)
    os.close(w); os.close(r)
    click.echo("hello")

def test_invoke():
    runner = CliRunner()
    result = runner.invoke(cmd)
    assert result.exit_code == 0
```

## Tests

- Adds `test_dup2_over_stdout_fd_does_not_leak` in `tests/test_testing.py`. Fails on `main` with `OSError: Illegal seek` during pytest teardown (same backtrace as the issue), passes with this change.
- Existing `test_faulthandler_enable` still passes — duped fd remains valid for `faulthandler`.
- Full suite: `1437 passed, 23 skipped, 1 xfailed`.

## Checklist

- [x] Add tests that demonstrate the correct behavior of the change. Tests fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code (`_NamedTextIOWrapper` docstring + `versionchanged`).
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `versionchanged` entries in any relevant code docs.