### PR TITLE
Added flake8-import-conventions and rule for typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,12 @@ select = [
     "I",  # isort
     "UP",  # pyupgrade
     "W",  # pycodestyle warning
+    "ICN", #flake8-import-conventions (ICN)
 ]
+
+[tool.ruff.lint.flake8-import-conventions.aliases]
+# Declare the default aliases.
+typing = "t"
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
Added flake8-import-conventions linter to ruff and rule to ensure `typing` library is imported as `t`.

Addresses issue #3161

Attached is diff of changed core.py showing `typing` imported as `z` instead of `t` and the core.py file with changes.  When these changes are applied, the command `pre-commit run --all-files` shows the following failure:
[core.py](https://github.com/user-attachments/files/28032967/core.py)
[diff.txt](https://github.com/user-attachments/files/28032972/diff.txt)



```shell
% pre-commit run --all-files        
ruff check...............................................................Failed
- hook id: ruff-check
- exit code: 1

ICN001 `typing` should be imported as `t`
  --> src/click/core.py:9:18
   |
 7 | import os
 8 | import sys
 9 | import typing as z
   |                  ^
10 | from abc import ABC
11 | from abc import abstractmethod
   |
help: Alias `typing` to `t`

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).

ruff format..............................................................Passed
uv-lock..................................................................Passed
codespell................................................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
fix utf-8 byte order marker..............................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
```

Kudos to @kevin-brown, @yurishevtsov, @Rowlando13, Alex Smith and others at #PyConUS 2026