### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -673,18 +673,36 @@ class Editor:
         import subprocess
 
         editor = self.get_editor()
+        args = shlex.split(editor)
         environ: dict[str, str] | None = None
 
         if self.env:
             environ = os.environ.copy()
             environ.update(self.env)
 
+        if WIN and args:
+            editor_name = os.path.basename(args[0]).lower()
+
+            if (
+                editor_name
+                in {
+                    "code",
+                    "code.cmd",
+                    "code.exe",
+                    "code-insiders",
+                    "code-insiders.cmd",
+                    "code-insiders.exe",
+                }
+                and "--wait" not in args
+            ):
+                args.append("--wait")
+
         try:
             # Split in POSIX mode (the default) for the same reasons as
             # in pager(): strips quotes from tokens and preserves quoted
             # Windows paths.
             c = subprocess.Popen(
-                args=shlex.split(editor) + list(filenames),
+                args=args + list(filenames),
                 env=environ,
             )
             exit_code = c.wait()

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -532,6 +532,16 @@ def test_editor_path_normalization(editor_cmd, filenames, expected_args):
             ["C:\\Program Files\\Sublime Text 3\\sublime_text.exe", "--wait"],
             id="quoted path with flag",
         ),
+        pytest.param(
+            "code",
+            ["code", "--wait"],
+            id="vscode-adds-wait",
+        ),
+        pytest.param(
+            "code --wait",
+            ["code", "--wait"],
+            id="vscode-keeps-existing-wait",
+        ),
     ],
 )
 def test_editor_windows_path_normalization(editor_cmd, expected_cmd):


### PR DESCRIPTION
Fixes #2582.

When the Windows editor command is VS Code's CLI (`code` or `code-insiders`), add `--wait` automatically if it was not already provided. Without that flag, VS Code returns before the user can edit the temporary file, and Click then removes the file immediately.

This keeps existing editor commands unchanged and avoids adding a duplicate flag when `code --wait` is already configured.

Tests run:
- `PYTHONPATH=src python -m pytest tests/test_termui.py -k "editor_windows_path_normalization or editor_path_normalization" -q`
- `PYTHONPATH=src python -m ruff check src/click/_termui_impl.py tests/test_termui.py`