### PR TITLE
AI spam

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3311,7 +3311,7 @@ def test_flag_group_unset_vs_none_vs_explicit(
 
 def test_flag_group_competition_duplicate_option_name(runner):
     """The same option name declared twice on the same command is a user
-    error.
+    warning.
     """
 
     @click.command()
@@ -3320,10 +3320,12 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match="used more than once"):
+        result = runner.invoke(cli, [])
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.output == "'second'"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This updates `test_flag_group_competition_duplicate_option_name` so it checks the duplicate-option warning directly instead of relying on the test suite's global `filterwarnings = error` setting to turn that warning into the command exception.

With `-Wdefault`, the command succeeds and emits the duplicate parameter warning, so the test should assert that behavior explicitly.

Closes #3476.

Tests:

- `pytest tests/test_options.py::test_flag_group_competition_duplicate_option_name -q`
- `pytest -Wdefault tests/test_options.py::test_flag_group_competition_duplicate_option_name -q`
- `pytest tests/test_options.py -k flag_group_competition -q`
- `ruff check tests/test_options.py`
- `ruff format --check tests/test_options.py`
