### PR TITLE
AI spam

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2674,10 +2674,21 @@ class Parameter(ABC):
             and existing_default_explicit
             and not self._default_explicit
         )
+        unprocessed_would_downgrade_callback = (
+            same_source
+            and source == ParameterSource.COMMANDLINE
+            and self.callback is None
+            and existing_value is not UNSET
+            and existing_value != value
+        )
         is_winner = (
             slot_empty
             or more_explicit
-            or (same_source and not auto_would_downgrade_explicit)
+            or (
+                same_source
+                and not auto_would_downgrade_explicit
+                and not unprocessed_would_downgrade_callback
+            )
         )
 
         if is_winner:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1626,6 +1626,32 @@ def test_default_dual_option_callback(runner, default, args, expected):
     assert result.exit_code == 0
 
 
+def test_shared_option_callback_value_is_preserved(runner):
+    marker = "$_fetch"
+
+    def fetch_value(ctx, param, value):
+        if value == marker:
+            return "fetched"
+
+        return value
+
+    @click.command()
+    @click.option("--custom", "custom")
+    @click.option("--fetch", "custom", flag_value=marker, callback=fetch_value)
+    def cli(custom):
+        click.echo(custom)
+
+    for args, expected in (
+        (["--fetch"], "fetched"),
+        (["--custom", "typed", "--fetch"], "fetched"),
+        (["--fetch", "--custom", "typed"], "typed"),
+    ):
+        result = runner.invoke(cli, args)
+
+        assert result.output == f"{expected}\n"
+        assert result.exit_code == 0
+
+
 @pytest.mark.parametrize(
     ("flag_value", "envvar_value", "expected"),
     [


### PR DESCRIPTION
﻿## Problem

Shared options that target the same parameter can process the same parser value more than once. When one option has a callback and another sibling option does not, the callback result can be overwritten by the sibling's raw parser value. In #2786 this allows an internal `flag_value` sentinel to reach the command callback when only the shortcut flag is provided.

## Solution

I tightened the shared-parameter arbitration so a callback-less option with the same command-line source does not replace an existing processed value with a different raw value. This preserves the callback result while keeping the existing explicit-source ordering behavior for normal shared options.

I also added regression coverage for the flag-only case and both mixed ordering cases:

- `--fetch` keeps the callback result
- `--custom typed --fetch` lets the later flag win
- `--fetch --custom typed` lets the later explicit value win

## Testing

- `uv run --group tests pytest tests\test_options.py -k "shared_option_callback_value_is_preserved or default_dual_option_callback" -q`
- `uv run --group tests pytest tests\test_options.py -q`
- `uv run ruff check src\click\core.py tests\test_options.py`
- `uv run --group tests pytest -q`
- `git diff --check`
