### PR TITLE
AI spam

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -635,7 +635,8 @@ class IntRange(_NumberRangeBase[int], IntParamType):
     corresponding boundary is not included in the range.
 
     If ``clamp`` is enabled, a value outside the range is clamped to the
-    boundary instead of failing.
+    boundary instead of failing. If a boundary is open, the value is
+    clamped to the nearest integer that is still inside the range.
 
     .. versionchanged:: 8.0
         Added the ``min_open`` and ``max_open`` parameters.


### PR DESCRIPTION
The `IntRange` docstring describes the `clamp` option as:

> If `clamp` is enabled, a value outside the range is clamped to the boundary instead of failing.

This is inaccurate when a boundary is open. Because an open boundary value is itself excluded from the range, `IntRange._clamp` returns `bound + dir` for open ends, i.e. it clamps to the nearest integer that is *still inside* the range — not to the boundary value.

### Reproduction

```python
import click

# closed boundary: clamps to the boundary, as documented
click.IntRange(0, 5, clamp=True).convert("6", None, None)                  # -> 5

# open boundary: clamps to the nearest in-range integer, NOT the boundary
click.IntRange(0, 5, max_open=True, clamp=True).convert("6", None, None)   # -> 4
click.IntRange(0, 5, min_open=True, clamp=True).convert("-3", None, None)  # -> 1
```

With `max_open=True`, the documented "clamped to the boundary" would give `5`, but `5` is excluded from the range, so the actual (and correct) result is `4`. The current docstring does not mention this.

### Change

Adds one clarifying sentence to the `IntRange` docstring so it matches `IntRange._clamp`. Documentation only — no behavior change.

### Validation

Confirmed the behavior above against the current source; `click` imports cleanly after the change.
