### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     Colorama is no longer a dependency and is not used. :issue:`2986` :pr:`3505`
 -   :class:`Argument` accepts a ``help`` parameter, and help output includes
     a ``Positional arguments`` section when argument help is available. :issue:`2983` :pr:`3473`
+-   :meth:`HelpFormatter.write_usage` does not break option names at hyphens
+    when wrapping at a line boundary. :issue:`3362`
 
 
 Version 8.4.2

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -67,6 +68,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +188,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +198,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -614,3 +614,24 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_write_usage_does_not_break_at_hyphens():
+    """Options containing hyphens should not be broken at the hyphen
+    when they fall at a line boundary. Regression for #3362.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+    ]
+    f = click.HelpFormatter(width=65)
+    f.write_usage("program", " ".join(options))
+    result = f.getvalue()
+    # No line should end with a trailing hyphen from an option name.
+    for line in result.splitlines():
+        stripped = line.rstrip()
+        assert not stripped.endswith("-"), f"line ends with hyphen: {line!r}"


### PR DESCRIPTION
Closes #3362

  `HelpFormatter.write_usage` now passes `break_on_hyphens=False` to `wrap_text` so
  that options like `--enable-verbose-logging` are not broken at the hyphen when they
  fall at a line boundary. Added `break_on_hyphens` parameter to `wrap_text` to support
  this.

  Added a regression test `test_write_usage_does_not_break_at_hyphens` and a
  CHANGES.rst entry.