### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Document what part of shell completion display is handled by Click versus
+  the shell. {issue}`3135`
 
 ## Version 8.4.2
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -37,3 +37,21 @@ Note that I used single quotes above, so my shell is not expanding the environme
 
 If you don't want Click to emulate (as best it can) unix expansion on Windows, pass windows_expand_args=False when calling the CLI.
 Windows command line doesn't do any *, ~, or $ENV expansion. It also doesn't distinguish between double quotes and single quotes (where the later means "don't expand here"). Click emulates the expansion so that the app behaves similarly on both platforms, but doesn't receive information about what quotes were used.
+
+### Shell Completion Display
+
+When completing a path, my shell only shows the filename part instead of the
+full path. Can Click do the same thing for custom completion values?
+
+#### Answer
+
+Click can mark file and path completion results specially. The shell's
+completion system then decides how those paths are shown. Some shells shorten
+path suggestions to the basename, while others may show them differently.
+
+For custom completion values, Click sends the full completion value to the
+shell. Display behavior such as showing only a basename is handled by the shell,
+not by Click in a general way.
+
+If you want different display behavior for a specific shell, write a custom
+shell completer for that shell.


### PR DESCRIPTION
Add an FAQ entry explaining which parts of completion display come from
Click and which parts come from the shell.

Fixes #3135.

Docs were updated in `docs/faqs.md`, with a `CHANGES.md` entry.

Checked:
- `git diff --check`
- edited Markdown lines wrap at 80 characters
- `uv run tox r -e docs`