### PR TITLE
Fix HelpFormatter.write_usage with empty args producing no output

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -158,6 +158,10 @@ class HelpFormatter:
         usage_prefix = f"{prefix:>{self.current_indent}}{prog} "
         text_width = self.width - self.current_indent
 
+        if not args:
+            self.write(f"{prefix:>{self.current_indent}}{prog}\n")
+            return
+
         if text_width >= (term_len(usage_prefix) + 20):
             # The arguments will fit to the right of the prefix.
             indent = " " * term_len(usage_prefix)


### PR DESCRIPTION
Fixes #3360

## Problem
When `write_usage` is called with no `args` (the default `""`), `wrap_text("")` produces an empty string, so no usage line is printed at all.

## Reproduction
```python
import click
f = click.HelpFormatter()
f.write_usage("program")
print(f.getvalue())  # empty line instead of "Usage: program\n"
```

## Fix
Added an early return that writes `prefix + prog` directly when `args` is empty or falsy. This avoids passing an empty string to `wrap_text`.
