### PR TITLE
Activate nightly workflow for random and stress tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,42 @@
+name: Nightly race tests
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  race-tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {name: Random 3.14, python: '3.14', tox: random}
+          - {name: Random 3.14t, python: '3.14t', tox: random}
+          - {name: Random 3.13, python: '3.13', tox: random}
+          - {name: Random 3.12, python: '3.12', tox: random}
+          - {name: Random 3.11, python: '3.11', tox: random}
+          - {name: Random 3.10, python: '3.10', tox: random}
+          - {name: Random Windows, python: '3.14', tox: random, os: windows-latest}
+          - {name: Random Mac, python: '3.14', tox: random, os: macos-latest}
+          - {name: Stress 3.14, python: '3.14', tox: stress-py3.14}
+          - {name: Stress 3.14t, python: '3.14t', tox: stress-py3.14t}
+          - {name: Stress Mac 3.14t, python: '3.14t', tox: stress-py3.14t, os: macos-latest}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+          prune-cache: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python }}
+      - run: uv run --locked --no-default-groups --group dev tox run
+        env:
+          TOX_ENV: ${{ matrix.tox }}


### PR DESCRIPTION
In https://github.com/pallets/click/pull/3139 we added stress tests and in https://github.com/pallets/click/pull/3151 we added randomization and parallel tests.

We decided to not activate them by default in https://github.com/pallets/click/pull/3151#issuecomment-3980528692 and rely on contributors diligence to run them by hand to catch regressions. In practice nobody does. I even often forget to run them on my own during my sessions, only focused on the task at hand.

I'd like to re-assess this decision in light of regressions that could have been caught if these test were active. See the following PRs:
- #3482
  Regression introduced in 8.4.0, could have been caught by `tests/test_stream_lifecycle.py`.
- #3499
  New stress test covering the root cause of #3470.
- #3470
  The bug exists because CI doesn't run tests in parallel.
- #2991
  The reason why stress test exist: *I originally only hit the race about once in 10k tries, so this seems difficult to test systematically.*.
- #3139
  Fix the regression from #2991, where only with the introduction of stress test keeps from recurring.
- #3238
  The random test already caught a leak nobody noticed via the default suite.

Also why even support parallel tests if we don't exercice them regularly? (ref: https://github.com/pallets/click/issues/2899)

Currently these tests adds ~15 minutes run-time. If you find this too long and invasive, I propose a compromise and run them nightly. But my preference would be to run them as part of the standard CI to incentivize contributors. And reduce surprises and and follow-up fixes.

Given the reversal in policy this change imply, I'm aiming for the next 8.5.0 minor release. I'm opening this PR as a way to discuss the best strategy forward.