### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes
     a ``Positional arguments`` section when argument help is available. :issue:`2983` :pr:`3473`
+-   :class:`LazyFile` no longer opens FIFO files during lazy read validation.
+    :issue:`2645`
 
 
 Version 8.4.2

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import os
 import re
+import stat
 import sys
 import typing as t
 from functools import update_wrapper
@@ -44,6 +45,13 @@ def safecall(func: t.Callable[P, R]) -> t.Callable[P, R | None]:
         return None
 
     return update_wrapper(wrapper, func)
+
+
+def _is_fifo(filename: str | os.PathLike[str]) -> bool:
+    try:
+        return stat.S_ISFIFO(os.stat(filename).st_mode)
+    except OSError:
+        return False
 
 
 def make_str(value: t.Any) -> str:
@@ -141,7 +149,7 @@ class LazyFile:
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
         else:
-            if "r" in mode:
+            if "r" in mode and not _is_fifo(filename):
                 # Open and close the file in case we're opening it for
                 # reading so that we can catch at least some errors in
                 # some cases early.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -716,6 +716,21 @@ def test_iter_lazyfile(tmpdir):
                 assert e_line == a_line.strip()
 
 
+@pytest.mark.skipif(WIN, reason="Named pipes are not supported on Windows.")
+def test_lazyfile_does_not_eagerly_open_fifo(tmp_path, monkeypatch):
+    path = tmp_path / "fifo"
+    os.mkfifo(path)
+
+    def fail_open(*args, **kwargs):
+        pytest.fail("LazyFile should not eagerly open FIFOs")
+
+    with monkeypatch.context() as m:
+        m.setattr("builtins.open", fail_open)
+        lazy_file = click.utils.LazyFile(path)
+
+    assert lazy_file._f is None
+
+
 class MockMain:
     __slots__ = "__package__"
 


### PR DESCRIPTION
Fixes #2645

This prevents `LazyFile` from eagerly opening and closing FIFO paths during
read-mode validation. For regular files, the existing early validation behavior
is preserved, but named pipes remain unopened until the first actual IO.

Validation:

- `uv run pytest tests/test_utils.py -q`
- `uv run pytest tests/test_utils.py tests/test_types.py -q -k "lazyfile or open_file or file"`
- `uv run ruff check src/click/utils.py tests/test_utils.py`
