### PR TITLE
apply Unix line endings for shell completion output for windows compat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 8.4.1
 
 Unreleased
 
+-   Zsh completion scripts parse correctly on Windows. :issue:`3277`
 
 
 Version 8.4.0

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -43,12 +43,13 @@ def shell_complete(
 
     comp = comp_cls(cli, ctx_args, prog_name, complete_var)
 
+    # Write bytes, otherwise Windows text stdout translates LF to CRLF and breaks.
     if instruction == "source":
-        echo(comp.source())
+        echo(comp.source().encode(), nl=False)
         return 0
 
     if instruction == "complete":
-        echo(comp.complete())
+        echo(comp.complete().encode())
         return 0
 
     return 1

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,3 +1,4 @@
+import io
 import textwrap
 import warnings
 from collections.abc import Mapping
@@ -11,6 +12,7 @@ from click.core import Group
 from click.core import Option
 from click.shell_completion import add_completion_class
 from click.shell_completion import CompletionItem
+from click.shell_completion import shell_complete
 from click.shell_completion import ShellComplete
 from click.types import Choice
 from click.types import File
@@ -368,6 +370,20 @@ def test_full_complete(runner, shell, env, expect):
     env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
     assert result.output == expect
+
+
+def test_source_uses_lf_line_endings(monkeypatch):
+    stdout = io.BytesIO()
+    stream = io.TextIOWrapper(stdout, encoding="utf-8", newline="\r\n")
+    monkeypatch.setattr("click.utils._default_text_stdout", lambda: stream)
+
+    cli = Group("cli", commands=[Command("a"), Command("b")])
+    assert shell_complete(cli, {}, "cli", "_CLI_COMPLETE", "zsh_source") == 0
+
+    stream.flush()
+    output = stdout.getvalue()
+    assert b"\r\n" not in output
+    assert b"\n" in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes shell completion installation on Windows where generated completion scripts could end up with CRLF line endings and fail to parse.

emits source and completions scripts through encoded bytes so the output stays LF-only and doesn't get converted to CRLF by Python.

Reimplements https://github.com/pallets/click/pull/3279

Fixes #3277

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
