### PR TITLE
Report full single-dash long option errors

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -489,8 +489,20 @@ class _OptionParser:
             # which says, that if we have a two character options prefix
             # (applies to "--foo" for instance), we do not dispatch to the
             # short option code and will instead raise the no option
-            # error.
-            if arg[:2] not in self._opt_prefixes:
+            # error.  The same applies to single-dash long options such as
+            # "-foo" when the unknown argument extends a known option and
+            # cannot be interpreted as a known short option.
+            single_dash_long_prefix = any(
+                arg.startswith(opt)
+                and opt[:1] == arg[:1]
+                and opt[:2] not in self._opt_prefixes
+                for opt in self._long_opt
+            )
+            first_short_opt = _normalize_opt(arg[:2], self.ctx) in self._short_opt
+
+            if arg[:2] not in self._opt_prefixes and (
+                first_short_opt or not single_dash_long_prefix
+            ):
                 self._match_short_opt(arg, state)
                 return
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -144,6 +144,18 @@ def test_unknown_options(runner, unknown_flag):
     assert f"No such option '{unknown_flag}'." in result.output
 
 
+def test_unknown_single_dash_long_option_reports_full_arg(runner):
+    @click.command()
+    @click.option("-dbg", is_flag=True)
+    def cli(dbg):
+        click.echo(f"dbg={dbg}")
+
+    result = runner.invoke(cli, ["-dbgwrong"])
+
+    assert result.exception
+    assert "No such option '-dbgwrong'." in result.output
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
Fixes #2779.

This keeps unknown arguments that extend a known single-dash long option on the long-option error path, so `-dbgwrong` reports the full unknown option instead of falling through to the first short-option character.

Verification:
- `git diff --check`
- Manual `CliRunner` smoke check for `-dbg`, `-dbgwrong`, and combined short flags
- Not run: full pytest suite (pytest/pip are unavailable in this environment)