### PR TITLE
Pre-8.4.2 release changelog and doc fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,8 @@ Released 2026-05-21
 -   ``get_parameter_source()`` is available during eager callbacks and type
     conversion again. :issue:`3458` :pr:`3484`
 -   Zsh completion scripts parse correctly on Windows. :issue:`3277` :pr:`3466`
--   Shell completion of `Choice` `Enum` values produces a valid completion
-    result. :issue:`3015`
+-   Shell completion of ``Enum`` values used as ``Choice`` options produces a
+    valid completion result. :issue:`3015` :pr:`3471`
 -   Fix empty byte-string handling in echo. :issue:`3487` :pr:`3493`
 -   Fix closed file error with ``echo_via_pager``. :issue:`3449` :pr:`3482`
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Released 2026-05-21
     valid completion result. :issue:`3015` :pr:`3471`
 -   Fix empty byte-string handling in echo. :issue:`3487` :pr:`3493`
 -   Fix closed file error with ``echo_via_pager``. :issue:`3449` :pr:`3482`
+-   Fix ``open_url`` on Windows when the file path contains spaces.
+    :issue:`2994` :pr:`3478`
 
 
 Version 8.4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,8 +26,8 @@ Released 2026-05-21
 -   Zsh completion scripts parse correctly on Windows. :issue:`3277` :pr:`3466`
 -   Shell completion of `Choice` `Enum` values produces a valid completion
     result. :issue:`3015`
--   Fix empty byte-string handling in echo. :issue:`3487`
--   Fix closed file error with `echo_via_pager`. :issue:`3449`
+-   Fix empty byte-string handling in echo. :issue:`3487` :pr:`3493`
+-   Fix closed file error with ``echo_via_pager``. :issue:`3449` :pr:`3482`
 
 
 Version 8.4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Version 8.4.1
 Released 2026-05-21
 
 -   ``get_parameter_source()`` is available during eager callbacks and type
-    conversion again. :issue:`3458` :issue:`3484`
+    conversion again. :issue:`3458` :pr:`3484`
 -   Zsh completion scripts parse correctly on Windows. :issue:`3277` :pr:`3466`
 -   Shell completion of `Choice` `Enum` values produces a valid completion
     result. :issue:`3015`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,7 +79,7 @@ Released 2026-05-17
     :pr:`2969`
 -   Use :func:`os.startfile` on Windows to open URLs in :func:`open_url`,
     replacing the ``start`` built-in which cannot be invoked without
-    ``shell=True``. :issue:`3164` :pr:`3186`
+    ``shell=True``. :issue:`2868` :issue:`3164` :pr:`3186`
 -   Fix Fish shell completion errors when option help text contains newlines.
     :issue:`3043` :pr:`3126`
 -   Add :class:`NoSuchCommand` exception with suggestions for misspelled

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extlinks = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
 }
+myst_enable_extensions = ["attrs_block"]
 myst_heading_anchors = 3
 
 # HTML -----------------------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,8 @@
-#
+```{eval-rst}
+.. rst-class:: hide-header
+```
+
+# Welcome to Click
 
 ```{image} _static/click-name.svg
 :align: center

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,4 @@
-```{eval-rst}
-.. rst-class:: hide-header
-```
-
+{.hide-header}
 # Welcome to Click
 
 ```{image} _static/click-name.svg

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -430,8 +430,11 @@ def _pager_contextmanager(
 @contextlib.contextmanager
 def get_pager_file(color: bool | None = None) -> t.Generator[t.TextIO, None, None]:
     """Context manager.
+
     Yields a writable file-like object which can be used as an output pager.
-    .. versionadded:: 8.4
+
+    .. versionadded:: 8.4.0
+
     :param color: controls if the pager supports ANSI colors or not.  The
                   default is autodetection.
     """


### PR DESCRIPTION
Inconsistencies I spotted after 8.4.1 release:

- Missing PR references in changelog entries:
  - #3493
  - #3482
  - #3484
  - #3471
  - #3478
- Changelog style and formatting
- `.. versionadded::` admonition styling
- rST to Markdown rewrite format

This is a WIP PR that I will use along the `stable` branch development cycle and is to be merged before its release.

Before removing the `draft` status, review all changes in the pending release diff: https://github.com/pallets/click/compare/8.4.1...stable

Follow up on https://github.com/pallets/click/pull/3495.