### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- `CliRunner` strips ANSI codes from prompts when `color=False`, matching the
+  behavior of `echo`. This was broken in `8.4.0` when prompt text moved off the
+  `echo` path for readline support. {issue}`3572`
 
 ## Version 8.4.1
 

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -471,9 +471,18 @@ class CliRunner:
             errors="backslashreplace",
         )
 
+        def _normalize_prompt(prompt: str | None) -> str:
+            # Prompts are written directly to stdout here rather than through
+            # ``echo``, so honor ``color=False`` by stripping ANSI codes as
+            # ``echo`` would.
+            prompt = prompt or ""
+            if not color:
+                prompt = _compat.strip_ansi(prompt)
+            return prompt
+
         @_pause_echo(echo_input)  # type: ignore
         def visible_input(prompt: str | None = None) -> str:
-            sys.stdout.write(prompt or "")
+            sys.stdout.write(_normalize_prompt(prompt))
             try:
                 val = next(text_input).rstrip("\r\n")
             except StopIteration as e:
@@ -484,7 +493,7 @@ class CliRunner:
 
         @_pause_echo(echo_input)  # type: ignore
         def hidden_input(prompt: str | None = None) -> str:
-            sys.stdout.write(f"{prompt or ''}\n")
+            sys.stdout.write(f"{_normalize_prompt(prompt)}\n")
             sys.stdout.flush()
             try:
                 return next(text_input).rstrip("\r\n")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -256,6 +256,28 @@ def test_with_color_but_pause_not_blocking():
     assert result.output == ""
 
 
+def test_prompt_strips_ansi_with_color_false():
+    @click.command()
+    def cli():
+        click.prompt(click.style("Name", fg="green"))
+        click.prompt(click.style("Secret", fg="green"), hide_input=True)
+        click.confirm(click.style("Continue", fg="green"))
+
+    runner = CliRunner()
+
+    result = runner.invoke(cli, input="x\ns\ny\n", color=False)
+    assert result.output == "Name: x\nSecret: \nContinue [y/N]: y\n"
+    assert not result.exception
+
+    result = runner.invoke(cli, input="x\ns\ny\n", color=True)
+    assert result.output == (
+        f"{click.style('Name', fg='green')}: x\n"
+        f"{click.style('Secret', fg='green')}: \n"
+        f"{click.style('Continue', fg='green')} [y/N]: y\n"
+    )
+    assert not result.exception
+
+
 def test_with_echo_via_pager():
     @click.command()
     def cli():


### PR DESCRIPTION
Fixes #3572

`CliRunner` writes prompt text directly to stdout via `visible_input` /
`hidden_input` rather than through `echo`, so `color=False` did not strip ANSI
codes from prompts. This regressed in 8.4.0, when `confirm()` / `prompt()` output
moved off the `echo` path for readline support. The fix strips ANSI in those two
functions when `color=False`, matching what `echo` does.

- **Test:** added `test_prompt_strips_ansi_with_color_false`, asserting prompts are
  stripped with `color=False` and preserved with `color=True`. It fails on `main`
  without this change.
- **Changelog:** added an entry under the unreleased 8.4.2 section in `CHANGES.md`.

LinkedIn: redacted