### PR TITLE
fix: Skip flaky pager test on macOS with free-threaded Python 3.14t

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -12,6 +12,7 @@ from weakref import WeakKeyDictionary
 
 CYGWIN = sys.platform.startswith("cygwin")
 WIN = sys.platform.startswith("win")
+MAC = sys.platform == "darwin"
 auto_wrap_for_ansi: t.Callable[[t.TextIO], t.TextIO] | None = None
 _ansi_re = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ import pytest
 
 import click._termui_impl
 import click.utils
+from click._compat import MAC
 from click._compat import WIN
 from click._utils import UNSET
 
@@ -309,6 +310,10 @@ EchoViaPagerTest = namedtuple(
 
 
 @pytest.mark.skipif(WIN, reason="Different behavior on windows.")
+@pytest.mark.skipif(
+    MAC and sys.version_info >= (3, 13) and sys._is_gil_enabled(),
+    reason="Generator exception tests are flaky in Python 3.14t on macOS.",
+)
 @pytest.mark.parametrize(
     "pager_cmd", ["cat", "cat ", " cat ", "less", " less", " less "]
 )


### PR DESCRIPTION
Temporarily fixes flaky test failure for `test_echo_via_pager` on macOS with 3.14t (free-threading) by skipping them for macOS + Python 3.14t combination until we figure out how to make the test result consistently pass when `test_echo_via_pager` and `test_stream_lifecycle` are running in parallel. 

fixes #2899 
