### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes
     a ``Positional arguments`` section when argument help is available. :issue:`2983` :pr:`3473`
+-   Shell completion for option values given as ``--option=value`` keeps the
+    option name when completing the value. :issue:`2847`
 
 
 Version 8.4.2

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,15 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        option_value = _split_option_value(ctx, incomplete)
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if option_value is not None and isinstance(obj, Option):
+            option_name, _ = option_value
+            _add_completion_prefix(completions, f"{option_name}=")
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -548,6 +555,22 @@ def _start_of_option(ctx: Context, value: str) -> bool:
     return c in ctx._opt_prefixes
 
 
+def _split_option_value(ctx: Context, value: str) -> tuple[str, str] | None:
+    """Split ``--option=value`` into the option name and value."""
+    if "=" not in value or not _start_of_option(ctx, value):
+        return None
+
+    name, _, value = value.partition("=")
+    return name, value
+
+
+def _add_completion_prefix(completions: list[CompletionItem], prefix: str) -> None:
+    """Prefix shell word completions that replace an entire option value."""
+    for item in completions:
+        if item.type == "plain":
+            item.value = f"{prefix}{item.value}"
+
+
 def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bool:
     """Determine if the given parameter is an option that needs a value.
 
@@ -649,10 +672,12 @@ def _resolve_incomplete(
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
     # split and discard the "=" to make completion easier.
+    option_value = _split_option_value(ctx, incomplete)
+
     if incomplete == "=":
         incomplete = ""
-    elif "=" in incomplete and _start_of_option(ctx, incomplete):
-        name, _, incomplete = incomplete.partition("=")
+    elif option_value is not None:
+        name, incomplete = option_value
         args.append(name)
 
     # The "--" marker tells Click to stop treating values as options

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,23 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+def test_option_value_with_equals():
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    assert _get_words(cli, [], "--color=") == [
+        "--color=auto",
+        "--color=always",
+        "--color=never",
+    ]
+    assert _get_words(cli, [], "--color=a") == [
+        "--color=auto",
+        "--color=always",
+    ]
+    assert _get_words(cli, [], "--color=al") == ["--color=always"]
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]
@@ -370,6 +387,30 @@ def test_full_complete(runner, shell, env, expect):
     cli = Group("cli", commands=[Command("a"), Command("b", help="bee")])
     env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("shell", "expect"),
+    [
+        ("bash", "plain,--color=auto\nplain,--color=always\n"),
+        ("zsh", "plain\n--color=auto\n_\nplain\n--color=always\n_\n"),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_option_value_with_equals(runner, shell, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli --color=a",
+            "COMP_CWORD": "1",
+            "_CLI_COMPLETE": f"{shell}_complete",
+        },
+    )
     assert result.output == expect
 
 


### PR DESCRIPTION
Keep the option name in shell completion results when completing values written as `--option=value`. Without this, bash and zsh can replace the entire current word with only the value, dropping the `--option=` prefix.

fixes #2847

Tests:
- `PYTHONPATH=src python -m pytest -q`
- `uv run --frozen pytest tests/test_shell_completion.py -q`
- `uv run --frozen ruff check src tests`
- `uv run --frozen mypy src/click/shell_completion.py`