### PR TITLE
Prevent pager wrapper from closing CliRunner stdout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 8.4.1
 
 Unreleased
 
+-   Prevent :func:`get_pager_file` from closing externally owned text
+    stream buffers when :func:`echo_via_pager` falls back to stdout.
+    :issue:`3449`
+
 
 
 Version 8.4.0

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -395,6 +395,9 @@ class MaybeStripAnsi(io.TextIOWrapper):
             text = strip_ansi(text)
         return super().write(text)
 
+    def close(self) -> None:
+        """Do not close buffers owned by the pager backend."""
+
 
 def _pager_contextmanager(
     color: bool | None = None,

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -726,6 +726,17 @@ def test_echo_via_pager_real_pager_handles_ansi(monkeypatch, capfd, color, expec
     assert out == expected
 
 
+def test_echo_via_pager_keeps_runner_stdout_open(runner):
+    @click.command()
+    def cli():
+        click.echo_via_pager("hello")
+
+    result = runner.invoke(cli)
+
+    assert result.output == "hello\n"
+    assert result.exit_code == 0
+
+
 def test_get_pager_file_pager_missing_binary_falls_back(monkeypatch, tmp_path):
     """``PAGER`` pointing to a nonexistent binary falls back to the text stdout."""
     pager_out = tmp_path / "pager_out.txt"


### PR DESCRIPTION
## Summary

- prevent `MaybeStripAnsi` from closing pager-owned stream buffers
- add a regression test covering `echo_via_pager()` under `CliRunner`
- document the fix in `CHANGES.rst`

## Why

`get_pager_file()` can wrap a text stream in `MaybeStripAnsi`, which inherits from `io.TextIOWrapper`. That wrapper owns and may close the underlying buffer when it is finalized. If paging falls back to `stdout` inside `CliRunner`, that buffer belongs to the runner, so `CliRunner.invoke()` later fails while flushing with `ValueError: I/O operation on closed file`.

Closes #3449

## Validation

- `python -m pytest tests/test_termui.py tests/test_stream_lifecycle.py -q`
- `python -m pytest -q`