### PR TITLE
AI junk

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -8,6 +8,7 @@ import pdb
 import shlex
 import sys
 import tempfile
+import threading
 import typing as t
 from types import TracebackType
 
@@ -23,6 +24,8 @@ if t.TYPE_CHECKING:
     from .core import Command
 
 CaptureMode = t.Literal["sys", "fd"]
+
+_isolated_filesystem_lock = threading.RLock()
 
 
 class EchoingStdin:
@@ -718,19 +721,20 @@ class CliRunner:
         .. versionchanged:: 8.0
             Added the ``temp_dir`` parameter.
         """
-        cwd = os.getcwd()
-        dt = tempfile.mkdtemp(dir=temp_dir)
-        os.chdir(dt)
+        with _isolated_filesystem_lock:
+            cwd = os.getcwd()
+            dt = tempfile.mkdtemp(dir=temp_dir)
+            os.chdir(dt)
 
-        try:
-            yield dt
-        finally:
-            os.chdir(cwd)
+            try:
+                yield dt
+            finally:
+                os.chdir(cwd)
 
-            if temp_dir is None:
-                import shutil
+                if temp_dir is None:
+                    import shutil
 
-                try:
-                    shutil.rmtree(dt)
-                except OSError:
-                    pass
+                    try:
+                        shutil.rmtree(dt)
+                    except OSError:
+                        pass

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -3,6 +3,7 @@ import io
 import os
 import pdb
 import sys
+import threading
 from io import BytesIO
 
 import pytest
@@ -452,6 +453,62 @@ def test_isolated_runner_custom_tempdir(runner, tmp_path):
 
     assert os.path.exists(d)
     os.rmdir(d)
+
+
+def test_isolated_runner_serializes_threads(tmp_path):
+    runner_1 = CliRunner()
+    runner_2 = CliRunner()
+    first_entered = threading.Event()
+    first_may_exit = threading.Event()
+    second_entered = threading.Event()
+    errors = []
+    first_dir = ""
+    second_dir = ""
+
+    def first_worker():
+        nonlocal first_dir
+
+        try:
+            with runner_1.isolated_filesystem(temp_dir=tmp_path) as d:
+                first_dir = d
+                first_entered.set()
+
+                with open("first.txt", "w", encoding="utf-8") as f:
+                    f.write("first")
+
+                assert first_may_exit.wait(timeout=1)
+        except BaseException as e:
+            errors.append(e)
+
+    def second_worker():
+        nonlocal second_dir
+
+        try:
+            with runner_2.isolated_filesystem(temp_dir=tmp_path) as d:
+                second_dir = d
+                second_entered.set()
+
+                with open("second.txt", "w", encoding="utf-8") as f:
+                    f.write("second")
+        except BaseException as e:
+            errors.append(e)
+
+    thread_1 = threading.Thread(target=first_worker)
+    thread_2 = threading.Thread(target=second_worker)
+    thread_1.start()
+    assert first_entered.wait(timeout=1)
+    thread_2.start()
+    assert not second_entered.wait(timeout=0.2)
+    first_may_exit.set()
+    thread_1.join()
+    assert second_entered.wait(timeout=1)
+    thread_2.join()
+
+    if errors:
+        raise errors[0]
+
+    assert os.path.exists(os.path.join(first_dir, "first.txt"))
+    assert os.path.exists(os.path.join(second_dir, "second.txt"))
 
 
 def test_isolation_stderr_errors():


### PR DESCRIPTION
## Summary

Fix `CliRunner.isolated_filesystem()` so concurrent threads cannot race while swapping the process working directory.

The root cause is that `isolated_filesystem()` changes the global process `cwd` with `os.chdir()` and restores it later, but it does not synchronize that global mutation. Two threads entering the context at the same time can therefore stomp each other's working directory.

This change serializes the temporary `cwd` swap with a re-entrant lock and adds a regression test that verifies a second runner cannot enter its isolated filesystem until the first one exits.

Fixes #3501.

## Test plan

- `python -m pytest tests/test_testing.py -k isolated -q`
- `python -m pytest tests/test_testing.py -q`
- `python -m pytest tests/test_arguments.py::test_file_args tests/test_arguments.py::test_file_atomics tests/test_basic.py::test_file_option tests/test_shell_completion.py::test_files_closed tests/test_utils.py::test_open_file tests/test_utils.py::test_open_file_respects_ignore -q`
