### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     tabs in option help text are now escaped, keeping the original completion
     format while still supporting multi-line help. :issue:`3502`
     :issue:`3043` :pr:`3504` :pr:`3508`
+-   Shell completion no longer evaluates parameter defaults or callbacks while
+    parsing completed arguments. :issue:`2614`
 -   Deprecated commands and options with empty or missing help text no longer
     render a stray leading space before the ``(DEPRECATED)`` label. :pr:`3509`
 -   A :class:`Group` with ``invoke_without_command=True`` marks its subcommand as

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2386,7 +2386,7 @@ class Parameter(ABC):
                 value = envvar_value
                 source = ParameterSource.ENVIRONMENT
 
-        if value is UNSET:
+        if value is UNSET and not ctx.resilient_parsing:
             default_map_value = ctx.lookup_default(self.name)
             if default_map_value is not None or ctx._default_map_has(self.name):
                 value = default_map_value
@@ -2397,7 +2397,7 @@ class Parameter(ABC):
                 if isinstance(value, str) and self.nargs != 1:
                     value = self.type.split_envvar_value(value)
 
-        if value is UNSET:
+        if value is UNSET and not ctx.resilient_parsing:
             default_value = self.get_default(ctx)
             if default_value is not UNSET:
                 value = default_value
@@ -2506,7 +2506,7 @@ class Parameter(ABC):
         if self.required and self.value_is_missing(value):
             raise MissingParameter(ctx=ctx, param=self)
 
-        if self.callback is not None:
+        if self.callback is not None and not ctx.resilient_parsing:
             # Legacy case: UNSET is not exposed directly to the callback, but converted
             # to None.
             if value is UNSET:
@@ -3449,7 +3449,7 @@ class Option(Parameter):
         if self.is_flag and not self.required and self.is_bool_flag and value is UNSET:
             value = False
 
-            if self.callback is not None:
+            if self.callback is not None and not ctx.resilient_parsing:
                 value = self.callback(ctx, self, value)
 
             return value

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -142,6 +142,51 @@ def test_argument_default():
     assert _get_words(cli, ["x"], "b") == ["b"]
 
 
+def test_completion_skips_defaults_and_callbacks():
+    calls = []
+
+    def default():
+        calls.append("default")
+        return "value"
+
+    def callback(ctx, param, value):
+        calls.append(f"callback:{value}")
+        return value
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--name"], default=default, callback=callback),
+            Argument(["arg"], type=Choice(["a"])),
+        ],
+    )
+
+    assert _get_words(cli, [], "") == ["a"]
+    assert calls == []
+
+    assert _get_words(cli, ["--name", "value"], "") == ["a"]
+    assert calls == []
+
+
+def test_completion_skips_flag_callback_for_missing_value():
+    calls = []
+
+    def callback(ctx, param, value):
+        calls.append(value)
+        return value
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--flag"], is_flag=True, callback=callback),
+            Argument(["arg"], type=Choice(["a"])),
+        ],
+    )
+
+    assert _get_words(cli, [], "") == ["a"]
+    assert calls == []
+
+
 def test_type_choice():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["a1", "a2", "b"]))])
     assert _get_words(cli, ["-c"], "") == ["a1", "a2", "b"]


### PR DESCRIPTION
Fixes #2614.

This keeps resilient parsing from evaluating parameter defaults, default maps, or callbacks while shell completion resolves the command context. That matches the documented behavior for resilient parsing and avoids slow or side-effectful default/callback code during tab completion.

Changes:
- skip default/default_map lookup while resilient parsing is active
- skip parameter callbacks while resilient parsing is active, including missing boolean flags
- add shell completion regression tests
- add a changelog entry

Tests:
- `uv run --locked --no-default-groups --group tests pytest tests/test_shell_completion.py -q`
- `uv run --locked --no-default-groups --group tests pytest tests/test_shell_completion.py tests/test_options.py tests/test_defaults.py tests/test_context.py -q`
- `uv run --locked --no-default-groups --group tests pytest -q`
- `git diff --check`