### PR TITLE
Fix sentinel typing and its uses in parser

### DIFF
--- a/src/click/_utils.py
+++ b/src/click/_utils.py
@@ -19,18 +19,18 @@ class Sentinel(enum.Enum):
         return f"{self.__class__.__name__}.{self.name}"
 
 
-UNSET = Sentinel.UNSET
+UNSET: t.Literal[Sentinel.UNSET] = Sentinel.UNSET
 """Sentinel used to indicate that a value is not set."""
 
-FLAG_NEEDS_VALUE = Sentinel.FLAG_NEEDS_VALUE
+FLAG_NEEDS_VALUE: t.Literal[Sentinel.FLAG_NEEDS_VALUE] = Sentinel.FLAG_NEEDS_VALUE
 """Sentinel used to indicate an option was passed as a flag without a
 value but is not a flag option.
 
 ``Option.consume_value`` uses this to prompt or use the ``flag_value``.
 """
 
-T_UNSET = t.Literal[UNSET]  # type: ignore[valid-type]
+T_UNSET: t.TypeAlias = t.Literal[Sentinel.UNSET]
 """Type hint for the :data:`UNSET` sentinel value."""
 
-T_FLAG_NEEDS_VALUE = t.Literal[FLAG_NEEDS_VALUE]  # type: ignore[valid-type]
+T_FLAG_NEEDS_VALUE: t.TypeAlias = t.Literal[Sentinel.FLAG_NEEDS_VALUE]
 """Type hint for the :data:`FLAG_NEEDS_VALUE` sentinel value."""

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3354,6 +3354,7 @@ class Option(Parameter):
         elif (
             self.multiple
             and value is not UNSET
+            and isinstance(value, cabc.Iterable)
             and source < ParameterSource.DEFAULT_MAP
             and any(v is FLAG_NEEDS_VALUE for v in value)
         ):

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -83,7 +83,7 @@ def _unpack_args(
         if nargs == 1:
             rv.append(_fetch(args))
         elif nargs > 1:
-            x = [_fetch(args) for _ in range(nargs)]
+            x: list[str | T_UNSET] = [_fetch(args) for _ in range(nargs)]
 
             # If we're reversed, we're pulling in the arguments in reverse,
             # so we need to turn them around.

--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -50,7 +50,7 @@ V = t.TypeVar("V")
 
 def _unpack_args(
     args: cabc.Sequence[str], nargs_spec: cabc.Sequence[int]
-) -> tuple[cabc.Sequence[str | cabc.Sequence[str | None] | None], list[str]]:
+) -> tuple[cabc.Sequence[str | cabc.Sequence[str | T_UNSET] | T_UNSET], list[str]]:
     """Given an iterable of arguments and an iterable of nargs specifications,
     it returns a tuple with all the unpacked arguments at the first index
     and all remaining arguments as the second.
@@ -65,7 +65,7 @@ def _unpack_args(
     rv: list[str | tuple[str | T_UNSET, ...] | T_UNSET] = []
     spos: int | None = None
 
-    def _fetch(c: deque[V]) -> V | T_UNSET:
+    def _fetch(c: deque[str]) -> str | T_UNSET:
         try:
             if spos is None:
                 return c.popleft()
@@ -75,13 +75,13 @@ def _unpack_args(
             return UNSET
 
     while nargs_spec:
-        nargs = _fetch(nargs_spec)
-
-        if nargs is None:
-            continue
+        if spos is None:
+            nargs = nargs_spec.popleft()
+        else:
+            nargs = nargs_spec.pop()
 
         if nargs == 1:
-            rv.append(_fetch(args))  # type: ignore[arg-type]
+            rv.append(_fetch(args))
         elif nargs > 1:
             x = [_fetch(args) for _ in range(nargs)]
 
@@ -186,12 +186,12 @@ class _Argument:
 
     def process(
         self,
-        value: str | cabc.Sequence[str | None] | None | T_UNSET,
+        value: str | cabc.Sequence[str | T_UNSET] | T_UNSET,
         state: _ParsingState,
     ) -> None:
         if self.nargs > 1:
             assert isinstance(value, cabc.Sequence)
-            holes = sum(1 for x in value if x is UNSET)
+            holes = sum(x is UNSET for x in value)
             if holes == len(value):
                 value = UNSET
             elif holes != 0:
@@ -425,10 +425,10 @@ class _OptionParser:
 
     def _get_value_from_state(
         self, option_name: str, option: _Option, state: _ParsingState
-    ) -> str | cabc.Sequence[str] | T_FLAG_NEEDS_VALUE:
+    ) -> str | cabc.Sequence[str] | T_UNSET | T_FLAG_NEEDS_VALUE:
         nargs = option.nargs
 
-        value: str | cabc.Sequence[str] | T_FLAG_NEEDS_VALUE
+        value: str | cabc.Sequence[str] | T_UNSET | T_FLAG_NEEDS_VALUE
 
         if len(state.rargs) < nargs:
             if option.obj._flag_needs_value:


### PR DESCRIPTION
I was working on improving typing by making `Parameter` generic. Though while I was working on that, I noticed that the way we type the sentinel values leads to them being perceived as `Any` as they're not properly typed. Or so I understand. It's past 2AM here so I might be entirely misunderstanding as I'm not entirely familiar with sentinel best practices.

This messed with typing in `Parameter` as where I replaced `Any` with `T_UNSET` and then a generic type, it basically meant `GenericType | Any` thus `Any`.

So in the first commit here, I think I corrected the issue which then lead to surfacing some typing issues in the parser:

```
➜ uv run mypy
src/click/parser.py:85: error: Unsupported operand types for < ("int" and "Literal[Sentinel.UNSET]")  [operator]
            elif nargs > 1:
                 ^
src/click/parser.py:85: note: Left operand is of type "int | Literal[Sentinel.UNSET]"
src/click/parser.py:86: error: Argument 1 to "_fetch" has incompatible type "deque[str]"; expected "deque[str | Literal[Sentinel.UNSET]]"  [arg-type]
                x = [_fetch(args) for _ in range(nargs)]
                            ^~~~
src/click/parser.py:86: error: Argument 1 to "range" has incompatible type "int | Literal[Sentinel.UNSET]"; expected "SupportsIndex"  [arg-type]
                x = [_fetch(args) for _ in range(nargs)]
                                                 ^~~~~
src/click/parser.py:94: error: Unsupported operand types for > ("int" and "Literal[Sentinel.UNSET]")  [operator]
            elif nargs < 0:
                 ^
src/click/parser.py:94: note: Left operand is of type "int | Literal[Sentinel.UNSET]"
src/click/parser.py:108: error: Argument 1 to "tuple" has incompatible type "list[str | tuple[str | Literal[Sentinel.UNSET], ...] | Literal[Sentinel.UNSET]]"; expected
"Iterable[Sequence[str | None] | None]"  [arg-type]
        return tuple(rv), list(args)
                     ^~
src/click/parser.py:194: error: Generator has incompatible item type "int"; expected "bool"  [misc]
                holes = sum(1 for x in value if x is UNSET)
                            ^
src/click/parser.py:194: error: Non-overlapping identity check (left operand type: "str | None", right operand type: "Literal[Sentinel.UNSET]")  [comparison-overlap]
                holes = sum(1 for x in value if x is UNSET)
                                                ^~~~~~~~~~
src/click/parser.py:382: error: Incompatible types in assignment (expression has type "Literal[Sentinel.UNSET]", variable has type "Sequence[str] | Literal[Sentinel.FLAG_NEEDS_VALUE]")  [assignment]
                value = UNSET
                        ^~~~~
src/click/parser.py:412: error: Incompatible types in assignment (expression has type "Literal[Sentinel.UNSET]", variable has type "Sequence[str] | Literal[Sentinel.FLAG_NEEDS_VALUE]")  [assignment]
                    value = UNSET
```

These are addressed in this commit.