### PR TITLE
fix(HelpFormatter): prevent write_usage from breaking option names at hyphens

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -61,6 +62,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -167,6 +169,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -176,7 +179,8 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args, text_width, initial_indent=indent, subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 


### PR DESCRIPTION
Fixes #3362

## Summary

When option names containing hyphens (e.g. `--enable-verbose-logging`) reach the line width limit in `write_usage`, Python's `textwrap.TextWrapper` breaks them at the hyphen by default (`break_on_hyphens=True`).

This adds a `break_on_hyphens` parameter to `wrap_text` (defaults to `True` to preserve existing behavior for general help text) and passes `False` from `write_usage` to keep option names intact.

## Before

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location ...
```

## After

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location ...
```

## Test plan

- [x] Manually verified fix with the reproduction from the issue
- [x] Verified that general text wrapping still breaks at hyphens (default behavior preserved)
- [ ] Project test suite (could not run locally)