### PR TITLE
Fix thread safety in CliRunner.isolated_filesystem

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
 -   A :class:`Group` with ``invoke_without_command=True`` marks its subcommand as
     optional in the usage help, showing ``[COMMAND]`` instead of ``COMMAND``.
     :issue:`3059` :pr:`3507`
+-   Lock the ``chdir`` in :meth:`CliRunner.isolated_filesystem` so it is
+    safe to use from multiple threads. :issue:`3501`
 
 
 Version 8.4.1

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -8,6 +8,7 @@ import pdb
 import shlex
 import sys
 import tempfile
+import threading
 import typing as t
 from types import TracebackType
 
@@ -24,7 +25,7 @@ if t.TYPE_CHECKING:
 
 CaptureMode: t.TypeAlias = t.Literal["sys", "fd"]
 ExceptionInfo: t.TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
-
+_isolated_filesystem_lock = threading.Lock()
 
 class EchoingStdin:
     _input: t.BinaryIO
@@ -750,20 +751,23 @@ class CliRunner:
 
         .. versionchanged:: 8.0
             Added the ``temp_dir`` parameter.
+
+        .. versionchanged:: 8.x
+            Added a module-level lock to prevent threads from racing on chdir
         """
         cwd = os.getcwd()
         dt = tempfile.mkdtemp(dir=temp_dir)
-        os.chdir(dt)
+        with _isolated_filesystem_lock:
+            os.chdir(dt)
+            try:
+                yield dt
+            finally:
+                os.chdir(cwd)
 
-        try:
-            yield dt
-        finally:
-            os.chdir(cwd)
+                if temp_dir is None:
+                    import shutil
 
-            if temp_dir is None:
-                import shutil
-
-                try:
-                    shutil.rmtree(dt)
-                except OSError:
-                    pass
+                    try:
+                        shutil.rmtree(dt)
+                    except OSError:
+                        pass

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -27,6 +27,7 @@ CaptureMode: t.TypeAlias = t.Literal["sys", "fd"]
 ExceptionInfo: t.TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
 _isolated_filesystem_lock = threading.Lock()
 
+
 class EchoingStdin:
     _input: t.BinaryIO
     _output: t.BinaryIO
@@ -752,7 +753,7 @@ class CliRunner:
         .. versionchanged:: 8.0
             Added the ``temp_dir`` parameter.
 
-        .. versionchanged:: 8.x
+        .. versionchanged:: 8.4.2
             Added a module-level lock to prevent threads from racing on chdir
         """
         cwd = os.getcwd()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -3,6 +3,7 @@ import io
 import os
 import pdb
 import sys
+import threading
 from io import BytesIO
 
 import pytest
@@ -453,6 +454,23 @@ def test_isolated_runner_custom_tempdir(runner, tmp_path):
     assert os.path.exists(d)
     os.rmdir(d)
 
+def test_isolated_filesystem(runner):
+    """isolated_filesystem should give each thread its own working directory.
+    """
+    def worker(name, results, barrier):
+        barrier.wait()
+        with runner.isolated_filesystem() as path:
+            results[name] = (path, os.getcwd())
+            assert os.path.exists(path)
+
+    barrier = threading.Barrier(2)
+    results = {}
+    t1 = threading.Thread(target=worker, args=("worker_1", results, barrier))
+    t2 = threading.Thread(target=worker, args=("worker_2", results, barrier))
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    for promised, actual in results.values():
+        assert os.path.realpath(promised) == os.path.realpath(actual)
 
 def test_isolation_stderr_errors():
     """Writing to stderr should escape invalid characters instead of

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -454,9 +454,10 @@ def test_isolated_runner_custom_tempdir(runner, tmp_path):
     assert os.path.exists(d)
     os.rmdir(d)
 
+
 def test_isolated_filesystem(runner):
-    """isolated_filesystem should give each thread its own working directory.
-    """
+    """isolated_filesystem should give each thread its own working directory."""
+
     def worker(name, results, barrier):
         barrier.wait()
         with runner.isolated_filesystem() as path:
@@ -467,10 +468,14 @@ def test_isolated_filesystem(runner):
     results = {}
     t1 = threading.Thread(target=worker, args=("worker_1", results, barrier))
     t2 = threading.Thread(target=worker, args=("worker_2", results, barrier))
-    t1.start(); t2.start(); t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     for promised, actual in results.values():
         assert os.path.realpath(promised) == os.path.realpath(actual)
+
 
 def test_isolation_stderr_errors():
     """Writing to stderr should escape invalid characters instead of


### PR DESCRIPTION
fixes #3501 

isolated_filesystem calls os.chdir on the process working directory. Since CWD is per-process, two threads entering the context manager at the same time can end up in each other's temp directory. Added a module-level lock around the chdir and teardown so only one thread is inside at a time.

Tradeoff: tests that use isolated_filesystem across threads now run serially through this lock. Picked it over passing the dir through explicitly, which would break the existing API.

Added a test that uses a Barrier to force both threads into the race window. Full suite still passes.