### PR TITLE
AI spam

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -222,6 +222,9 @@ class ShellComplete:
     be provided by subclasses.
     """
 
+    keep_option_prefix: t.ClassVar[bool] = False
+    """Whether completions for ``--option=value`` should include ``--option=``."""
+
     cli: Command
     ctx_args: cabc.MutableMapping[str, t.Any]
     prog_name: str
@@ -303,6 +306,20 @@ class ShellComplete:
         """
         args, incomplete = self.get_completion_args()
         completions = self.get_completions(args, incomplete)
+
+        if (
+            self.keep_option_prefix
+            and incomplete.startswith("--")
+            and "=" in incomplete
+        ):
+            prefix, _, _ = incomplete.partition("=")
+            completions = [
+                CompletionItem(
+                    f"{prefix}={item.value}", item.type, item.help, **item._info
+                )
+                for item in completions
+            ]
+
         out = [self.format_completion(item) for item in completions]
         return "\n".join(out)
 
@@ -312,6 +329,7 @@ class BashComplete(ShellComplete):
 
     name: t.ClassVar[str] = "bash"
     source_template: t.ClassVar[str] = _SOURCE_BASH
+    keep_option_prefix: t.ClassVar[bool] = True
 
     @staticmethod
     def _check_version() -> None:
@@ -371,6 +389,7 @@ class ZshComplete(ShellComplete):
 
     name: t.ClassVar[str] = "zsh"
     source_template: t.ClassVar[str] = _SOURCE_ZSH
+    keep_option_prefix: t.ClassVar[bool] = True
 
     def get_completion_args(self) -> tuple[list[str], str]:
         cwords = split_arg_string(os.environ["COMP_WORDS"])

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -373,6 +373,50 @@ def test_full_complete(runner, shell, env, expect):
     assert result.output == expect
 
 
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        (
+            "bash",
+            {"COMP_WORDS": "cli --color=r", "COMP_CWORD": "1"},
+            "plain,--color=red\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --color=r", "COMP_CWORD": "1"},
+            "plain\n--color=red\n_\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_long_option_value_with_equals(runner, shell, env, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["red", "green"]))],
+    )
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        ("bash", {"COMP_WORDS": "cli --color r", "COMP_CWORD": "2"}, "plain,red\n"),
+        ("zsh", {"COMP_WORDS": "cli --color r", "COMP_CWORD": "2"}, "plain\nred\n_\n"),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_long_option_value_with_space(runner, shell, env, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["red", "green"]))],
+    )
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
 def test_source_uses_lf_line_endings(monkeypatch):
     stdout = io.BytesIO()
     stream = io.TextIOWrapper(stdout, encoding="utf-8", newline="\r\n")


### PR DESCRIPTION
Fixes #2847.

## Summary
- Preserve the `--option=` prefix when Bash and Zsh shell completion return values for an incomplete `--long-option=value` word.
- Keep the existing `--long-option value` completion behavior unchanged.
- Add regression coverage for Bash and Zsh completion helper output for both equals and space-separated option values.

## Root Cause
Click already resolved `--option=value` into the option plus the incomplete value before asking the option type for completions, but Bash and Zsh replace the entire current shell word. Returning only the completed value, such as `red`, caused the shell to replace `--color=r` with `red` instead of `--color=red`.

## Validation
- `PYTHONPATH=src /opt/miniconda3/bin/python3.13 -m pytest tests/test_shell_completion.py -q`
- `PYTHONPATH=src /opt/miniconda3/bin/python3.13 -m pytest -q`
- `/opt/miniconda3/bin/ruff check --no-fix src tests`
- `/opt/miniconda3/bin/ruff format --check src/click/shell_completion.py tests/test_shell_completion.py`
- `git diff --check`
