### PR TITLE
Accept ZFS error-message for non-UTF-8 names

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -243,13 +243,22 @@ def test_path_surrogates(tmp_path, monkeypatch):
     ],
 )
 def test_file_surrogates(type, tmp_path):
-    path = tmp_path / "\udcff"
+    """Ensures that the error handling in ``click.File`` is robust.
 
-    # - common case: �': No such file or directory
-    # - special case: Illegal byte sequence
-    # The special case is seen with rootless Podman. The root cause is most
-    # likely that the path is handled by a user-space program (FUSE).
-    match = r"(�': No such file or directory|Illegal byte sequence)"
+    ``EILSEQ`` shows up with rootless Podman (FUSE-backed paths) and on filesystems
+    that reject non-UTF-8 names, like ZFS with ``utf8only=on``.
+
+    See: https://github.com/pallets/click/issues/2634
+    """
+    path = tmp_path / "\udcff"
+    match = (
+        # Common case: �': No such file or directory.
+        r"(�': No such file or directory"
+        # BSD/macOS libc special case (EILSEQ).
+        r"|Illegal byte sequence"
+        # glibc special case (EILSEQ).
+        r"|Invalid or incomplete multibyte or wide character)"
+    )
     with pytest.raises(click.BadParameter, match=match):
         type.convert(path, None, None)
 


### PR DESCRIPTION
This PR update the list of file-system specific error messages for a test that is supposed to fail for non-UTF8 filesystem.

Closes: #2634.

Relates to: 
- #2945
- #2946

CC @ruro