### PR TITLE
Add missing space between option help text and deprecation label

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2786,7 +2786,11 @@ class Option(Parameter):
                 if isinstance(deprecated, str)
                 else "(DEPRECATED)"
             )
-            help = help + deprecated_message if help is not None else deprecated_message
+            help = (
+                f"{help} {deprecated_message}"
+                if help is not None
+                else deprecated_message
+            )
 
         self.prompt = prompt_text
         self.confirmation_prompt = confirmation_prompt


### PR DESCRIPTION
Without the space, a deprecated documented option currently appears as:
`--deprecated-opt   Old option(DEPRECATED[: too old])`
After:
`--deprecated-opt   Old option (DEPRECATED[: too old])`