### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- When several options share a name (feature-switch groups), an option the
+  user did not pass no longer overwrites the value produced by the one they
+  did, so the passed option's callback result is preserved. {issue}`2786`
 
 ## Version 8.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Unreleased
 - When several options share a name (feature-switch groups), an option the
   user did not pass no longer overwrites the value produced by the one they
   did, so the passed option's callback result is preserved. {issue}`2786`
+  {pr}`3567`
 
 ## Version 8.4.2
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -507,6 +507,12 @@ class Context:
         # parameter name and both fall back to their default value.
         # Refs: https://github.com/pallets/click/issues/3403
         self._param_default_explicit = {}
+        # Parameters the parser actually produced a value for. Used so a
+        # parameter sharing its name with another (feature-switch groups) does
+        # not claim a value contributed by a sibling option it didn't receive.
+        # ``None`` means the parser hasn't populated it yet.
+        # Refs: https://github.com/pallets/click/issues/2786
+        self._params_from_parser: set[Parameter] | None = None
         self._exit_stack = ExitStack()
 
     @property
@@ -1320,6 +1326,7 @@ class Command:
 
         parser = self.make_parser(ctx)
         opts, args, param_order = parser.parse_args(args=args)
+        ctx._params_from_parser = set(param_order)
 
         for param in iter_params_for_processing(param_order, self.get_params(ctx)):
             _, args = param.handle_parse_result(ctx, opts, args)
@@ -2440,6 +2447,18 @@ class Parameter(ABC):
         """
         # Collect from the parse the value passed by the user to the CLI.
         value = opts.get(self.name, UNSET)
+        # When several parameters share the same name (feature-switch groups),
+        # the parser records the value under that shared name. If this parameter
+        # was not the one the user actually provided, the value belongs to a
+        # sibling and must not be claimed here, otherwise this parameter could
+        # overwrite the value the winning option produced.
+        # Refs: https://github.com/pallets/click/issues/2786
+        if (
+            value is not UNSET
+            and ctx._params_from_parser is not None
+            and self not in ctx._params_from_parser
+        ):
+            value = UNSET
         # If the value is set, it means it was sourced from the command line by the
         # parser, otherwise it left unset by default.
         source = (

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1627,6 +1627,41 @@ def test_default_dual_option_callback(runner, default, args, expected):
 
 
 @pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        # --fetch alone: the flag callback result must win and not be overwritten
+        # by the unspecified --custom option that shares the same name.
+        (["--fetch"], "fetched"),
+        (["--custom", "given"], "given"),
+        # The option specified last wins when both are given.
+        (["--custom", "given", "--fetch"], "fetched"),
+        (["--fetch", "--custom", "given"], "given"),
+        ([], None),
+    ],
+)
+def test_value_option_does_not_override_sibling_flag_callback(runner, args, expected):
+    """A value option and a flag_value option sharing a name must not let the one
+    the user did not pass overwrite the value produced by the other's callback.
+
+    Regression test for https://github.com/pallets/click/issues/2786
+    """
+    sentinel = "__fetch__"
+
+    def resolve(ctx, param, value):
+        return "fetched" if value == sentinel else value
+
+    @click.command()
+    @click.option("--custom", "custom")
+    @click.option("--fetch", "custom", flag_value=sentinel, callback=resolve)
+    def cli(custom):
+        click.echo(repr(custom), nl=False)
+
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0
+    assert result.output == repr(expected)
+
+
+@pytest.mark.parametrize(
     ("flag_value", "envvar_value", "expected"),
     [
         # The envvar match exactly the flag value and is case-sensitive.


### PR DESCRIPTION
Closes #2786.

## The bug

When two options target the same parameter name (a "feature switch" group) and one of them transforms the value in a callback, the option the user *didn't* pass can overwrite the value produced by the one they did:

```python
SENTINEL = "__fetch__"

def resolve(ctx, param, value):
    return fetch() if value == SENTINEL else value   # fetch() -> "foo"

@click.command()
@click.option("--custom", "custom")
@click.option("--fetch", "custom", flag_value=SENTINEL, callback=resolve)
def cli(custom):
    click.echo(custom)
```

```console
$ cli --fetch
$_fetch        # expected: foo
```

The callback runs and returns `"foo"`, but the final value is the raw sentinel.

## Cause

The parser stores option values keyed by the shared parameter name, so `opts["custom"]` holds whatever the last matching option on the command line set (here `--fetch`'s `flag_value`). In `Parameter.consume_value` **both** options read that same slot and both report `ParameterSource.COMMANDLINE`, even though `--custom` was never passed.

`iter_params_for_processing` processes options the user passed first and the rest last, so the unpassed `--custom` (no callback) is handled after `--fetch` and, having the same source, wins the feature-switch arbitration added in #3403 - clobbering `--fetch`'s callback result.

## Fix

The parser already records which parameters actually produced a value (`param_order`). I stash that set on the context and, in `consume_value`, an option that wasn't among them no longer claims a value that a sibling sharing its name put in the slot. It falls back to its own default instead, so the existing arbitration keeps the option the user actually passed as the winner.

The change is gated on the new context attribute being populated, so any code path that calls `consume_value` without going through `parse_args` keeps the old behavior.

## Tests

Added a regression test covering `--fetch`, `--custom`, both orders, and no args; it fails on `main` (`--fetch` returns the raw sentinel) and passes here. Full suite is green and `ruff` is clean.

I left the `{pr}` reference off the changelog entry since I don't have the number yet - happy to add it.
