### PR TITLE
Avoid breaking HelpFormatter usage args on hyphens

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,8 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_long_words: bool = True,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +54,10 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_long_words: if this flag is set then long words may be
+                             wrapped to the next line in the middle of a word.
+    :param break_on_hyphens: if this flag is set then long words may be
+                             wrapped on hyphens.
     """
     from ._textwrap import TextWrapper
 
@@ -61,6 +67,8 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_long_words=break_long_words,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -167,6 +175,8 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_long_words=False,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -176,7 +186,12 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_long_words=False,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -425,6 +425,32 @@ def test_formatting_with_options_metavar_empty(runner):
     assert "Usage: cli VAR\n" in result.output
 
 
+def test_help_formatter_write_usage_does_not_break_on_hyphens():
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+
+    assert formatter.getvalue() == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+
 def test_help_formatter_write_text():
     text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
     formatter = click.HelpFormatter(width=len("  Lorem ipsum dolor sit amet,"))


### PR DESCRIPTION
## Summary
- prevent `HelpFormatter.write_usage` from breaking usage arguments in the middle of hyphenated option names
- keep the existing wrapping behavior for other `wrap_text` callers by adding explicit wrapper controls
- add a regression test covering the reported example

## Reproduction
Using the issue's example with `PYTHONPATH=src python3` before this change produced:

```text
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
               --force-overwrite-existing --network-timeout-
               seconds --debug-trace-enabled
```

After this change it produces:

```text
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

Fixes #3362.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_formatting.py -q`
