### PR TITLE
Handle missing command in alias docs

### DIFF
--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:

--- a/tests/typing/typing_aliased_group.py
+++ b/tests/typing/typing_aliased_group.py
@@ -21,11 +21,10 @@ class AliasedGroup(click.Group):
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
-    ) -> tuple[str | None, click.Command, list[str]]:
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         # always return the full command name
         _, cmd, args = super().resolve_command(ctx, args)
-        assert cmd is not None
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 @click.command(cls=AliasedGroup)


### PR DESCRIPTION
Fixes #2402.

The `AliasedGroup.resolve_command` example assumed `cmd` was always present, but shell completion can call this while Click is using resilient parsing. In that path `Group.resolve_command` can return `None`, so the example should mirror Click's built-in handling.

I updated the docs example and the matching typing example.

Checks run:

```
uv run --locked --no-default-groups --group typing mypy tests/typing/typing_aliased_group.py
uv run --locked --no-default-groups --group typing pyright tests/typing/typing_aliased_group.py
uv run --locked --no-default-groups --group pre-commit pre-commit run trailing-whitespace --files docs/extending-click.md tests/typing/typing_aliased_group.py
uv run --locked --no-default-groups --group pre-commit pre-commit run end-of-file-fixer --files docs/extending-click.md tests/typing/typing_aliased_group.py
```