### PR TITLE
AI spam

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3320,10 +3320,11 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match="used more than once"):
+        result = runner.invoke(cli, [])
+
+    assert result.exit_code == 0
+    assert result.output == "'second'"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- update test_flag_group_competition_duplicate_option_name to assert the expected UserWarning explicitly
- assert the successful duplicate-option output when warnings are not promoted to errors

## Issue
Fixes #3476

## Verification
- PYTHONPATH=src python -m pytest -Wdefault tests/test_options.py::test_flag_group_competition_duplicate_option_name -q
- PYTHONPATH=src python -m pytest tests/test_options.py -q