### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Supported versions of Windows enable ANSI terminal styles by default.
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
+-   Flush each streamed write in ``echo_via_pager`` so pagers receive generator
+    output promptly. :issue:`3242`
 
 
 Version 8.4.2

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -335,6 +335,7 @@ def echo_via_pager(
     with get_pager_file(color=color) as pager:
         for text in itertools.chain(text_generator, "\n"):
             pager.write(text)
+            pager.flush()
 
 
 @t.overload

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import stat
 import subprocess
 import sys
 from collections import namedtuple
+from contextlib import contextmanager
 from contextlib import nullcontext
 from decimal import Decimal
 from fractions import Fraction
@@ -299,6 +300,66 @@ def _test_gen_func_echo(file=None):
 def _test_simulate_keyboard_interrupt(file=None):
     yield "output_before_keyboard_interrupt"
     raise KeyboardInterrupt()
+
+
+def test_echo_via_pager_flushes_generator_chunks(monkeypatch):
+    class RecordingPager:
+        def __init__(self):
+            self.flushes = []
+            self.writes = []
+
+        def write(self, text):
+            self.writes.append(text)
+
+        def flush(self):
+            self.flushes.append("".join(self.writes))
+
+    pager = RecordingPager()
+
+    @contextmanager
+    def get_pager_file(color=None):
+        yield pager
+
+    monkeypatch.setattr(click.termui, "get_pager_file", get_pager_file)
+
+    def generate():
+        yield "first"
+        assert pager.flushes == ["first"]
+        yield "second"
+
+    click.echo_via_pager(generate())
+
+    assert pager.writes == ["first", "second", "\n"]
+    assert pager.flushes == ["first", "firstsecond", "firstsecond\n"]
+
+
+def test_echo_via_pager_ignores_broken_pipe_during_flush(monkeypatch):
+    class BrokenPipePager:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, text):
+            self.writes.append(text)
+
+        def flush(self):
+            raise BrokenPipeError
+
+    pager = BrokenPipePager()
+
+    @contextmanager
+    def pager_contextmanager(color=None):
+        try:
+            yield pager, "utf-8", color
+        except BrokenPipeError:
+            pass
+
+    monkeypatch.setattr(
+        click._termui_impl, "_pager_contextmanager", pager_contextmanager
+    )
+
+    click.echo_via_pager(["hello", "ignored"])
+
+    assert pager.writes == ["hello"]
 
 
 EchoViaPagerTest = namedtuple(


### PR DESCRIPTION
Flush each streamed write in `echo_via_pager` so pager processes can display generator output promptly instead of waiting for the pipe buffer to fill or close.

Fixes #3242.

Validation:
- `uv run ruff check src/click/termui.py tests/test_utils.py`
- `uv run ruff format --check src/click/termui.py tests/test_utils.py`
- `uv run pytest tests/test_utils.py tests/test_termui.py`