### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -449,6 +449,12 @@ def get_pager_file(color: bool | None = None) -> t.Generator[t.TextIO, None, Non
             yield stream
         finally:
             stream.flush()
+            # MaybeStripAnsi wraps an existing buffer (e.g. sys.stdout.buffer).
+            # io.TextIOWrapper takes ownership of the buffer and closes it on
+            # GC, which would silently close sys.stdout. Detach first so the
+            # buffer is not closed when this wrapper is collected.
+            if isinstance(stream, MaybeStripAnsi):
+                stream.detach()
 
 
 @contextlib.contextmanager

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -747,3 +747,16 @@ def test_capture_pytest_matrix(
     # Click output is not leaking into Pytest.
     assert "inside-stdout" not in captured.out
     assert "inside-stderr" not in captured.err
+
+
+def test_echo_via_pager_in_cli_runner() -> None:
+    """CliRunner should not get 'I/O operation on closed file' after echo_via_pager."""
+
+    @click.command()
+    def cli() -> None:
+        click.echo_via_pager("Hello, pager!")
+
+    runner = CliRunner()
+    result = runner.invoke(cli)
+    assert result.exit_code == 0
+    assert "Hello, pager!" in result.output


### PR DESCRIPTION
Fixes #3449

## Root cause

`MaybeStripAnsi` subclasses `io.TextIOWrapper` and wraps `sys.stdout.buffer`. `io.TextIOWrapper` takes ownership of its underlying buffer and closes it when the wrapper is closed or garbage collected.

After `echo_via_pager` returns and the `with get_pager_file()` context exits, the `MaybeStripAnsi` instance goes out of scope. When Python GC collects it, `TextIOWrapper.__del__` closes the buffer — which effectively closes `sys.stdout`. Then `CliRunner.invoke`'s `finally` block calls `sys.stdout.flush()` and gets `ValueError: I/O operation on closed file`.

## Fix

After `stream.flush()` in `get_pager_file`'s `finally` block, call `stream.detach()` when the stream is a `MaybeStripAnsi`. `detach()` dissociates the `TextIOWrapper` from the buffer without closing it, so `sys.stdout.buffer` (and `sys.stdout`) remain open.

```python
finally:
    stream.flush()
    if isinstance(stream, MaybeStripAnsi):
        stream.detach()
```

## Test

Added `test_echo_via_pager_in_cli_runner` to `tests/test_testing.py` — a minimal reproduction of the reported bug that previously crashed with `ValueError`.