### PR TITLE
platform-dependent `testing.CaptureMode` type alias

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -22,7 +22,10 @@ if t.TYPE_CHECKING:
 
     from .core import Command
 
-CaptureMode: t.TypeAlias = t.Literal["sys", "fd"]
+if sys.platform == "win32":
+    CaptureMode: t.TypeAlias = t.Literal["sys"]  # pyright: ignore[reportRedeclaration]
+else:
+    CaptureMode: t.TypeAlias = t.Literal["sys", "fd"]  # pyright: ignore[reportRedeclaration]
 ExceptionInfo: t.TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
 
 


### PR DESCRIPTION
`CliRunner.__init__` will raise a `ValueError` if `capture="fd"` on windows. By using the fact that type-checkers are able to understand basic `sys.platform` checks (https://typing.python.org/en/latest/spec/directives.html#version-and-platform-checking), we can use Python's type system to prevent this from happening, by having a definition for the `CaptureMode` type alias on windows, improving type-safety.