### PR TITLE
Quote Explorer select paths with spaces

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -759,7 +759,8 @@ def open_url(url: str, wait: bool = False, locate: bool = False) -> int:
     elif WIN:
         if locate:
             url = _unquote_file(url)
-            args = ["explorer", f"/select,{url}"]
+            url = url.replace('"', '""')
+            args = ["explorer", f'/select,"{url}"']
             try:
                 return subprocess.call(args)
             except OSError:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -569,6 +569,20 @@ def test_editor_nonexistent_exception():
             Editor(editor="nonexistent").edit_files(["f.txt"])
 
 
+def test_launch_windows_locate_quotes_path_with_spaces(monkeypatch):
+    monkeypatch.setattr(click._termui_impl.sys, "platform", "win32")
+    monkeypatch.setattr(click._termui_impl, "WIN", True)
+    monkeypatch.setattr(click._termui_impl, "CYGWIN", False)
+
+    with patch("subprocess.call", return_value=0) as mock_call:
+        rv = click._termui_impl.open_url(r"C:\Users\Public\click demo", locate=True)
+
+    assert rv == 0
+    mock_call.assert_called_once_with(
+        ["explorer", r'/select,"C:\Users\Public\click demo"']
+    )
+
+
 @pytest.mark.parametrize(
     ("pager_env", "expected_parts"),
     [


### PR DESCRIPTION
## Summary

Fixes #2994 by quoting the Explorer `/select,` target on Windows when `click.launch(..., locate=True)` receives a path containing spaces.

The Windows shell parser treats `/select,C:\path with spaces` incorrectly, so Explorer falls back to opening a default folder. Passing `/select,"C:\path with spaces"` preserves the target path. Double quotes inside the path are escaped defensively before building the Explorer argument.

## Validation

- `uv run --frozen pytest tests/test_termui.py::test_launch_windows_locate_quotes_path_with_spaces -q`
- `uv run --frozen pytest tests/test_termui.py -q`
