### PR TITLE
Fix Context.get_parameter_source returning None inside ParamType.convert

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Version 8.4.1
 
 Unreleased
 
+-   Fix ``Context.get_parameter_source`` returning ``None`` when
+    called from a custom ``ParamType.convert``. The source is now
+    recorded before ``process_value`` runs. :issue:`3458`
+
 
 Version 8.4.0
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2609,6 +2609,13 @@ class Parameter(ABC):
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
 
+            # Record the source before invoking ``process_value`` so that a
+            # custom ``ParamType.convert`` can read it via
+            # ``ctx.get_parameter_source`` during conversion. The arbitration
+            # block below restores the prior source if this parameter loses
+            # the slot. Refs: https://github.com/pallets/click/issues/3458
+            ctx.set_parameter_source(self.name, source)
+
             # Display a deprecation warning if necessary.
             if (
                 self.deprecated
@@ -2654,14 +2661,17 @@ class Parameter(ABC):
         )
 
         if is_winner:
-            ctx.set_parameter_source(self.name, source)
+            # Source already set above before ``process_value``.
             if self.expose_value:
                 ctx.params[self.name] = value
                 ctx._param_default_explicit[self.name] = self._default_explicit
-        elif existing_source is None:
-            # Nothing has claimed the slot yet. Record at least our source so downstream
-            # lookups don't return ``None``.
-            ctx.set_parameter_source(self.name, source)
+        elif existing_source is not None:
+            # Lost the slot and another parameter had already claimed it;
+            # restore that parameter's source.
+            ctx.set_parameter_source(self.name, existing_source)
+        # If neither winner nor existing_source, the tentative set above
+        # remains, matching the prior behaviour of recording our source so
+        # downstream lookups don't return ``None``.
 
         return value, args
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -774,6 +774,56 @@ def test_parameter_source(runner, option_args, invoke_args, expect):
     assert rv.return_value == expect
 
 
+def test_parameter_source_available_in_convert(runner):
+    """``ParamType.convert`` can read ``ctx.get_parameter_source`` for the
+    parameter being converted.
+
+    Regression test for #3458: 8.4 deferred the call to
+    ``set_parameter_source`` until after ``process_value``, so a custom
+    ``ParamType.convert`` saw ``None``.
+    """
+    seen: dict[str, ParameterSource | None] = {}
+
+    class RecordSource(click.ParamType):
+        name = "record_source"
+
+        def convert(self, value, param, ctx):
+            seen[param.name] = ctx.get_parameter_source(param.name)
+            return value
+
+    @click.command()
+    @click.option("--from-default", type=RecordSource(), default="d")
+    @click.option("--from-cli", type=RecordSource())
+    def cli(from_default, from_cli):
+        pass
+
+    result = runner.invoke(cli, ["--from-cli", "x"])
+    assert result.exit_code == 0
+    assert seen["from_default"] is ParameterSource.DEFAULT
+    assert seen["from_cli"] is ParameterSource.COMMANDLINE
+
+
+def test_parameter_source_available_in_convert_envvar(runner):
+    """``ParameterSource.ENVIRONMENT`` is visible to ``convert`` too."""
+    seen: dict[str, ParameterSource | None] = {}
+
+    class RecordSource(click.ParamType):
+        name = "record_source"
+
+        def convert(self, value, param, ctx):
+            seen[param.name] = ctx.get_parameter_source(param.name)
+            return value
+
+    @click.command()
+    @click.option("--name", type=RecordSource(), envvar="MY_NAME")
+    def cli(name):
+        pass
+
+    result = runner.invoke(cli, [], env={"MY_NAME": "from-env"})
+    assert result.exit_code == 0
+    assert seen["name"] is ParameterSource.ENVIRONMENT
+
+
 def test_propagate_opt_prefixes():
     parent = click.Context(click.Command("test"))
     parent._opt_prefixes = {"-", "--", "!"}


### PR DESCRIPTION
Closes #3458.

In 8.4, `Parameter.handle_parse_result` was reworked (#3404, 0f71fe7) to arbitrate the parameter slot after `process_value` runs, and the call to `ctx.set_parameter_source` was moved to after that arbitration step. As a side effect, a custom `ParamType.convert` that reads `ctx.get_parameter_source(param.name)` during conversion now sees `None` instead of the actual source. In 8.3.3 the source was set right after `consume_value`, before `process_value`, so convert could read it.

Repro from the issue (`pip install click==8.4.0`):

```python
import click

class Source(click.ParamType):
    name = "source"
    def convert(self, value, param, ctx):
        return {"value": value, "source": ctx.get_parameter_source(param.name)}

@click.command
@click.option("--default", type=Source(), default="/tmp/file")
@click.option("--nodefault", type=Source())
def main(default, nodefault):
    print("default:", default)
    print("nodefault:", nodefault)
```

```
$ python source.py
default: {'value': '/tmp/file', 'source': None}        # was DEFAULT in 8.3.3
$ python source.py --default cli --nodefault cli
default: {'value': 'cli', 'source': None}              # was COMMANDLINE in 8.3.3
nodefault: {'value': 'cli', 'source': None}
```

Fix: record the source right after `consume_value` so `convert` can read it, and restore the previous owner's source if this parameter loses the arbitration. The arbitration outcome (`is_winner`, what ends up in `ctx.params`, what ends up in `_param_default_explicit`) is unchanged. The post-arbitration `set_parameter_source` calls become a no-op for the winner (already set) and a restore for the loser. The "nothing has claimed the slot yet" fallback from #3403 is preserved by the tentative set.

Two regression tests in `tests/test_context.py`:

- `test_parameter_source_available_in_convert`: covers `DEFAULT` (no arg) and `COMMANDLINE` (`--from-cli x`) inside `convert`.
- `test_parameter_source_available_in_convert_envvar`: same with `ENVIRONMENT` (`envvar="MY_NAME"` set via runner env).

`pytest tests/` shows 1624 passed, 25 skipped (2.37s), no regressions. The existing dual-flag/feature-switch tests from #3404 still pass.
