### PR TITLE
Fix indentation on quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -142,17 +142,17 @@ and registered with a group later with `group.add_command()`. This could be used
 modules.
 
 ```{code-block} python
-    @click.command()
-    def greet():
-        click.echo("Hello, World!")
+@click.command()
+def greet():
+    click.echo("Hello, World!")
 ```
 
 ```{code-block} python
-    @click.group()
-    def group():
-        pass
+@click.group()
+def group():
+    pass
 
-    group.add_command(greet)
+group.add_command(greet)
 ```
 
 ## Adding Parameters


### PR DESCRIPTION
This PR fixes the indentation for two code blocks in the docs. They were accidentally indented due to the RST conversion (since RST required indentation). I checked other instances of {code-block} and the others seem fine.

<img width="935" height="408" alt="Screenshot 2026-05-18 at 10 08 30 AM" src="https://github.com/user-attachments/assets/aa025614-ebf3-41e9-bda4-0503b7370881" />
