### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 8.5.0
 
 Unreleased
 
+-   Add a glossary of command-line terms to the general reference docs.
+    :issue:`3077`
+
 -   Supported versions of Windows enable ANSI terminal styles by default.
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 

--- a/docs/command-line-reference.md
+++ b/docs/command-line-reference.md
@@ -10,6 +10,33 @@ local: true
 ---
 ```
 
+(cli-glossary)=
+## Glossary
+
+This section defines the command-line terms used throughout Click's
+reference docs. Keeping these meanings consistent helps avoid ambiguity
+when describing how a Click program is declared and how a user invokes it.
+
+- **Command line application**: A program that a user runs from a shell by
+  entering a command name and, optionally, parameters. In Click, a command
+  line application is built from one or more commands.
+- **Command line utility**: A command line application that performs a focused
+  task, often designed to compose well with other commands or scripts.
+- **Terminal**: The interactive text environment where a user enters commands
+  and reads output. The terminal is distinct from the shell that parses the
+  command line before Click receives it.
+- **Parameter**: A value that Click parses from the command line. Options and
+  arguments are both parameters.
+- **Option**: A parameter identified by one or more prefixed names, such as
+  `--count` or `-c`. Options are usually optional and can accept values,
+  behave as flags, or be provided multiple times.
+- **Flag**: An option that changes behavior by being present, rather than by
+  requiring a separate value. Boolean flags such as `--verbose` commonly switch
+  a value from `False` to `True`, while feature-switch flags can choose from a
+  fixed set of values.
+- **Argument**: A parameter identified by its position on the command line,
+  rather than by a prefixed option name.
+
 (exit-codes)=
 ## Exit Codes
 


### PR DESCRIPTION
Adds a glossary section to the general command-line reference docs, defining the terms requested in #3077 and a couple of closely related Click terms used throughout the docs.

Included terms:
- command line application
- command line utility
- terminal
- parameter
- option
- flag
- argument

Fixes #3077.

Validation:
- `git diff --check`

Note: I did not run the Sphinx docs build locally because this fresh clone does not have the docs dependency group installed in the environment.