### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ Version 8.4.2
 
 Unreleased
 
+-   A parameter's default value is no longer evaluated during shell
+    completion. ``resilient_parsing`` is honored when sourcing the default, so
+    expensive default callbacks are not called while generating completions.
+    :issue:`2614`
 -   Fix Fish shell completion broken in ``8.4.0`` by :pr:`3126`. Newlines and
     tabs in option help text are now escaped, keeping the original completion
     format while still supporting multi-line help. :issue:`3502`

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2369,6 +2369,11 @@ class Parameter(ABC):
         If no value is found, an internal sentinel value is returned.
 
         :meta private:
+
+        .. versionchanged:: 8.4.2
+            The parameter's default value is no longer applied when
+            ``ctx.resilient_parsing`` is enabled, such as during shell
+            completion.
         """
         # Collect from the parse the value passed by the user to the CLI.
         value = opts.get(self.name, UNSET)
@@ -2397,7 +2402,7 @@ class Parameter(ABC):
                 if isinstance(value, str) and self.nargs != 1:
                     value = self.type.split_envvar_value(value)
 
-        if value is UNSET:
+        if value is UNSET and not ctx.resilient_parsing:
             default_value = self.get_default(ctx)
             if default_value is not UNSET:
                 value = default_value

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -585,3 +585,25 @@ def test_fish_format_completion_escapes_help():
     # The newline is escaped to the literal characters backslash-n and the tab
     # becomes a space, so each completion stays on one line for fish.
     assert fc.format_completion(item) == "plain,--at\tfirst\\nsecond third"
+
+
+def test_default_callback_not_called_during_completion():
+    """A default callback must not be evaluated while generating completions.
+
+    ``ctx.resilient_parsing`` is enabled during completion, and the docs
+    promise that default values (including default callbacks) are ignored in
+    that mode. See issue #2614.
+    """
+    called = []
+
+    def expensive_default():
+        called.append(True)
+        return "computed"
+
+    @click.command()
+    @click.option("--thing", default=expensive_default)
+    def cli(thing):
+        pass
+
+    _get_completions(cli, args=[], incomplete="")
+    assert not called, "default callback was evaluated during completion"


### PR DESCRIPTION
Fixes #2614

`Parameter.consume_value` sourced the parameter's default value unconditionally. As a result, default callbacks (and other defaults) were evaluated even during shell completion, where `ctx.resilient_parsing` is enabled.

The `Context.resilient_parsing` docs state that in this mode "Default values will also be ignored. This is useful for implementing things such as completion support." This change honors that flag when sourcing the default, so expensive default callbacks are no longer called while generating completions.

### Changes
- `consume_value` only applies the parameter default when `not ctx.resilient_parsing`.
- Added a test that fails without the change: a default callback must not run while `ShellComplete` generates completions.
- `CHANGES.rst` entry and a `.. versionchanged::` note.

The full test suite passes (1668 passed, 0 regressions).
