### PR TITLE
AI spam

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,15 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            for item in completions:
+                if item.type == "plain":
+                    item.value = f"{completion_prefix}{item.value}"
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -636,7 +643,7 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str]:
     """Find the Click object that will handle the completion of the
     incomplete value. Return the object and the incomplete value.
 
@@ -649,18 +656,27 @@ def _resolve_incomplete(
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
     # split and discard the "=" to make completion easier.
+    completion_prefix = ""
+
+    if args and args[-1] == "=" and len(args) > 1 and _start_of_option(ctx, args[-2]):
+        args.pop()
+        completion_prefix = f"{args[-1]}="
+
     if incomplete == "=":
         incomplete = ""
+        if args and _start_of_option(ctx, args[-1]):
+            completion_prefix = f"{args[-1]}="
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, completion_prefix
 
     params = ctx.command.get_params(ctx)
 
@@ -668,14 +684,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, completion_prefix

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,25 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+@pytest.mark.parametrize(
+    ("args", "incomplete", "expect"),
+    [
+        ([], "--color=", ["--color=auto", "--color=always", "--color=never"]),
+        ([], "--color=a", ["--color=auto", "--color=always"]),
+        ([], "--color=al", ["--color=always"]),
+        (["--color"], "=", ["--color=auto", "--color=always", "--color=never"]),
+        (["--color", "="], "a", ["--color=auto", "--color=always"]),
+        (["--color"], "a", ["auto", "always"]),
+    ],
+)
+def test_option_value_completion_with_equals(args, incomplete, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    assert _get_words(cli, args, incomplete) == expect
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
﻿## Summary
- preserve the completed option name when shell completion is requested as `--option=value`
- add regression coverage for bash/zsh split forms such as `--color=`, `--color=a`, and `--color = a`
- keep the existing `--option value` completion behavior unchanged

Fixes #2847.

## Tests
- `PYTHONPATH=src py -3 -m pytest tests/test_shell_completion.py -q`
- `PYTHONPATH=src py -3 -m pytest -q`
- `py -3 -m ruff check src/click/shell_completion.py tests/test_shell_completion.py`