### PR TITLE
AI spam

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3022,7 +3022,7 @@ class Option(Parameter):
         # being instantiated by the callable check below.
         if value is True and self.is_flag and not self.is_bool_flag:
             value = self.flag_value
-        elif call and callable(value):
+        elif call and callable(value) and not ctx.resilient_parsing:
             value = value()
 
         return value


### PR DESCRIPTION
Fixes #2614

## Summary

When `resilient_parsing=True` (used during tab completion), default callbacks should not be evaluated. This matches the documented behavior: "Default values will also be ignored" in resilient parsing mode.

## Changes

- `src/click/core.py`: Added `not ctx.resilient_parsing` guard before calling default callbacks in `Option.get_default()`

## Why this is safe

- The `resilient_parsing` flag already guards against other interactive behaviours
- Before Click 8.0, there was an explicit `ignore_default_values` flag that did this
- Expense default callbacks should not be triggered during tab completion