### PR TITLE
Add type annotations for instance attributes in `utils`

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -205,8 +205,10 @@ class LazyFile:
 
 
 class KeepOpenFile:
+    _file: t.IO[t.Any]
+
     def __init__(self, file: t.IO[t.Any]) -> None:
-        self._file: t.IO[t.Any] = file
+        self._file = file
 
     def __getattr__(self, name: str) -> t.Any:
         return getattr(self._file, name)

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -117,6 +117,14 @@ class LazyFile:
     files for writing.
     """
 
+    name: str
+    mode: str
+    encoding: str | None
+    errors: str | None
+    atomic: bool
+    _f: t.IO[t.Any] | None
+    should_close: bool
+
     def __init__(
         self,
         filename: str | os.PathLike[str],
@@ -124,14 +132,12 @@ class LazyFile:
         encoding: str | None = None,
         errors: str | None = "strict",
         atomic: bool = False,
-    ):
-        self.name: str = os.fspath(filename)
+    ) -> None:
+        self.name = os.fspath(filename)
         self.mode = mode
         self.encoding = encoding
         self.errors = errors
         self.atomic = atomic
-        self._f: t.IO[t.Any] | None
-        self.should_close: bool
 
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
@@ -507,6 +513,8 @@ class PacifyFlushWrapper:
     other cleanup code, and the case where the underlying file is not a broken
     pipe, all calls and attributes are proxied.
     """
+
+    wrapped: t.IO[t.Any]
 
     def __init__(self, wrapped: t.IO[t.Any]) -> None:
         self.wrapped = wrapped


### PR DESCRIPTION
I noticed that the type coverage of `click` was pretty high, but not quite at 100% yet (according to typestats: https://jorenham.github.io/typestats/dashboard/report/#click). So towards that end, this adds type annotations for the instance attributes of the classes in `click.utils`, increasing the type-coverage of `click` by almost 0.5% (90.97% -> 91.47%).

If you're open to it, I'd also like to open PRs for the other modules, so that we can reach that sweet 100% type coverage :)
