### PR TITLE
fix: avoid help option collisions with help arguments

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1101,8 +1101,11 @@ class Command:
             # Avoid circular import.
             from .decorators import help_option
 
-            # Apply help_option decorator and pop resulting option
-            help_option(*help_option_names)(self)
+            # Give the auto-generated help option an internal name that can't
+            # collide with a user-defined argument or option called "help".
+            # Its value is never exposed, but the parser still needs a unique
+            # parameter name while resolving arguments and options.
+            help_option(*help_option_names, "__click_internal_help_option")(self)
             self._help_option = self.params.pop()  # type: ignore[assignment]
 
         return self._help_option

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,6 +29,22 @@ def test_basic_functionality(runner):
     assert result.exit_code == 0
 
 
+def test_help_argument_name_does_not_shadow_help_option(runner):
+    @click.command()
+    @click.argument("help")
+    def cli(help):
+        click.echo(help)
+
+    result = runner.invoke(cli, ["value"])
+    assert result.exit_code == 0
+    assert result.output == "value\n"
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage: cli [OPTIONS] HELP" in result.output
+    assert "Show this message and exit." in result.output
+
+
 def test_repr():
     @click.command()
     def command():


### PR DESCRIPTION
## Summary
- fix the auto-generated help option so its internal parameter name no longer collides with a user-defined argument named `help`
- add a regression test covering commands that declare `@click.argument("help")`
- preserve the existing visible `--help` behavior while avoiding parser confusion

## Bug
This addresses the argument-name case from #2819.

Before this change, a command like:

```python
@click.command()
@click.argument("help")
def cli(help):
    click.echo(help)
```

would incorrectly treat positional input as the boolean `--help` option.

## Implementation
The auto-generated help option already uses `expose_value=False`, but it still needs an internal parameter name while the parser resolves values. This PR gives that option a private internal name so it can't collide with user-defined parameters called `help`.

## Testing
- `PYTHONPATH=src python3 -m pytest -q tests/test_basic.py`
