### PR TITLE
Add all dev groups to default groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ exclude = [
 ]
 
 [tool.uv]
-default-groups = ["dev", "pre-commit", "tests", "typing"]
+default-groups = ["dev", "docs", "docs-auto", "gha-update", "pre-commit", "tests", "tests-random", "typing"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Contributors currently have to run "uv sync --all-groups" to get all the groups required for all the dev tools. Instead of requiring that, let's add all those groups to uv default groups.
The drawback is that the install could take much longer to bring down large packages, but it doesn't seem like any of the extra groups are too heavy.