### PR TITLE
Fix: show full option name in error for unknown multi-char short options

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -398,7 +398,7 @@ class _OptionParser:
                 if self.ignore_unknown_options:
                     unknown_options.append(ch)
                     continue
-                raise NoSuchOption(opt, ctx=self.ctx)
+                raise NoSuchOption(arg, ctx=self.ctx)
             if option.takes_value:
                 # Any characters left in arg?  Pretend they're the
                 # next arg, and stop consuming characters of arg.

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,19 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option '{unknown_flag}'." in result.output
 
 
+def test_unknown_multichar_short_option_shows_full_name(runner):
+    """Error message should show the full option string, not just the first char."""
+
+    @click.command()
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["-dbg"])
+    assert result.exception
+    assert "No such option '-dbg'." in result.output
+    assert "No such option '-d'." not in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
When an unknown multi-character short option like `-dbg` is passed, click shows "No such option: -d" instead of "No such option:
  -dbg". Only the first character was shown, which is misleading.

  Fixed by passing the full original argument to `NoSuchOption` in `_match_short_opt` instead of the single-character `opt`.

  Added a test `test_unknown_multichar_short_option_shows_full_name` to verify the fix.

  fixes #2779