### PR TITLE
Fix echoing empty binary messages

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -294,11 +294,11 @@ def echo(
         out = message
 
     if nl:
-        out = out or ""
-        if isinstance(out, str):
-            out += "\n"
+        if isinstance(out, (bytes, bytearray)):
+            out = out + b"\n"
         else:
-            out += b"\n"
+            out = out or ""
+            out += "\n"
 
     if not out:
         file.flush()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from contextlib import nullcontext
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial
+from io import BytesIO
 from io import StringIO
 from unittest.mock import patch
 
@@ -90,6 +91,21 @@ def test_echo(runner):
     with runner.isolation() as outstreams:
         click.echo(bytearray(b"\x1b[31mx\x1b[39m"), nl=False)
         assert outstreams[0].getvalue() == b"\x1b[31mx\x1b[39m"
+
+
+@pytest.mark.parametrize("message_type", [bytes, bytearray])
+def test_echo_empty_bytes(message_type, runner):
+    with runner.isolation() as outstreams:
+        click.echo(message_type())
+        assert outstreams[0].getvalue().replace(b"\r\n", b"\n") == b"\n"
+
+    f = BytesIO()
+    click.echo(message_type(), file=f)
+    assert f.getvalue() == b"\n"
+
+    f = BytesIO()
+    click.echo(message_type(), nl=False, file=f)
+    assert f.getvalue() == b""
 
 
 def test_echo_custom_file():


### PR DESCRIPTION
Fixes #3487

## Summary
- preserve binary message types when adding a trailing newline in `click.echo`
- cover empty `bytes` and `bytearray` output to default and binary streams

## Tests
- `uv run --frozen python -m pytest tests/test_utils.py -k "echo" -q`
- `uv run --frozen python -m pytest tests/test_utils.py -q`
- `uv run --frozen python -m pytest -q`
- `uv run --frozen ruff check src\click\utils.py tests\test_utils.py`