### PR TITLE
docs: fix flag-pair separator and small typos in options guide

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -352,7 +352,7 @@ Use cases for this more explicit pattern include:
 * Shell aliases can set a flag, then an invocation can add a negation of the
   flag
 
-If a forward slash(`/`) is contained in your option name already, you can split
+If a forward slash (`/`) is contained in your option name already, you can split
 the parameters using `;`. In Windows `/` is commonly used as the prefix
 character.
 
@@ -709,7 +709,7 @@ Here are the rules used to parse environment variable values for flag options:
 ```{caution}
 For boolean flags with a pair of values, the only recognized environment variable is the one provided to the `envvar` argument.
 
-So an option defined as `--flag\--no-flag`, with a `envvar="FLAG"` parameter, there is no magical `NO_FLAG=<anything>` variable that is recognized. Only the `FLAG=<anything>` environment variable is recognized.
+So an option defined as `--flag/--no-flag`, with an `envvar="FLAG"` parameter, there is no magical `NO_FLAG=<anything>` variable that is recognized. Only the `FLAG=<anything>` environment variable is recognized.
 ```
 
 If the flag is activated, its value is set to `flag_value`. Otherwise, the value


### PR DESCRIPTION
Small documentation fixes in `docs/options.md`. In the environment-variables caution note, a flag pair was written with a backslash separator instead of the forward slash that Click actually uses; it now reads `--flag/--no-flag`, matching the rest of the page (for example `--shout/--no-shout`). The same sentence now reads "with an `envvar`" instead of "with a `envvar`". Earlier in the page, "forward slash(`/`)" gains a missing space ("forward slash (`/`)"). These are wording and typo fixes only, with no behavior or content changes. Per the PR template, an issue is not required for documentation typo fixes.