### PR TITLE
fix: avoid overwriting shared option callback results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.5.0
 
 Unreleased
 
+-   Avoid processing uninvoked sibling options that share a parameter name
+    after an invoked option has already produced a callback result. :issue:`2786`
+
 
 Version 8.4.1
 -------------

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -148,6 +148,19 @@ def iter_params_for_processing(
     This behavior and its effect on callback evaluation is detailed at:
     https://click.palletsprojects.com/en/stable/advanced/#callback-evaluation-order
     """
+    name_counts: dict[str, int] = {}
+
+    for param in declaration_order:
+        if not param.name:
+            continue
+
+        name_counts[param.name] = name_counts.get(param.name, 0) + 1
+
+    invoked_shared_names = {
+        param.name
+        for param in invocation_order
+        if param.name and name_counts.get(param.name, 0) > 1
+    }
 
     def sort_key(item: Parameter) -> tuple[bool, float]:
         try:
@@ -157,7 +170,13 @@ def iter_params_for_processing(
 
         return not item.is_eager, idx
 
-    return sorted(declaration_order, key=sort_key)
+    return [
+        param
+        for param in sorted(declaration_order, key=sort_key)
+        if param in invocation_order
+        or not param.name
+        or param.name not in invoked_shared_names
+    ]
 
 
 class ParameterSource(enum.IntEnum):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1613,6 +1613,45 @@ def test_default_dual_option_callback(runner, default, args, expected):
 
 
 @pytest.mark.parametrize(
+    ("args", "expected", "fetch_calls"),
+    [
+        (["--fetch"], "custom=foo\n", 1),
+        (["--custom", "bar"], "custom=bar\n", 0),
+        (["--custom", "bar", "--fetch"], "custom=foo\n", 1),
+        (["--fetch", "--custom", "bar"], "custom=bar\n", 0),
+        ([], "custom=None\n", 0),
+    ],
+)
+def test_shared_dest_flag_callback_value_not_overwritten(
+    runner, args, expected, fetch_calls
+):
+    sentinel = "$_fetch"
+    calls = []
+
+    def fetch():
+        calls.append("fetch")
+        return "foo"
+
+    def callback(ctx, param, value):
+        if value == sentinel:
+            return fetch()
+
+        return value
+
+    @click.command()
+    @click.option("--custom", "custom")
+    @click.option("--fetch", "custom", flag_value=sentinel, callback=callback)
+    def cli(custom):
+        click.echo(f"custom={custom}")
+
+    result = runner.invoke(cli, args)
+
+    assert result.output == expected
+    assert len(calls) == fetch_calls
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
     ("flag_value", "envvar_value", "expected"),
     [
         # The envvar match exactly the flag value and is case-sensitive.


### PR DESCRIPTION
Fixes #2786

## Summary

When two options share the same parameter name, such as `--custom` and `--fetch`, invoking only `--fetch` could run its callback and then have that callback result overwritten by the uninvoked sibling option. In the reported case this exposed the internal sentinel value as `$_fetch`.

This updates parameter processing so that, once one option with a shared parameter name is invoked, uninvoked siblings with that same name are not processed later. Shared-name options with no invocation still follow the existing default handling, and multiple explicitly invoked options keep the existing invocation-order behavior.

I also added focused regression coverage for `--fetch`, `--custom`, both invocation orders, and the no-argument default case, plus a changelog entry.

## Testing

- `uv run pytest tests/test_options.py -k shared_dest_flag_callback_value_not_overwritten`
  - Before the code change, the new regression failed for `--fetch` with `custom=$_fetch`.
  - After the code change, it passes.
- `uv run pytest tests/test_options.py tests/test_basic.py`
- `uv run pytest`
- `uv run ruff check src/click/core.py tests/test_options.py`
- `uv run ruff format --check src/click/core.py tests/test_options.py`
- `uv run tox r`
  - Local gap: this fails only in the `py3.14t` and `stress-py3.14t` environments on `tests/test_utils.py::test_echo_via_pager`. The same full `py3.14t` environment also fails on a clean `origin/main` checkout in my local setup, while the isolated `uv run tox r -e py3.14t -- tests/test_utils.py::test_echo_via_pager` command passes on clean `origin/main`.
