### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Unreleased
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes
     a ``Positional arguments`` section when argument help is available. :issue:`2983` :pr:`3473`
 -   :class:`FloatRange` with ``clamp`` enabled always returns a ``float``,
-    even when the boundary was given as an ``int``. :issue:`3547`
+    even when the boundary was given as an ``int``. :issue:`3547` :pr:`3548`
 
 
 Version 8.4.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes
     a ``Positional arguments`` section when argument help is available. :issue:`2983` :pr:`3473`
+-   :class:`FloatRange` with ``clamp`` enabled always returns a ``float``,
+    even when the boundary was given as an ``int``. :issue:`3547`
 
 
 Version 8.4.2

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -670,6 +670,10 @@ class FloatRange(_NumberRangeBase[float], FloatParamType):
     boundary instead of failing. This is not supported if either
     boundary is marked ``open``.
 
+    .. versionchanged:: 8.5
+        A clamped value is always a ``float``, even when the boundary was
+        given as an ``int``.
+
     .. versionchanged:: 8.0
         Added the ``min_open`` and ``max_open`` parameters.
     """
@@ -693,7 +697,10 @@ class FloatRange(_NumberRangeBase[float], FloatParamType):
 
     def _clamp(self, bound: float, dir: t.Literal[1, -1], open: bool) -> float:
         if not open:
-            return bound
+            # The boundary may have been passed as an ``int`` (e.g.
+            # ``FloatRange(0, 1)``); coerce it so clamping always returns
+            # a ``float``.
+            return self._number_class(bound)
 
         # Could use math.nextafter here, but clamping an
         # open float range doesn't seem to be particularly useful. It's

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -81,6 +81,14 @@ def test_float_range_no_clamp_open():
         sneaky.convert("1.5", None, None)
 
 
+@pytest.mark.parametrize("value", ["2.5", "-2.5"])
+def test_float_range_clamp_returns_float(value):
+    """Clamping always returns a ``float``, even when the boundary was
+    given as an ``int``. https://github.com/pallets/click/issues/3547"""
+    result = click.FloatRange(0, 1, clamp=True).convert(value, None, None)
+    assert type(result) is float
+
+
 @pytest.mark.parametrize(
     ("nargs", "multiple", "default", "expect"),
     [


### PR DESCRIPTION
`FloatRange(..., clamp=True)` could return an `int` instead of a `float` when an out-of-range value was clamped to a boundary that had been written as an integer literal.

```python
import click

t = click.FloatRange(0, 1, clamp=True)
print(repr(t.convert("2.5", None, None)))   # 1   (int)  -> should be 1.0
print(repr(t.convert("-2.5", None, None)))  # 0   (int)  -> should be 0.0
```

`FloatRange` is declared as `_NumberRangeBase[float]` / `FloatParamType` and is documented to return a `float`, so returning an `int` here violates the type contract.

**Root cause**

The constructor stores the boundaries exactly as they were passed in, so `FloatRange(0, 1, clamp=True)` keeps `self.min`/`self.max` as Python `int`s. `FloatRange._clamp` returned the stored boundary verbatim for non-open bounds, propagating that `int` to the caller.

**Fix**

Coerce the boundary through `self._number_class` (which is `float` for `FloatRange`) before returning it, so a clamped value is always a `float`. In-range values and `IntRange` are unaffected.

**Tests**

Added `test_float_range_clamp_returns_float`, parametrized over a value above and below the range, asserting `type(result) is float`. The existing clamp tests use `float` boundary literals (`0.5`/`1.5`) and `test_range` compares with `==` (where `1 == 1.0`), so they did not catch this. The new test fails on `main` (`AssertionError: <class 'int'> is float`) and passes with the change.

fixes #3547

---

- [x] Add tests that demonstrate the correct behavior of the change. Tests fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in relevant code docs.
