### PR TITLE
AI spam

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2398,7 +2398,14 @@ class Parameter(ABC):
                     value = self.type.split_envvar_value(value)
 
         if value is UNSET:
-            default_value = self.get_default(ctx)
+            default_value = self.get_default(ctx, call=not ctx.resilient_parsing)
+            if (
+                ctx.resilient_parsing
+                and callable(default_value)
+                and default_value is self.default
+            ):
+                default_value = UNSET
+
             if default_value is not UNSET:
                 value = default_value
                 source = ParameterSource.DEFAULT

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -174,6 +174,18 @@ def test_option_count():
     assert _get_words(cli, ["-c"], "-") == ["--help"]
 
 
+def test_option_callable_default_ignored():
+    calls = []
+
+    def default():
+        calls.append(None)
+        return "value"
+
+    cli = Command("cli", params=[Option(["--name"], default=default)])
+    assert _get_words(cli, [], "-") == ["--name", "--help"]
+    assert calls == []
+
+
 def test_option_optional():
     cli = Command(
         "cli",


### PR DESCRIPTION
## Summary

Avoid calling callable parameter defaults while Click is doing resilient parsing for shell completion.

This keeps tab completion responsive for commands that use expensive default factories, while preserving normal command invocation behavior.

Fixes #2614.

## Root cause

Shell completion builds a context with `resilient_parsing=True`, but `consume_value` still called `get_default()` with its default `call=True`. Callable defaults were evaluated before completion results were produced.

## Checks

- `uv run pytest tests/test_shell_completion.py::test_option_callable_default_ignored -q`
- `uv run pytest tests/test_shell_completion.py -q`
- `uv run pytest tests/test_defaults.py tests/test_options.py -q`
- `uv run pytest -q`
- `uv run ruff check src/click/core.py tests/test_shell_completion.py`