### PR TITLE
Fix empty HelpFormatter usage output

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,6 +158,11 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
+        if not args:
+            self.write(usage_prefix[:-1])
+            self.write("\n")
+            return
+
         if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -433,3 +433,9 @@ def test_help_formatter_write_text():
     actual = formatter.getvalue()
     expected = "  Lorem ipsum dolor sit amet,\n  consectetur adipiscing elit\n"
     assert actual == expected
+
+
+def test_help_formatter_write_usage_without_args():
+    formatter = click.HelpFormatter()
+    formatter.write_usage("program")
+    assert formatter.getvalue() == "Usage: program\n"


### PR DESCRIPTION
Closes #3360

## Summary
- Make `HelpFormatter.write_usage()` write the usage line when called without an `args` string.
- Add a regression test for a no-argument usage line.

## Impact
This fixes direct `HelpFormatter` usage for commands or internal command-like prompts that do not take arguments. Existing usage wrapping behavior is unchanged when arguments are provided.

## Validation
- `python -m pytest tests/test_formatting.py -q` -> 24 passed
- `python -m pytest -q` with `TMP`/`TEMP` pointed at a checkout-local temp directory -> 1441 passed, 77 skipped, 30000 deselected, 1 xfailed
- `git diff --check` -> passed; only Windows line-ending conversion warnings were reported