### PR TITLE
Fix CliRunner.invoke crash when command uses echo_via_pager

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ Version 8.4.1
 
 Unreleased
 
+-   Fix ``ValueError: I/O operation on closed file`` raised by
+    ``CliRunner.invoke`` when the command uses ``echo_via_pager``.
+    The ``MaybeStripAnsi`` wrapper introduced for ``get_pager_file``
+    closed the underlying ``sys.stdout.buffer`` on garbage
+    collection. :issue:`3449`
+
 
 Version 8.4.0
 -------------

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -439,16 +439,30 @@ def get_pager_file(color: bool | None = None) -> t.Generator[t.TextIO, None, Non
         # Split streams by capabilities rather than the abstract TextIO /
         # BinaryIO annotations: buffered text streams can be unwrapped to bytes,
         # while text-only streams are yielded as-is.
+        wrapper: MaybeStripAnsi | None = None
         if _has_binary_buffer(stream):
             # Text stream backed by a binary buffer.
-            stream = MaybeStripAnsi(stream.buffer, color=color, encoding=encoding)
+            wrapper = MaybeStripAnsi(stream.buffer, color=color, encoding=encoding)
+            stream = wrapper
         elif isinstance(stream, t.BinaryIO):
             # Binary stream
-            stream = MaybeStripAnsi(stream, color=color, encoding=encoding)
+            wrapper = MaybeStripAnsi(stream, color=color, encoding=encoding)
+            stream = wrapper
         try:
             yield stream
         finally:
             stream.flush()
+            if wrapper is not None:
+                # TextIOWrapper.close (invoked on garbage collection) also
+                # closes the underlying buffer. When the buffer is
+                # sys.stdout.buffer (the _nullpager path), that breaks any
+                # later writes to sys.stdout -- notably CliRunner.invoke's
+                # final sys.stdout.flush(). Detach the wrapper here so the
+                # buffer's lifetime stays with whoever produced it.
+                try:
+                    wrapper.detach()
+                except ValueError:
+                    pass
 
 
 @contextlib.contextmanager

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -818,6 +818,54 @@ def test_get_pager_file_nullpager_keeps_stringio_stream(monkeypatch):
     assert created[0].getvalue() == styled_text
 
 
+def test_get_pager_file_nullpager_keeps_buffer_open(monkeypatch):
+    """The wrapper around ``stream.buffer`` must not close the buffer on exit.
+
+    Regression test for #3449: ``CliRunner.invoke`` calls
+    ``sys.stdout.flush()`` after the command returns, which raised
+    ``ValueError: I/O operation on closed file`` because the
+    ``MaybeStripAnsi`` wrapper closed ``sys.stdout.buffer`` on garbage
+    collection.
+    """
+    buffer = io.BytesIO()
+
+    class TextStreamWithBuffer(io.TextIOWrapper):
+        pass
+
+    text_stream = TextStreamWithBuffer(buffer, encoding="utf-8", write_through=True)
+
+    monkeypatch.setattr(
+        click._termui_impl, "_default_text_stdout", lambda: text_stream
+    )
+    monkeypatch.setattr(
+        click._termui_impl, "isatty", lambda stream: stream is not sys.stdin
+    )
+
+    with click.get_pager_file(color=False) as pager:
+        pager.write("hello\n")
+
+    assert not buffer.closed
+    text_stream.write("after\n")
+    text_stream.flush()
+    assert buffer.getvalue() == b"hello\nafter\n"
+
+
+def test_echo_via_pager_with_clirunner(runner):
+    """``echo_via_pager`` must not break ``CliRunner.invoke``'s post-call flush.
+
+    Regression test for #3449.
+    """
+
+    @click.command()
+    def cli():
+        click.echo_via_pager("paged output\n")
+
+    result = runner.invoke(cli)
+    assert result.exception is None
+    assert result.exit_code == 0
+    assert "paged output" in result.output
+
+
 def test_get_pager_file_flushes_stream_on_exception(monkeypatch):
     """Exceptions should still flush the yielded stream in ``finally``."""
 


### PR DESCRIPTION
Closes #3449.

In 8.4 `get_pager_file` wraps the pager stream's underlying binary buffer with a `TextIOWrapper` subclass (`MaybeStripAnsi`). On the no-tty `_nullpager` path that buffer is `sys.stdout.buffer`. When the wrapper is garbage collected after `echo_via_pager` returns, `TextIOWrapper.close` closes the wrapped buffer along with it, so the next call to `sys.stdout.flush()` in `CliRunner.invoke` raises `ValueError: I/O operation on closed file`.

Repro from the issue:

```python
from click import command, echo_via_pager
from click.testing import CliRunner

@command()
def cli():
    echo_via_pager("Hello, Click!")

CliRunner().invoke(cli)
```

Bisects to c69643b ("Add file-like pager: `click.get_pager_file()`", #1572) which introduced `MaybeStripAnsi`. The same trace is hit in Fedora's click 8.4 build (189 errors, all `ValueError: I/O operation on closed file`) and in Software Heritage's swh-storage test suite.

Fix: detach the wrapper from its buffer in the `finally` of `get_pager_file`, so the buffer's lifetime stays with whoever produced it. The pipe/tempfile paths already manage their own stream lifetimes in their own `finally` blocks, so detaching is safe there too.

Two regression tests in `tests/test_termui.py`:

- `test_get_pager_file_nullpager_keeps_buffer_open`: monkeypatches `_default_text_stdout` to a `TextIOWrapper` over an in-memory `BytesIO`, runs `get_pager_file` to completion, and asserts the buffer is still writable afterwards.
- `test_echo_via_pager_with_clirunner`: the exact CliRunner repro from the issue, asserting `result.exception is None`.

`pytest tests/` shows 1624 passed, 25 skipped (3.25s), no regressions.
