### PR TITLE
wrap_text breaks option names at hyphens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 8.4.0
 
 Unreleased
 
+-   :func:`wrap_text` accepts a ``break_on_hyphens`` parameter.
+    :meth:`HelpFormatter.write_usage` passes ``False`` so option
+    names like ``--max-retry-count`` are not split across lines.
+    :issue:`3362`
 -   :class:`ParamType` typing improvements. :pr:`3371`
 
     -   :class:`ParamType` is now a generic abstract base class,

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,8 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if ``False``, hyphens in words will not be
+                             used as line break points.
     """
     from ._textwrap import TextWrapper
 
@@ -61,6 +64,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -167,6 +171,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -176,7 +181,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,16 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_write_usage_no_break_on_hyphens():
+    f = click.HelpFormatter(width=65)
+    f.write_usage(
+        "program",
+        "--enable-verbose-logging --output-file-path"
+        " --max-retry-count --disable-cache-mode",
+    )
+    assert f.getvalue() == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+    )


### PR DESCRIPTION
Fixes #3362.

`textwrap.TextWrapper` defaults to `break_on_hyphens=True`, so option names like `--max-retry-count` get split across lines in usage output. This passes `break_on_hyphens=False` to preserve them.