### PR TITLE
Handle empty bytes in echo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   Zsh completion scripts parse correctly on Windows. :issue:`3277`
 -   Shell completion of `Choice` `Enum` values produces a valid completion
     result. :issue:`3015`
+-   Fix empty byte-string handling in echo. :issue:`3487`
+
 
 Version 8.4.0
 -------------

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -232,7 +232,7 @@ class KeepOpenFile:
 
 
 def echo(
-    message: t.Any | None = None,
+    message: object = None,
     file: t.IO[t.Any] | None = None,
     nl: bool = True,
     err: bool = False,
@@ -287,14 +287,15 @@ def echo(
         if file is None:
             return
 
-    # Convert non bytes/text into the native string type.
-    if message is not None and not isinstance(message, (str, bytes, bytearray)):
-        out: str | bytes | bytearray | None = str(message)
-    else:
-        out = message
+    match message:
+        case str() | bytes() | bytearray():
+            out = message
+        case None:
+            out = ""
+        case _:
+            out = str(message)
 
     if nl:
-        out = out or ""
         if isinstance(out, str):
             out += "\n"
         else:
@@ -310,7 +311,6 @@ def echo(
     # would expect. Eg: you can write to StringIO for other cases.
     if isinstance(out, (bytes, bytearray)):
         binary_file = _find_binary_writer(file)
-
         if binary_file is not None:
             file.flush()
             binary_file.write(out)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from contextlib import nullcontext
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial
+from io import BytesIO
 from io import StringIO
 from unittest.mock import patch
 
@@ -96,6 +97,10 @@ def test_echo_custom_file():
     f = StringIO()
     click.echo("hello", file=f)
     assert f.getvalue() == "hello\n"
+
+    b = BytesIO()
+    click.echo(b"", b)
+    assert b.getvalue() == b"\n"
 
 
 def test_echo_no_streams(monkeypatch, runner):


### PR DESCRIPTION
Previously, an empty byte string could cause an exception if `nl=True`.

This PR narrows the type scope of `out`, to `bytes() | bytearray() | str` and handles all cases exhaustively.

We also change from `typing.Any`, which effectively disables typing for a variable, to `object`, which is more restrictive. See  https://mypy.readthedocs.io/en/latest/dynamic_typing.html#any-vs-object for more.

fixes #3487

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
