### PR TITLE
Fix launch(locate=True) failing for paths with spaces on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.4.0
 
 Unreleased
 
+-   Quote the ``/select`` argument passed to Windows Explorer in
+    :func:`launch` so that file paths containing spaces are located
+    correctly. :issue:`2994`
 -   :class:`ParamType` typing improvements. :pr:`3371`
 
     -   :class:`ParamType` is now a generic abstract base class,

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -758,8 +758,8 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
             null.close()
     elif WIN:
         if locate:
-            url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            url = _unquote_file(url).replace('"', '""')
+            args = ["explorer", f'/select,"{url}"']
             try:
                 return subprocess.call(args)
             except OSError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -780,3 +780,23 @@ def test_make_default_short_help(value, max_length, alter, expect):
 
     out = click.utils.make_default_short_help(value, max_length)
     assert out == expect
+
+
+@pytest.mark.skipif(not WIN, reason="Windows-only behaviour")
+def test_launch_locate_quotes_path_with_spaces():
+    """launch(locate=True) must quote the /select argument so that paths
+    containing spaces are passed correctly to Windows Explorer."""
+    path = r"C:\Users\John Doe\My Documents\report.pdf"
+
+    with patch("subprocess.call") as mock_call:
+        mock_call.return_value = 0
+        click._termui_impl.open_url(path, locate=True)
+
+    mock_call.assert_called_once()
+    args = mock_call.call_args[0][0]
+    # The /select value must be enclosed in double-quotes so Explorer
+    # receives the full path as a single token even when it contains spaces.
+    assert args[0] == "explorer"
+    assert args[1] == f'/select,"{path}"', (
+        f"Expected quoted /select argument, got: {args[1]!r}"
+    )


### PR DESCRIPTION
Fixes #2994.

## What changed

`click.launch(path, locate=True)` calls Windows Explorer with the
`/select,<path>` flag to highlight the target file. When the path
contains spaces (e.g. `C:\Users\John Doe\report.pdf`), Explorer
receives `/select,C:\Users\John Doe\report.pdf` as an unquoted token
and splits on the space, so it silently falls back to opening the
Documents folder instead.

The fix wraps the argument in double-quotes:

```python
# before
args = ["explorer", f"/select,{url}"]

# after
url = _unquote_file(url).replace('"', '""')
args = ["explorer", f'/select,"{url}"']
```

The `.replace('"', '""')` ensures that any literal double-quote
characters already in the path are properly escaped before wrapping.

## Tests

Added `test_launch_locate_quotes_path_with_spaces` in `tests/test_utils.py`.
It patches `subprocess.call` and asserts that the generated `/select`
argument is double-quoted, so the test is platform-independent and runs
in CI without needing a real Windows Explorer.