### PR TITLE
Keep usage option names intact when wrapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Unreleased
     written even when no arguments follow, and the trailing separator
     space is stripped so the line ends at the program name.
     :issue:`3360` :pr:`3434`
+-   Fix :meth:`HelpFormatter.write_usage` breaking long option names at
+    internal hyphens when wrapping usage lines. :issue:`3362`
 -   Show custom error messages from types when :func:`prompt` with
     ``hide_input=True`` fails validation, instead of always showing a
     generic message. Built-in type messages mask the input value.

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,10 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: allow line breaks after hyphens in compound words.
+
+    .. versionchanged:: 8.4
+        Added the ``break_on_hyphens`` parameter.
 
     .. versionchanged:: 8.4
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +72,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -181,6 +187,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -190,7 +197,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -87,6 +87,32 @@ def test_wrapping_long_options_strings(runner):
     ]
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+
+    assert formatter.getvalue().splitlines() == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location --user-auth-token",
+        "               --auto-update-interval --force-overwrite-existing",
+        "               --network-timeout-seconds --debug-trace-enabled",
+    ]
+
+
 def test_wrapping_long_command_name(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
Keep `HelpFormatter.write_usage` from wrapping option tokens at internal
hyphens. Usage strings are whitespace-separated tokens, so a long option such
as `--max-retry-count` should move to the next line as a unit instead of being
split as `--max-` / `retry-count`.

This forwards `textwrap.TextWrapper`'s `break_on_hyphens` control through
`wrap_text`, then disables hyphen breaks only for usage-line wrapping. General
help text keeps the existing default behavior.

Closes #3362.

Tests:

- `PYTHONPATH=src python3 -m pytest tests/test_formatting.py::test_write_usage_does_not_break_options_at_hyphens -q`
- `PYTHONPATH=src python3 -m pytest tests/test_formatting.py -q`
- `PYTHONPATH=src python3 -m pytest -q`
- `git diff --check`
