### PR TITLE
fix: handle empty args in HelpFormatter.write_usage

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -155,6 +155,10 @@ class HelpFormatter:
         if prefix is None:
             prefix = f"{_('Usage:')} "
 
+        if not args:
+            self.write(f"{prefix:>{self.current_indent}}{prog}\n")
+            return
+
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 


### PR DESCRIPTION
When `write_usage(prog, args)` is called with an empty `args`,
the usage line is not printed (just a blank line). This happens because
`wrap_text("")` returns `""`, so only `"\n"` gets written.

Fix: add an early return when `args` is empty to write the usage
prefix and program name directly.

Fixes #3360