### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 Unreleased
 
+- `echo`, `secho`, and other color-aware output respect the `NO_COLOR` and
+  `FORCE_COLOR` environment variables when no explicit color preference is
+  set by the caller or context, matching the behavior of the Python
+  interpreter. `NO_COLOR` takes precedence and empty values are ignored.
+  {issue}`3022`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Unreleased
   `FORCE_COLOR` environment variables when no explicit color preference is
   set by the caller or context, matching the behavior of the Python
   interpreter. `NO_COLOR` takes precedence and empty values are ignored.
-  {issue}`3022`
+  {issue}`3022` {pr}`3568`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import typing as t
 from threading import local
 
@@ -54,14 +55,31 @@ def pop_context() -> None:
 def resolve_color_default(color: bool | None = None) -> bool | None:
     """Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
-    the current context.
+    the current context, then from the environment.
+
+    When neither the ``color`` argument nor the active context expresses a
+    preference, the ``NO_COLOR`` and ``FORCE_COLOR`` environment variables are
+    consulted, mirroring how the Python interpreter itself decides whether to
+    colorize output. A non-empty ``NO_COLOR`` disables color and takes
+    precedence over a non-empty ``FORCE_COLOR``, which forces it on; empty
+    values are ignored.
+
+    .. versionchanged:: 8.5
+        The ``NO_COLOR`` and ``FORCE_COLOR`` environment variables are
+        respected as a fallback.
     """
     if color is not None:
         return color
 
     ctx = get_current_context(silent=True)
 
-    if ctx is not None:
+    if ctx is not None and ctx.color is not None:
         return ctx.color
+
+    if os.environ.get("NO_COLOR"):
+        return False
+
+    if os.environ.get("FORCE_COLOR"):
+        return True
 
     return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -855,3 +855,76 @@ def test_make_default_short_help(value, max_length, alter, expect):
 
     out = click.utils.make_default_short_help(value, max_length)
     assert out == expect
+
+
+def test_echo_no_color_env(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: True)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    styled = click.style("foo", fg="red")
+
+    click.echo(styled)
+    out, _ = capfd.readouterr()
+    assert out == "foo\n"  # color stripped despite an interactive terminal
+
+
+def test_echo_force_color_env(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    styled = click.style("foo", fg="red")
+
+    click.echo(styled)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled}\n"  # color kept despite a non-interactive stream
+
+
+def test_echo_no_color_takes_precedence_over_force_color(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: True)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    styled = click.style("foo", fg="red")
+
+    click.echo(styled)
+    out, _ = capfd.readouterr()
+    assert out == "foo\n"
+
+
+def test_echo_empty_color_env_is_ignored(monkeypatch, capfd):
+    # Empty values are not a preference, so auto-detection (a tty here) wins.
+    monkeypatch.setattr(click._compat, "isatty", lambda x: True)
+    monkeypatch.setenv("NO_COLOR", "")
+    monkeypatch.setenv("FORCE_COLOR", "")
+    styled = click.style("foo", fg="red")
+
+    click.echo(styled)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled}\n"
+
+
+def test_echo_explicit_color_arg_overrides_color_env(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: True)
+    monkeypatch.setenv("NO_COLOR", "1")
+    styled = click.style("foo", fg="red")
+
+    click.echo(styled, color=True)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled}\n"  # explicit color=True beats NO_COLOR
+
+
+def test_resolve_color_default_reads_color_env(monkeypatch):
+    from click.globals import resolve_color_default
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    assert resolve_color_default() is None
+    assert resolve_color_default(True) is True
+    assert resolve_color_default(False) is False
+
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert resolve_color_default() is False
+    assert resolve_color_default(True) is True  # explicit preference wins
+
+    monkeypatch.delenv("NO_COLOR")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert resolve_color_default() is True


### PR DESCRIPTION
Adds support for the `NO_COLOR` and `FORCE_COLOR` environment variables, as requested in #3022.

`resolve_color_default()` is the single place every color-aware output path goes through (`echo`, `secho`, `prompt`, and error display). Today it returns the explicit `color` argument if one is given, otherwise the active context's `color`, otherwise `None` (auto-detect from whether the stream is a TTY). This adds one more fallback step: when neither the caller nor the context expresses a preference, the environment is consulted.

- A non-empty `NO_COLOR` disables color (per https://no-color.org).
- A non-empty `FORCE_COLOR` forces it on.
- `NO_COLOR` takes precedence over `FORCE_COLOR`; empty values are ignored.

This helps in CI (GitHub Actions, GitLab, Jenkins), where stdout is not a TTY but colored logs are often wanted, and conversely for users who set `NO_COLOR` globally. An explicit `color=` argument or a context `color` setting still wins, so nothing changes for callers that already opt in or out, and behavior is unchanged when neither variable is set.

fixes #3022

### Changes

- `src/click/globals.py` — `resolve_color_default()` falls back to `NO_COLOR` / `FORCE_COLOR`, with a `.. versionchanged:: 8.5` note.
- `tests/test_utils.py` — tests for the env fallback, `NO_COLOR` precedence over `FORCE_COLOR`, empty-value handling, explicit-argument override, and a direct unit test of `resolve_color_default()`.
- `CHANGES.md` — changelog entry.

### Notes

I went with the no-color.org convention where a variable counts only when set to a non-empty string (so `NO_COLOR= mytool` does *not* disable color), rather than mere presence. Happy to switch to presence-based checks if you'd rather match the interpreter's exact semantics.
