### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 8.5.0
 
 Unreleased
 
+-   :func:`wrap_text` no longer breaks text at hyphens. CLI option names
+    such as ``--enable-verbose-logging`` now wrap only at whitespace. :issue:`3362`
 -   Supported versions of Windows enable ANSI terminal styles by default.
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -67,6 +67,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=False,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -436,6 +436,30 @@ def test_help_formatter_write_text():
     assert actual == expected
 
 
+def test_wrap_text_does_not_break_at_hyphens():
+    """wrap_text must not split tokens at hyphens.
+
+    CLI option names such as ``--enable-verbose-logging`` should never be
+    broken in the middle at a hyphen; wrapping must happen only at
+    whitespace boundaries.  Regression for :issue:`3362`.
+    """
+    args = (
+        "--enable-verbose-logging --output-file-path --max-retry-count"
+        " --disable-cache-mode --config-file-location"
+    )
+    result = click.formatting.wrap_text(
+        args,
+        width=65,
+        initial_indent="Usage: program ",
+        subsequent_indent="               ",
+    )
+    for line in result.splitlines():
+        stripped = line.rstrip()
+        assert not stripped.endswith(
+            "-"
+        ), f"wrap_text broke a token at a hyphen: {stripped!r}"
+
+
 @pytest.mark.parametrize(
     ("body", "width", "initial_indent"),
     [


### PR DESCRIPTION
Fixes #3362.

`textwrap.TextWrapper` defaults to `break_on_hyphens=True`, which breaks compound words at hyphens when they fall at the wrap boundary. That default is designed for English prose, but a CLI help formatter is not prose — option names like `--enable-verbose-logging`, paths, and other hyphenated identifiers should never be split at a hyphen.

Before this change, `write_usage` could produce:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count ...
```

After:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count ...
```

The fix is a single-line change: pass `break_on_hyphens=False` to the `TextWrapper` constructor inside `wrap_text`. All existing tests continue to pass (none depended on hyphen-breaking behaviour), and a new test captures the regression.