### PR TITLE
AI junk

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3320,10 +3320,11 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match="used more than once"):
+        result = runner.invoke(cli, [])
+
+    assert result.exit_code == 0
+    assert result.output == "'second'"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`test_flag_group_competition_duplicate_option_name` only passed when warnings were promoted to errors. When the suite is run with `-Wdefault`, Click still emits the expected duplicate-option warning, but the command exits normally, so the test failed.

## Fix

Assert the duplicate-option `UserWarning` directly with `pytest.warns`, then verify the current command result and output.

## Tests run

- `uv run pytest -q -Wdefault tests/test_options.py::test_flag_group_competition_duplicate_option_name`
- `uv run pytest -q tests/test_options.py::test_flag_group_competition_duplicate_option_name`
- `uv run pytest -q tests/test_options.py -k flag_group_competition`
- `uv run pytest -q`
- `uv run ruff check tests/test_options.py`
- `git diff --check`

## Limitations

No runtime behavior changed; this only updates the test expectation.

Fixes #3476
