### PR TITLE
AI junk

### DIFF
--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -142,7 +142,7 @@ class LazyFile:
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
         else:
-            if "r" in mode and not stat.S_ISFIFO(os.stat(filename).st_mode):
+            if "r" in mode and (WIN or not stat.S_ISFIFO(os.stat(filename).st_mode)):
                 # Open and close the file in case we're opening it for
                 # reading so that we can catch at least some errors in
                 # some cases early.

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import os
 import re
+import stat
 import sys
 import typing as t
 from functools import update_wrapper
@@ -141,7 +142,7 @@ class LazyFile:
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
         else:
-            if "r" in mode:
+            if "r" in mode and not stat.S_ISFIFO(os.stat(filename).st_mode):
                 # Open and close the file in case we're opening it for
                 # reading so that we can catch at least some errors in
                 # some cases early.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -716,6 +716,27 @@ def test_iter_lazyfile(tmpdir):
                 assert e_line == a_line.strip()
 
 
+def test_lazyfile_read_validates_regular_file(tmp_path):
+    path = tmp_path / "file.txt"
+    path.write_text("content")
+
+    with patch("click.utils.open") as open_:
+        click.utils.LazyFile(path, "r")
+
+    open_.assert_called_once_with(path, "r")
+
+
+@pytest.mark.skipif(WIN, reason="Named pipes are not supported on Windows.")
+def test_lazyfile_read_skips_fifo_validation(tmp_path):
+    path = tmp_path / "pipe"
+    os.mkfifo(path)
+
+    with patch("click.utils.open") as open_:
+        click.utils.LazyFile(path, "rb")
+
+    open_.assert_not_called()
+
+
 class MockMain:
     __slots__ = "__package__"
 


### PR DESCRIPTION
Fixes #2645.

`LazyFile` currently opens and closes files eagerly for read-mode validation. That is useful for regular files, but for FIFOs the validation open can consume or disrupt the writer before the later lazy read opens the pipe.

This skips the eager validation open when the path is a FIFO while preserving the existing validation behavior for regular files.

Validation:

- `.venv/bin/python -m pytest -q tests/test_utils.py::test_lazyfile_read_validates_regular_file tests/test_utils.py::test_lazyfile_read_skips_fifo_validation tests/test_utils.py::test_iter_lazyfile`
- `.venv/bin/python -m pytest -q tests/test_utils.py`
- `.venv/bin/ruff check src/click/utils.py tests/test_utils.py`
- `.venv/bin/ruff format --check src/click/utils.py tests/test_utils.py`
- `.venv/bin/python -m pytest -q`
