### PR TITLE
write_usage with empty args produces a blank line instead of usage info

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -155,6 +155,10 @@ class HelpFormatter:
         if prefix is None:
             prefix = f"{_('Usage:')} "
 
+        if not args:
+            self.write(f"{prefix:>{self.current_indent}}{prog}\n")
+            return
+
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,26 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+def test_write_usage_empty_args():
+    """write_usage with no args should still print the usage line.
+
+    When args is empty, the usage line should show just "Usage: <prog>"
+    instead of printing a blank line.
+
+    Regression test for https://github.com/pallets/click/issues/3360.
+    """
+    f = click.HelpFormatter()
+    f.write_usage("program")
+    assert f.getvalue() == "Usage: program\n"
+
+    # With a custom prefix
+    f2 = click.HelpFormatter()
+    f2.write_usage("myapp", prefix="MyApp: ")
+    assert f2.getvalue() == "MyApp: myapp\n"
+
+    # Normal case with args should still work
+    f3 = click.HelpFormatter()
+    f3.write_usage("program", "[OPTIONS] COMMAND [ARGS]...")
+    assert "Usage:" in f3.getvalue()
+    assert "[OPTIONS]" in f3.getvalue()


### PR DESCRIPTION
Calling `HelpFormatter.write_usage("program")` without an `args` parameter (or with an empty string) outputs a blank line instead of the expected `Usage: program`.

This happens because `wrap_text("")` returns `""`, so only `self.write("")` followed by `self.write("\n")` is executed.

Fix: add an early return when `args` is empty that writes the usage prefix and program name directly, then returns.

Closes #3360