### PR TITLE
 Fix usage wrapping for hyphenated options

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,8 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then wrapping may occur
+                             after hyphens in words.
     """
     from ._textwrap import TextWrapper
 
@@ -61,6 +64,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -167,6 +171,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -176,7 +181,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -86,6 +86,34 @@ def test_wrapping_long_options_strings(runner):
     ]
 
 
+def test_usage_does_not_wrap_option_names_at_hyphens():
+    args = " ".join(
+        [
+            "--enable-verbose-logging",
+            "--output-file-path",
+            "--max-retry-count",
+            "--disable-cache-mode",
+            "--config-file-location",
+            "--user-auth-token",
+            "--auto-update-interval",
+            "--force-overwrite-existing",
+            "--network-timeout-seconds",
+            "--debug-trace-enabled",
+        ]
+    )
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", args)
+
+    assert formatter.getvalue().splitlines() == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location --user-auth-token",
+        "               --auto-update-interval --force-overwrite-existing",
+        "               --network-timeout-seconds --debug-trace-enabled",
+    ]
+
+
 def test_wrapping_long_command_name(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
## Summary
- add a break_on_hyphens option to Click's internal wrap_text helper
- disable hyphen breaks when wrapping HelpFormatter.write_usage argument strings
- add a regression test for hyphenated long option names in usage output

## Why
HelpFormatter.write_usage currently delegates to textwrap.TextWrapper with its default break_on_hyphens=True, so usage tokens like --max-retry-count can be split into --max- and retry-count. Usage output is easier to read when option names and metavars stay intact across wraps.

Fixes #3362.

## Validation
- Ran the issue repro with PYTHONPATH=src using Python 3.12.13
- .venv/bin/python -m pytest tests/test_formatting.py -q
- .venv/bin/python -m pytest -q