### PR TITLE
shell autocomplete uses normalize_choice() 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 8.4.1
 Unreleased
 
 -   Zsh completion scripts parse correctly on Windows. :issue:`3277`
+-   Shell completion of `Choice` `Enum` values produces a valid completion
+    result. :issue:`3015`
 
 
 Version 8.4.0

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -408,8 +408,7 @@ class Choice(ParamType[ParamTypeValue], t.Generic[ParamTypeValue]):
         """
         from click.shell_completion import CompletionItem
 
-        str_choices = map(str, self.choices)
-
+        str_choices = [self.normalize_choice(choice, ctx) for choice in self.choices]
         if self.case_sensitive:
             matched = (c for c in str_choices if c.startswith(incomplete))
         else:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -473,7 +473,8 @@ def test_context_settings(runner):
     assert result.output == "plain,a\nplain,b\n"
 
 
-@pytest.mark.parametrize(("value", "expect"), [(False, ["Au", "al"]), (True, ["al"])])
+# case_sensitive=False normalizes values to lowercase, matching remains case insensitive
+@pytest.mark.parametrize(("value", "expect"), [(False, ["au", "al"]), (True, ["al"])])
 def test_choice_case_sensitive(value, expect):
     cli = Command(
         "cli",


### PR DESCRIPTION
Shell completion for `Choice` with enum types doesn't work. When using `Choice(MyEnum)`, autocomplete suggests `"MyEnum.foo"` instead of `"foo"`, which is the actual accepted value. (#3015) I've changed shell_complete() to use normalize_choice() instead of simply converting choices to strings like in https://github.com/pallets/click/pull/3017, this does fail the test_choice_case_sensitive() test though.

 I can fix the enum autocomplete bug, but there's a decision to make:

A)  Manually handle enums, preserve original case  
- `test_choice_case_sensitive` passes as is
- Autocomplete doesn't respect `normalize_choice()` overrides

B) Use `normalize_choice()` for consistency  (current approach)
- Requires updating test: `["Au", "al"]` to `["au", "al"]` when `case_sensitive=False`
- Autocomplete is con sistent with other text behavior

I can amend the current approach to update the test I've just left a note for now! 😃

Closes #3015