### PR TITLE
AI junk

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -242,6 +242,10 @@ def test_path_surrogates(tmp_path, monkeypatch):
         click.File(mode="r", lazy=True),
     ],
 )
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 def test_file_surrogates(type, tmp_path):
     path = tmp_path / "\udcff"
 
@@ -254,6 +258,10 @@ def test_file_surrogates(type, tmp_path):
         type.convert(path, None, None)
 
 
+@pytest.mark.skipif(
+    not _non_utf8_filenames_supported(),
+    reason="The current OS or FS doesn't support non-UTF-8 filenames.",
+)
 def test_file_error_surrogates():
     message = FileError(filename="\udcff").format_message()
     assert message == "Could not open file '�': unknown error"


### PR DESCRIPTION
﻿Fixes pallets/click#2634.

## Summary

- Add the existing `_non_utf8_filenames_supported()` skip guard to `test_file_surrogates`.
- Add the same skip guard to `test_file_error_surrogates`.
- Keep the change scoped to `tests/test_types.py`; no runtime behavior changes.

## Validation

- Baseline on this Windows environment before the patch: `.venv\Scripts\python.exe -m pytest tests/test_types.py::test_path_surrogates tests/test_types.py::test_file_surrogates tests/test_types.py::test_file_error_surrogates -vv --tb=short` -> 4 passed.
- After patch: `.venv\Scripts\python.exe -m pytest tests/test_types.py::test_path_surrogates tests/test_types.py::test_file_surrogates tests/test_types.py::test_file_error_surrogates -vv --tb=short` -> 4 passed.
- Broader file check: `.venv\Scripts\python.exe -m pytest tests/test_types.py -q` -> 41 passed, 1 skipped.
- `git diff --check` passed.

## RepoHarness / MiMo experiment note

This PR was prepared during a RepoHarness runtime experiment driven by Xiaomi MiMo (`mimo-v2.5-pro`) through an OpenAI-compatible Chat Completions adapter. RepoHarness was constrained to the isolated local clone and `tests/test_types.py`, with trace/report evidence captured locally before this PR was opened.
