### PR TITLE
Avoid UnicodeEncodeError for default stdout

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -267,6 +267,8 @@ def echo(
     .. versionchanged:: 2.0
         Support colors on Windows if colorama is installed.
     """
+    file_is_default = file is None
+
     if file is None:
         if err:
             file = _default_text_stderr()
@@ -321,7 +323,21 @@ def echo(
             elif not color:
                 out = strip_ansi(out)
 
-    file.write(out)  # type: ignore
+    try:
+        file.write(out)  # type: ignore
+    except UnicodeEncodeError:
+        if file_is_default and isinstance(out, str):
+            binary_file = _find_binary_writer(file)
+
+            if binary_file is not None:
+                file.flush()
+                encoding = getattr(file, "encoding", None) or sys.getdefaultencoding()
+                binary_file.write(out.encode(encoding, "replace"))
+                binary_file.flush()
+                return
+
+        raise
+
     file.flush()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,9 @@ from contextlib import nullcontext
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial
+from io import BytesIO
 from io import StringIO
+from io import TextIOWrapper
 from unittest.mock import patch
 
 import pytest
@@ -95,6 +97,17 @@ def test_echo_custom_file():
     f = StringIO()
     click.echo("hello", file=f)
     assert f.getvalue() == "hello\n"
+
+
+def test_echo_replaces_unencodable_default_stdout(monkeypatch):
+    stream = BytesIO()
+    stdout = TextIOWrapper(stream, encoding="cp1252", errors="surrogateescape")
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    click.echo("\u2023")
+
+    stdout.flush()
+    assert stream.getvalue() == b"?\n"
 
 
 def test_echo_no_streams(monkeypatch, runner):


### PR DESCRIPTION
Fixes #2121.

When Click writes help text to the default stdout on Windows, Python can expose a narrow stream encoding such as `cp1252` with `surrogateescape`. In that case a Unicode character in help text can raise `UnicodeEncodeError` before Click can finish rendering help.

This keeps the fallback narrow: if writing to the default stream fails with `UnicodeEncodeError`, write the encoded bytes with replacement through the underlying binary stream. Explicit `file=` streams still keep their configured error behavior.

Tested:
- `uv run pytest tests/test_utils.py -q`
- `uv run ruff check src/click/utils.py tests/test_utils.py`
- local Windows repro with `py -X utf8=0`