### PR TITLE
Fix `HelpFormatter.write_usage` with empty args

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -63,7 +63,7 @@ def wrap_text(
         replace_whitespace=False,
     )
     if not preserve_paragraphs:
-        return wrapper.fill(text)
+        return wrapper.fill(text) if text else initial_indent
 
     p: list[tuple[int, bool, str]] = []
     buf: list[str] = []

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,10 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_without_args():
+    f = click.HelpFormatter()
+    f.write_usage("Program")
+    expected = "Usage: Program \n"
+    assert f.getvalue() == expected


### PR DESCRIPTION
Fixes #3360.

This fixes `HelpFormatter.write_usage()` when it is called without `args`.

Previously, `write_usage("Program")` passed an empty string to `wrap_text()` while using the usage prefix as `initial_indent`. Since there was no text to wrap, `wrap_text()` returned an empty string and only a blank line was written.

This change preserves the usage prefix for the empty-args case, so `write_usage("Program")` now writes:

```python
"Usage: Program \n"
```

Tests were added to cover this behavior.

Tests run:

```text
pytest tests/test_formatting.py -q
pytest
```
