### PR TITLE
Fix HelpFormatter.write_usage dropping prefix when args is empty

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -161,14 +161,19 @@ class HelpFormatter:
         if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)
-            self.write(
-                wrap_text(
-                    args,
-                    text_width,
-                    initial_indent=usage_prefix,
-                    subsequent_indent=indent,
+            if args:
+                self.write(
+                    wrap_text(
+                        args,
+                        text_width,
+                        initial_indent=usage_prefix,
+                        subsequent_indent=indent,
+                    )
                 )
-            )
+            else:
+                # No args, but still need to write the "Usage: prog" prefix.
+                # rstrip removes the trailing space added when building usage_prefix.
+                self.write(usage_prefix.rstrip())
         else:
             # The prefix is too long, put the arguments on the next line.
             self.write(usage_prefix)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,11 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_write_usage_no_args():
+    """Regression test for issue #3360: write_usage with empty args
+    should still emit the 'Usage: prog' prefix, not an empty line."""
+    f = click.HelpFormatter()
+    f.write_usage("program")
+    assert f.getvalue() == "Usage: program\n"


### PR DESCRIPTION
Fixes #3360.

Tracked this down — when `args=""` the function calls `wrap_text("", ..., initial_indent=usage_prefix, ...)`, but `textwrap.fill` of an empty string returns `""` without emitting the `initial_indent`. So the `"Usage: program "` prefix gets dropped on the floor and only the trailing newline makes it through. Empty line, just like the issue.

So the fix just writes the prefix directly when there are no args, and only goes through `wrap_text` when there's something to wrap. The else-branch (prefix too long) doesn't hit this because it already writes `usage_prefix` before the wrap call.

Added a regression test using the reporter's repro.