### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- Fix Bash shell completion when ``=`` is in ``COMP_WORDBREAKS``, causing
+  ``--option=value`` to be split into separate tokens. Fix Zsh shell completion
+  so that ``--option=value`` completions include the ``--option=`` prefix,
+  allowing the shell to replace the whole word correctly. {issue}`2847`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -360,6 +360,23 @@ class BashComplete(ShellComplete):
         except IndexError:
             incomplete = ""
 
+        # Bash may split ``--option=value`` into ``["--option", "=", "value"]``
+        # when ``=`` is in ``COMP_WORDBREAKS``. Reassemble the option and its
+        # partial value so that ``_resolve_incomplete`` can handle it normally.
+        #
+        # .. versionchanged:: 8.5.0
+        #     Reassemble ``--option = value`` tokens split by ``COMP_WORDBREAKS``.
+        if incomplete and args and args[-1] == "=":
+            # args[-2] is the option name, args[-1] is "=", incomplete is the value
+            if len(args) >= 2 and _start_of_option_str(args[-2]):
+                incomplete = args[-2] + "=" + incomplete
+                args = args[:-2]
+        elif not incomplete and args and args[-1] == "=":
+            # cursor is right after "=", value is empty
+            if len(args) >= 2 and _start_of_option_str(args[-2]):
+                incomplete = args[-2] + "="
+                args = args[:-2]
+
         return args, incomplete
 
     def format_completion(self, item: CompletionItem) -> str:
@@ -383,6 +400,40 @@ class ZshComplete(ShellComplete):
             incomplete = ""
 
         return args, incomplete
+
+    def complete(self) -> str:
+        args, incomplete = self.get_completion_args()
+
+        # Zsh passes ``--option=value`` as a single word. ``_resolve_incomplete``
+        # already strips the ``--option=`` prefix internally, but the returned
+        # completion values are bare (e.g. ``always`` instead of
+        # ``--color=always``). Zsh's ``compadd`` replaces the *whole* current
+        # word, so we must restore the prefix on every completion value.
+        #
+        # .. versionchanged:: 8.5.0
+        #     Prepend ``--option=`` prefix to completions for ``--option=value``
+        #     words so Zsh replaces the whole token correctly.
+        option_prefix = ""
+        if "=" in incomplete and _start_of_option_str(incomplete):
+            option_prefix, _, _ = incomplete.partition("=")
+            option_prefix += "="
+            # Pass the original ``incomplete`` unchanged; ``_resolve_incomplete``
+            # will strip the prefix itself when resolving the parameter.
+
+        completions = self.get_completions(args, incomplete)
+
+        if option_prefix:
+            completions = [
+                CompletionItem(
+                    f"{option_prefix}{item.value}",
+                    type=item.type,
+                    help=item.help,
+                )
+                for item in completions
+            ]
+
+        out = [self.format_completion(item) for item in completions]
+        return "\n".join(out)
 
     def format_completion(self, item: CompletionItem) -> str:
         help_ = item.help or "_"
@@ -546,6 +597,11 @@ def _start_of_option(ctx: Context, value: str) -> bool:
 
     c = value[0]
     return c in ctx._opt_prefixes
+
+
+def _start_of_option_str(value: str) -> bool:
+    """Check if *value* looks like an option name (starts with ``-``)."""
+    return bool(value) and value[0] == "-"
 
 
 def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bool:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -585,3 +585,60 @@ def test_fish_format_completion_escapes_help():
     # The newline is escaped to the literal characters backslash-n and the tab
     # becomes a space, so each completion stays on one line for fish.
     assert fc.format_completion(item) == "plain,--at\tfirst\\nsecond third"
+
+
+@pytest.mark.parametrize(
+    ("env", "expect"),
+    [
+        # Bash splits "--color=auto" into ["--color", "=", "auto"] when
+        # COMP_WORDBREAKS includes "=". Completions should still be returned.
+        (
+            {"COMP_WORDS": "cli --color =", "COMP_CWORD": "2"},
+            "plain,auto\nplain,always\nplain,never\n",
+        ),
+        (
+            {"COMP_WORDS": "cli --color = al", "COMP_CWORD": "3"},
+            "plain,always\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_bash_completion_with_equals_separator(runner, env, expect):
+    """Bash splits ``--opt=val`` into ``--opt``, ``=``, ``val`` when ``=`` is
+    in ``COMP_WORDBREAKS``. Completion should recognise the option and return
+    value completions."""
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    env["_CLI_COMPLETE"] = "bash_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("env", "expect"),
+    [
+        # Zsh keeps "--color=auto" as one word; completions must preserve the
+        # "--color=" prefix so that compadd replaces the whole token.
+        (
+            {"COMP_WORDS": "cli --color=", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\nplain\n--color=never\n_\n",
+        ),
+        (
+            {"COMP_WORDS": "cli --color=al", "COMP_CWORD": "1"},
+            "plain\n--color=always\n_\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_zsh_completion_with_equals_separator(runner, env, expect):
+    """Zsh passes ``--opt=val`` as a single word; completions must include the
+    ``--opt=`` prefix so that the shell replaces the whole word correctly."""
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    env["_CLI_COMPLETE"] = "zsh_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect


### PR DESCRIPTION
Bash includes `=` in `COMP_WORDBREAKS` by default, which causes the shell to
split `--option=value` into three separate completion tokens: `--option`, `=`,
and `value`. Click's `BashComplete.get_completion_args` was not aware of this
split, so the option was never identified and no completions were returned.

Zsh passes `--option=value` as a single word. `_resolve_incomplete` correctly
strips the prefix and finds the right parameter, but the returned completions
are bare values (e.g. `always`). Zsh's `compadd` replaces the *whole* current
word, so inserting bare `always` discards the `--color=` prefix the user had
already typed.

fixes #2847

**Changes:**

- `BashComplete.get_completion_args`: detect the `["--option", "=", "value"]`
  split pattern and reassemble it into a single `--option=value` incomplete
  string before passing to `_resolve_incomplete`.
- `ZshComplete.complete`: when `incomplete` contains `--option=value`, save the
  `--option=` prefix, let `get_completions` resolve normally, then prepend the
  prefix to every returned completion value.
- New private helper `_start_of_option_str(value)` for a context-free "looks
  like an option" check (used before a `Context` is available).

**Tests:**

- `test_bash_completion_with_equals_separator`: two parametrised cases —
  cursor at `=` (empty value) and cursor after partial value. Both fail without
  the fix.
- `test_zsh_completion_with_equals_separator`: two parametrised cases —
  cursor at `=` (empty value) and cursor after partial value. Both fail without
  the fix.
- All 54 pre-existing completion tests continue to pass (58 total after adding
  the 4 new ones; 1676 suite-wide).

**Checklist (CONTRIBUTING.rst):**

- [x] Tests fail without the change, pass with it.
- [x] `.. versionchanged:: 8.5.0` entries added to the affected methods.
- [x] Entry added to `CHANGES.md` under Version 8.5.0.
- [x] Ruff checks pass (`ruff check` and `ruff format --check`).
