### PR TITLE
AI spam

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -471,6 +471,7 @@ class Context:
         self._close_callbacks: list[t.Callable[[], t.Any]] = []
         self._depth = 0
         self._parameter_source: dict[str, ParameterSource] = {}
+        self._parameter_invocations: set[int] = set()
         # Tracks whether the option that currently owns each parameter slot in
         # :attr:`params` had its ``default`` set explicitly by the user. Used
         # to tie-break feature-switch groups where multiple options share a
@@ -1276,6 +1277,7 @@ class Command:
 
         parser = self.make_parser(ctx)
         opts, args, param_order = parser.parse_args(args=args)
+        ctx._parameter_invocations = {id(param) for param in param_order}
 
         for param in iter_params_for_processing(param_order, self.get_params(ctx)):
             _, args = param.handle_parse_result(ctx, opts, args)
@@ -2674,10 +2676,18 @@ class Parameter(ABC):
             and existing_default_explicit
             and not self._default_explicit
         )
+        same_source_wins = (
+            same_source
+            and not auto_would_downgrade_explicit
+            and (
+                source != ParameterSource.COMMANDLINE
+                or id(self) in ctx._parameter_invocations
+            )
+        )
         is_winner = (
             slot_empty
             or more_explicit
-            or (same_source and not auto_would_downgrade_explicit)
+            or same_source_wins
         )
 
         if is_winner:

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2684,11 +2684,7 @@ class Parameter(ABC):
                 or id(self) in ctx._parameter_invocations
             )
         )
-        is_winner = (
-            slot_empty
-            or more_explicit
-            or same_source_wins
-        )
+        is_winner = slot_empty or more_explicit or same_source_wins
 
         if is_winner:
             if self.expose_value:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1667,9 +1667,7 @@ def test_same_name_value_option_does_not_override_flag_callback_result(
     def cli(custom):
         return custom
 
-    result = runner.invoke(
-        cli, args, standalone_mode=False, catch_exceptions=False
-    )
+    result = runner.invoke(cli, args, standalone_mode=False, catch_exceptions=False)
     assert result.return_value == expected
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1038,6 +1038,22 @@ def test_option_custom_class(runner):
     assert "you won't see me" not in result.output
 
 
+def test_option_custom_class_does_not_need_to_be_hashable(runner):
+    class CustomOption(click.Option):
+        def __eq__(self, other):
+            return self is other
+
+    @click.command()
+    @click.option("--testoption", cls=CustomOption)
+    def cmd(testoption):
+        return testoption
+
+    result = runner.invoke(
+        cmd, ["--testoption", "value"], standalone_mode=False, catch_exceptions=False
+    )
+    assert result.return_value == "value"
+
+
 @pytest.mark.parametrize(
     ("param_decl", "option_kwargs", "pass_argv"),
     (
@@ -1624,6 +1640,37 @@ def test_default_dual_option_callback(runner, default, args, expected):
     result = runner.invoke(main, args)
     assert result.output == f"Callback value: {expected!r}"
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    (
+        (["--fetch"], "fetched"),
+        (["--custom", "local", "--fetch"], "fetched"),
+        (["--fetch", "--custom", "local"], "local"),
+    ),
+)
+def test_same_name_value_option_does_not_override_flag_callback_result(
+    runner, args, expected
+):
+    sentinel = "$_fetch"
+
+    def fetch_value(ctx, param, value):
+        if value == sentinel:
+            return "fetched"
+
+        return value
+
+    @click.command()
+    @click.option("--custom", "custom")
+    @click.option("--fetch", "custom", flag_value=sentinel, callback=fetch_value)
+    def cli(custom):
+        return custom
+
+    result = runner.invoke(
+        cli, args, standalone_mode=False, catch_exceptions=False
+    )
+    assert result.return_value == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2786.

When two options share a parameter name (a normal value option plus a `flag_value` option with a `callback`) and only the flag is passed, the value option would override the slot, so the function received the flag-value sentinel instead of the value produced by the callback.

This tracks which parameters were actually invoked on the command line and makes the invoked option win the shared slot, so the callback result is used. The last option specified on the command line wins, and the callback fires on the flag_value path. Invocation tracking uses `id()` so custom `Option` subclasses that are not hashable still work (covered by an added test).

Added a parametrized regression test in `tests/test_options.py` covering `--fetch` alone, `--custom local --fetch`, and `--fetch --custom local`. The full test suite passes (1671 passed locally).

Prepared with AI assistance.