### PR TITLE
Fix get_parameter_source() returning None in type.convert() and callbacks

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2609,6 +2609,12 @@ class Parameter(ABC):
         with augment_usage_errors(ctx, param=self):
             value, source = self.consume_value(ctx, opts)
 
+            # Register the source early so that ParamType.convert() and option
+            # callbacks can call ctx.get_parameter_source() and receive the
+            # correct value.  The arbitration block below may restore the
+            # previous winner's source if this parameter loses the slot.
+            ctx.set_parameter_source(self.name, source)
+
             # Display a deprecation warning if necessary.
             if (
                 self.deprecated
@@ -2658,10 +2664,13 @@ class Parameter(ABC):
             if self.expose_value:
                 ctx.params[self.name] = value
                 ctx._param_default_explicit[self.name] = self._default_explicit
-        elif existing_source is None:
-            # Nothing has claimed the slot yet. Record at least our source so downstream
-            # lookups don't return ``None``.
-            ctx.set_parameter_source(self.name, source)
+        elif existing_source is not None:
+            # Another parameter already won the slot.  We set our source early
+            # (before process_value) so restore the winner's source now.
+            ctx.set_parameter_source(self.name, existing_source)
+        # else: existing_source is None — our early set stands; we are the first
+        # to claim the slot even though expose_value is False or we lost on
+        # ctx.params but the source slot was empty.
 
         return value, args
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -774,6 +774,60 @@ def test_parameter_source(runner, option_args, invoke_args, expect):
     assert rv.return_value == expect
 
 
+def test_get_parameter_source_available_in_type_convert(runner):
+    """get_parameter_source() must return a non-None value inside ParamType.convert().
+
+    Regression test for https://github.com/pallets/click/issues/3458:
+    click 8.4 deferred ctx.set_parameter_source until after process_value(),
+    so ctx.get_parameter_source() returned None when called from convert().
+    """
+
+    class CapturingType(click.ParamType):
+        name = "capturing"
+
+        def convert(self, value, param, ctx):
+            self.captured_source = ctx.get_parameter_source(param.name)
+            return value
+
+    cap = CapturingType()
+
+    @click.command()
+    @click.option("--opt", type=cap, default="default_val")
+    def cli(opt):
+        pass
+
+    # Default source: should be ParameterSource.DEFAULT, not None.
+    runner.invoke(cli, [])
+    assert cap.captured_source == ParameterSource.DEFAULT
+
+    # CLI source: should be ParameterSource.COMMANDLINE, not None.
+    runner.invoke(cli, ["--opt", "cli_val"])
+    assert cap.captured_source == ParameterSource.COMMANDLINE
+
+
+def test_get_parameter_source_available_in_callback(runner):
+    """get_parameter_source() must return a non-None value inside option callbacks.
+
+    Regression test for https://github.com/pallets/click/issues/3458.
+    """
+    captured = {}
+
+    def cb(ctx, param, value):
+        captured["source"] = ctx.get_parameter_source(param.name)
+        return value
+
+    @click.command()
+    @click.option("--opt", default="default_val", callback=cb)
+    def cli(opt):
+        pass
+
+    runner.invoke(cli, [])
+    assert captured["source"] == ParameterSource.DEFAULT
+
+    runner.invoke(cli, ["--opt", "cli_val"])
+    assert captured["source"] == ParameterSource.COMMANDLINE
+
+
 def test_propagate_opt_prefixes():
     parent = click.Context(click.Command("test"))
     parent._opt_prefixes = {"-", "--", "!"}


### PR DESCRIPTION
## Summary

Fixes #3458

In 8.4.0, `handle_parse_result()` was refactored to support feature-switch group arbitration (#3403). As part of that refactor, `ctx.set_parameter_source()` was moved to *after* `process_value()` completes. This broke any `ParamType.convert()` implementation or option callback that calls `ctx.get_parameter_source(param.name)` — they received `None` instead of the actual source.

This also causes pallets/flask#6025 (`FLASK_DEBUG` env var stopped working in click 8.4), where Flask's `_set_debug` callback relies on `get_parameter_source()` to distinguish default values from user-set ones.

## Root cause

```
consume_value()              ← source determined here
process_value()              ← type.convert() / callback called here
  └─ type.convert(value, param, ctx)
       └─ ctx.get_parameter_source(param.name)  ← returns None! ❌
ctx.set_parameter_source()  ← source registered here (too late)
```

## Fix

Set the source immediately after `consume_value()`, before `process_value()` is called. If the parameter subsequently loses feature-switch arbitration (another parameter with a more explicit source already claimed the slot), restore the winner's source.

```
consume_value()              ← source determined here
ctx.set_parameter_source()  ← registered early ✅
process_value()
  └─ type.convert(value, param, ctx)
       └─ ctx.get_parameter_source(param.name)  ← returns correct source ✅
arbitration                 ← restore winner's source if we lose
```

The arbitration semantics for `ctx.params` are unchanged.

## Test plan

- [ ] `test_get_parameter_source_available_in_type_convert` — asserts `convert()` sees `DEFAULT` for default invocation and `COMMANDLINE` for CLI invocation
- [ ] `test_get_parameter_source_available_in_callback` — same check for option callbacks
- [ ] All existing `test_parameter_source` parametrized cases still pass
- [ ] Feature-switch group tests (if any) still pass