### PR TITLE
fix: print program name in write_usage when no args (#3360)

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,27 +158,33 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
-        if text_width >= (term_len(usage_prefix) + 20):
-            # The arguments will fit to the right of the prefix.
-            indent = " " * term_len(usage_prefix)
-            self.write(
-                wrap_text(
-                    args,
-                    text_width,
-                    initial_indent=usage_prefix,
-                    subsequent_indent=indent,
+        if args:
+            if text_width >= (term_len(usage_prefix) + 20):
+                # The arguments will fit to the right of the prefix.
+                indent = " " * term_len(usage_prefix)
+                self.write(
+                    wrap_text(
+                        args,
+                        text_width,
+                        initial_indent=usage_prefix,
+                        subsequent_indent=indent,
+                    )
                 )
-            )
+            else:
+                # The prefix is too long, put the arguments on the next line.
+                self.write(usage_prefix)
+                self.write("\n")
+                indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
+                self.write(
+                    wrap_text(
+                        args,
+                        text_width,
+                        initial_indent=indent,
+                        subsequent_indent=indent,
+                    )
+                )
         else:
-            # The prefix is too long, put the arguments on the next line.
-            self.write(usage_prefix)
-            self.write("\n")
-            indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
-            self.write(
-                wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
-                )
-            )
+            self.write(usage_prefix.rstrip())
 
         self.write("\n")
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,10 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_write_usage_with_no_args():
+    """Write usage should print program name even when no args are given."""
+    f = click.HelpFormatter()
+    f.write_usage("program")
+    assert f.getvalue() == "Usage: program\n"


### PR DESCRIPTION
Fixes #3360

## Problem
When no  are passed to , the usage line is not printed at all. This is because  returns an empty string, losing the usage prefix.



## Fix
Added a check for empty  in . When  is empty, the method now writes the usage prefix directly (without the trailing space) instead of passing the empty string through .

## Test
Added  to verify the fix.