### PR TITLE
Add test coverage for 3 or more flag_value options sharing one parameter name

### DIFF
--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -166,6 +166,18 @@ def test_shared_param_prefers_first_default(runner):
     result = runner.invoke(prefers_red, ["--green"])
     assert "green" in result.output
 
+def test_shared_param_default_three_options(runner):
+    @click.command
+    @click.option("--red", "color", flag_value="red")
+    @click.option("--green", "color", flag_value="green", default=True)
+    @click.option("--blue", "color", flag_value="blue")
+    def cli(color):
+        click.echo(color)
+
+    assert "green" in runner.invoke(cli, []).output
+    assert "red" in runner.invoke(cli, ["--red"]).output
+    assert "blue" in runner.invoke(cli, ["--blue"]).output
+
 
 @pytest.mark.parametrize(
     ("default_map", "key", "expected"),

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -166,6 +166,7 @@ def test_shared_param_prefers_first_default(runner):
     result = runner.invoke(prefers_red, ["--green"])
     assert "green" in result.output
 
+
 def test_shared_param_default_three_options(runner):
     @click.command
     @click.option("--red", "color", flag_value="red")


### PR DESCRIPTION
#3079 added a regression test for two flag_value options sharing a name. The original report in #3071 used three options with default=True on the middle one, which isn't directly tested in that PR.

The test gives red/green/blue sharing `color` and the default on green (middle): no args returns green, and passing --red or --blue returns that option's flag_value.

This passes on current main, so it's a coverage only change and does not fail without a code change. Raising it because #3071 is locked so I couldn't open a ticket first, and the reported case (three options) isn't covered today. It's ok to close if you'd rather not carry coverage-only tests.

Test lives next to test_shared_param_prefers_first_default in test_defaults.py.