### PR TITLE
Restore parameter source during type conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.4.1
 
 Unreleased
 
+-   Restore :meth:`Context.get_parameter_source` during type conversion
+    for values sourced from parameter defaults. :issue:`3458`
+
 
 
 Version 8.4.0

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2608,6 +2608,7 @@ class Parameter(ABC):
 
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
+            ctx.set_parameter_source(self.name, source)
 
             # Display a deprecation warning if necessary.
             if (
@@ -2654,10 +2655,14 @@ class Parameter(ABC):
         )
 
         if is_winner:
-            ctx.set_parameter_source(self.name, source)
             if self.expose_value:
                 ctx.params[self.name] = value
                 ctx._param_default_explicit[self.name] = self._default_explicit
+        elif existing_source is not None:
+            # ``process_value`` should observe the current parameter's source,
+            # but a losing parameter must not replace the source of the
+            # already-winning value in the slot.
+            ctx.set_parameter_source(self.name, existing_source)
         elif existing_source is None:
             # Nothing has claimed the slot yet. Record at least our source so downstream
             # lookups don't return ``None``.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -774,6 +774,21 @@ def test_parameter_source(runner, option_args, invoke_args, expect):
     assert rv.return_value == expect
 
 
+def test_parameter_source_available_during_type_conversion(runner):
+    class Source(click.ParamType):
+        def convert(self, value, param, ctx):
+            return ctx.get_parameter_source(param.name)
+
+    @click.command()
+    @click.option("--option", default="value", type=Source())
+    def cli(option):
+        click.echo(option.name)
+
+    rv = runner.invoke(cli)
+
+    assert rv.output == "DEFAULT\n"
+
+
 def test_propagate_opt_prefixes():
     parent = click.Context(click.Command("test"))
     parent._opt_prefixes = {"-", "--", "!"}


### PR DESCRIPTION
## Summary

- expose the current parameter source before type conversion runs
- restore the previous winning source when a competing parameter loses slot arbitration
- add a regression test for `get_parameter_source()` inside `ParamType.convert`

## Why

In Click 8.4, source assignment moved after `process_value()` to support the newer shared-slot arbitration logic. That means custom parameter types can no longer inspect the source during `convert()`, and defaults now appear as `None` instead of `ParameterSource.DEFAULT`.

This keeps the 8.4 arbitration behavior while restoring the pre-8.4 visibility guarantee during type conversion.

Closes #3458

## Validation

- `python -m pytest tests/test_context.py tests/test_defaults.py -q`
- `python -m pytest -q`