### PR TITLE
Fixed write_usage producing empty output when args is empty.

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,7 +158,9 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
-        if text_width >= (term_len(usage_prefix) + 20):
+        if not args:
+            self.write(usage_prefix.rstrip())
+        elif text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)
             self.write(

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,10 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_no_args():
+    """write_usage with no args should still print the usage line."""
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"


### PR DESCRIPTION
Fixes #3360.

When `HelpFormatter.write_usage` is called with no `args` (or an empty string), the usage line was silently dropped. The call to `wrap_text("", ...)` returned an empty string, so only the trailing `\n` was written to the buffer.

**Root cause:** `wrap_text` with an empty text string returns `""`, writing nothing. The `usage_prefix` (e.g. `"Usage: program "`) was only passed as the `initial_indent` to `wrap_text`, not written directly.

**Fix:** Short-circuit when `args` is empty — write `usage_prefix` (stripped of its trailing space) directly and skip `wrap_text` entirely.

**Before:**
```python
import click
f = click.HelpFormatter()
f.write_usage("program")
print(repr(f.getvalue()))
# '\n'  ← empty line, usage line missing
```

**After:**
```python
print(repr(f.getvalue()))
# 'Usage: program\n'  ← correct
```

Test added in `tests/test_formatting.py`. Full suite: 1494 passed, 24 skipped.