### PR TITLE
Fix Zsh, Fish and Bash shell completion with long options using =

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -301,6 +301,17 @@ class ShellComplete:
         """
         args, incomplete = self.get_completion_args()
         completions = self.get_completions(args, incomplete)
+
+        # In shells that do not split on '=' (e.g. Zsh, Fish), if the
+        # incomplete value started with an option name and '=', we must
+        # prepend it to the completion values so the shell doesn't
+        # replace the whole token with just the value.
+        if "=" in incomplete:
+            prefix, _, _ = incomplete.partition("=")
+            if prefix.startswith("-"):
+                for item in completions:
+                    item.value = f"{prefix}={item.value}"
+
         out = [self.format_completion(item) for item in completions]
         return "\n".join(out)
 
@@ -652,6 +663,10 @@ def _resolve_incomplete(
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+
+    # In bash, COMP_WORDBREAKS might split '=' into its own arg.
+    if args and args[-1] == "=":
+        args.pop()
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -375,8 +375,7 @@ def test_full_complete(runner, shell, env, expect):
     [
         (
             {"COMP_WORDS": "", "COMP_CWORD": "0"},
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                     plain
                     a
                     _
@@ -389,34 +388,29 @@ def test_full_complete(runner, shell, env, expect):
                     plain
                     c:e
                     _
-                """
-            ),
+                """),
         ),
         (
             {"COMP_WORDS": "a c", "COMP_CWORD": "1"},
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                     plain
                     c\\:d
                     cee:dee
                     plain
                     c:e
                     _
-                """
-            ),
+                """),
         ),
         (
             {"COMP_WORDS": "a c:", "COMP_CWORD": "1"},
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                     plain
                     c\\:d
                     cee:dee
                     plain
                     c:e
                     _
-                """
-            ),
+                """),
         ),
     ],
 )
@@ -440,6 +434,47 @@ def test_zsh_full_complete_with_colons(
             "_CLI_COMPLETE": "zsh_complete",
         },
     )
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        ("bash", {"COMP_WORDS": "cli --opt = a", "COMP_CWORD": "3"}, "plain,a\n"),
+        (
+            "bash",
+            {"COMP_WORDS": "cli --opt =", "COMP_CWORD": "2"},
+            "plain,a\nplain,b\n",
+        ),
+        # zsh doesn't split `=` by default
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --opt=", "COMP_CWORD": "1"},
+            "plain\n--opt=a\n_\nplain\n--opt=b\n_\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --opt=a", "COMP_CWORD": "1"},
+            "plain\n--opt=a\n_\n",
+        ),
+        # fish doesn't split `=` by default
+        (
+            "fish",
+            {"COMP_WORDS": "cli --opt=", "COMP_CWORD": "--opt="},
+            "plain\n--opt=a\n_\nplain\n--opt=b\n_\n",
+        ),
+        (
+            "fish",
+            {"COMP_WORDS": "cli --opt=a", "COMP_CWORD": "--opt=a"},
+            "plain\n--opt=a\n_\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_with_equals(runner, shell, env, expect):
+    cli = Command("cli", params=[Option(["--opt"], type=Choice(["a", "b"]))])
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
     assert result.output == expect
 
 


### PR DESCRIPTION
This PR fixes issue #2847.

In Zsh and Fish (which do not split = by default), completing an option with = (like --color=a) replaces the option with just the value because the completion script expects the whole word back. This PR fixes this by prepending the prefix for these shells during completion.

For Bash (which splits = by default), args captures the =, which causes the option to be unrecognized. This PR simply pops = from args before completion parsing.

Tests were updated to cover bash, zsh, and fish cases.