### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Shell completion no longer invokes callable defaults, callable default map
+  entries, or parameter callbacks while resolving the completion context.
+  {issue}`2614` {pr}`3570`
 
 ## Version 8.4.2
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2455,18 +2455,26 @@ class Parameter(ABC):
                 source = ParameterSource.ENVIRONMENT
 
         if value is UNSET:
-            default_map_value = ctx.lookup_default(self.name)
-            if default_map_value is not None or ctx._default_map_has(self.name):
-                value = default_map_value
-                source = ParameterSource.DEFAULT_MAP
+            if ctx.resilient_parsing:
+                default_map_value = ctx.lookup_default(self.name, call=False)
+            else:
+                default_map_value = ctx.lookup_default(self.name)
 
-                # A string from default_map must be split for multi-value
-                # parameters, matching value_from_envvar behavior.
-                if isinstance(value, str) and self.nargs != 1:
-                    value = self.type.split_envvar_value(value)
+            if default_map_value is not None or ctx._default_map_has(self.name):
+                if not (ctx.resilient_parsing and callable(default_map_value)):
+                    value = default_map_value
+                    source = ParameterSource.DEFAULT_MAP
+
+                    # A string from default_map must be split for multi-value
+                    # parameters, matching value_from_envvar behavior.
+                    if isinstance(value, str) and self.nargs != 1:
+                        value = self.type.split_envvar_value(value)
 
         if value is UNSET:
-            default_value = self.get_default(ctx)
+            default_value = self.get_default(ctx, call=not ctx.resilient_parsing)
+            if ctx.resilient_parsing and callable(default_value):
+                default_value = UNSET
+
             if default_value is not UNSET:
                 value = default_value
                 source = ParameterSource.DEFAULT
@@ -2574,7 +2582,7 @@ class Parameter(ABC):
         if self.required and self.value_is_missing(value):
             raise MissingParameter(ctx=ctx, param=self)
 
-        if self.callback is not None:
+        if self.callback is not None and not ctx.resilient_parsing:
             # Legacy case: UNSET is not exposed directly to the callback, but converted
             # to None.
             if value is UNSET:
@@ -3533,7 +3541,7 @@ class Option(Parameter):
         if self.is_flag and not self.required and self.is_bool_flag and value is UNSET:
             value = False
 
-            if self.callback is not None:
+            if self.callback is not None and not ctx.resilient_parsing:
                 value = self.callback(ctx, self, value)
 
             return value

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -142,6 +142,60 @@ def test_argument_default():
     assert _get_words(cli, ["x"], "b") == ["b"]
 
 
+def test_resilient_parsing_skips_default_callbacks():
+    def default():
+        raise AssertionError("default should not be called")
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--expensive"], default=default),
+            Option(["--color"], type=Choice(["auto", "always", "never"])),
+        ],
+    )
+
+    assert _get_words(cli, ["--color"], "a") == ["auto", "always"]
+
+
+def test_resilient_parsing_skips_parameter_callbacks():
+    def callback(ctx, param, value):
+        raise AssertionError("callback should not be called")
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--expensive"], default="value", callback=callback),
+            Option(["--color"], type=Choice(["auto", "always", "never"])),
+        ],
+    )
+
+    assert _get_words(cli, ["--color"], "a") == ["auto", "always"]
+
+
+def test_resilient_parsing_skips_default_map_callbacks():
+    def default():
+        raise AssertionError("default map should not be called")
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--expensive"]),
+            Option(["--color"], type=Choice(["auto", "always", "never"])),
+        ],
+    )
+    comp = ShellComplete(
+        cli,
+        {"default_map": {"expensive": default}},
+        cli.name,
+        "_CLICK_COMPLETE",
+    )
+
+    assert [c.value for c in comp.get_completions(["--color"], "a")] == [
+        "auto",
+        "always",
+    ]
+
+
 def test_type_choice():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["a1", "a2", "b"]))])
     assert _get_words(cli, ["-c"], "") == ["a1", "a2", "b"]


### PR DESCRIPTION
Shell completion resolves a context with resilient parsing enabled, but callable defaults, callable default map entries, and parameter callbacks were still invoked while processing missing parameters. That can make completion unexpectedly slow or fail if those callbacks depend on normal command execution state.

This updates value processing so resilient parsing does not invoke those callables, while leaving static defaults available for existing completion behavior. It also adds shell completion regression tests covering callable defaults, callable default map entries, and parameter callbacks.

fixes #2614

Tests:
- uv run pytest -q
- uv run tox run -e style
- uv run tox run -e typing

CHANGES.md has been updated.