### PR TITLE
AI junk

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3296,8 +3296,8 @@ def test_flag_group_unset_vs_none_vs_explicit(
 
 
 def test_flag_group_competition_duplicate_option_name(runner):
-    """The same option name declared twice on the same command is a user
-    error.
+    """The same option name declared twice on the same command emits a
+    ``UserWarning`` flagging the duplicate.
     """
 
     @click.command()
@@ -3306,10 +3306,8 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match=r"--xyz is used more than once"):
+        runner.invoke(cli, [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #3476.

`test_flag_group_competition_duplicate_option_name` currently asserts on `result.exit_code == 1` and `isinstance(result.exception, UserWarning)`. That only holds when pytest converts warnings to exceptions, either via the project's `filterwarnings = ["error"]` config or an explicit `-Werror` invocation. Under `-Wdefault` the warning still fires but is not converted, the command exits cleanly with code 0, and the assertion fails. mgorny flagged this in the issue from a downstream Linux distro packaging context where tests are run with `-Wdefault` so unrelated warning regressions are visible.

## Change

Replace the exit-code/exception assertions with `pytest.warns(UserWarning, match=r"--xyz is used more than once")` around `runner.invoke`. The contract being exercised here is "emitting a UserWarning for the duplicate option name," and `pytest.warns` is the direct expression of that contract. It is robust under both `-Werror` and `-Wdefault` because the context manager installs its own warning filter for the duration of the block.

I considered also asserting the exact warning count (currently 2, because `Command.get_params` is invoked from both `make_parser` and `parse_args` in the parse path), but did not pin it. The count is an implementation detail of the parse pipeline's call structure and would couple this test to internal click internals rather than to the duplicate-option-name contract. If the maintainers would prefer the count assertion, happy to add it.

## Verification

```
$ uv run pytest -Wdefault tests/test_options.py::test_flag_group_competition_duplicate_option_name -v
PASSED

$ uv run pytest tests/test_options.py::test_flag_group_competition_duplicate_option_name -v
PASSED  # project default (filterwarnings = ["error"]) still passes

$ uv run pytest -Wdefault tests/ -q
1632 passed, 24 skipped, 30000 deselected, 1 xfailed in 10.16s  # no regressions
```

No changelog entry as this is a test-only change. Happy to add one if preferred.