### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- `prompt` and `confirm` strip ANSI codes from the prompt text again when
+  color is disabled. The prompt is passed to `input()` directly since 8.4.0,
+  bypassing `echo` and its ANSI handling. {issue}`3572` {pr}`3575`
 
 ## Version 8.4.1
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -11,6 +11,7 @@ from contextlib import AbstractContextManager
 from contextlib import redirect_stdout
 from gettext import gettext as _
 
+from . import _compat
 from ._compat import isatty
 from ._compat import strip_ansi
 from .exceptions import Abort
@@ -84,6 +85,12 @@ def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
     """Call a prompt function, passing the full prompt on non-Windows so
     readline can handle line editing and cursor positioning correctly.
     """
+    # The prompt bypasses ``echo``, so ANSI codes must be stripped here
+    # when color is disabled. Look up ``should_strip_ansi`` through the
+    # module as ``CliRunner`` replaces it during isolation.
+    stream = sys.stderr if err else sys.stdout
+    if _compat.should_strip_ansi(stream, resolve_color_default()):
+        text = strip_ansi(text)
     if err:
         with redirect_stdout(sys.stderr):
             return func(text)

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1560,3 +1560,47 @@ def test_hide_input_value_never_leaks_when_err_true(runner):
     result = runner.invoke(cli, input="leaky\n", mix_stderr=False)
     assert "leaky" not in result.stdout
     assert "leaky" not in result.stderr
+
+
+@pytest.mark.parametrize("color", [False, True])
+def test_prompt_strips_ansi_when_color_disabled(runner, color):
+    """Since 8.4 the full prompt is passed to ``input()`` and bypasses
+    ``echo``, so ANSI codes must be stripped separately when color is
+    disabled. https://github.com/pallets/click/issues/3572
+    """
+    styled = click.style("Name", fg="green")
+
+    @click.command()
+    def cli():
+        click.prompt(styled, default="x")
+
+    result = runner.invoke(cli, input="\n", color=color)
+    expected = f"{styled} [x]: \n" if color else "Name [x]: \n"
+    assert result.output == expected
+
+
+@pytest.mark.parametrize("color", [False, True])
+def test_confirm_strips_ansi_when_color_disabled(runner, color):
+    """See ``test_prompt_strips_ansi_when_color_disabled``."""
+    styled = click.style("Continue?", fg="green")
+
+    @click.command()
+    def cli():
+        click.confirm(styled, abort=True)
+
+    result = runner.invoke(cli, input="y\n", color=color)
+    expected = f"{styled} [y/N]: y\n" if color else "Continue? [y/N]: y\n"
+    assert result.output == expected
+
+
+def test_confirm_err_strips_ansi_when_color_disabled(runner):
+    """The prompt is redirected to stderr with ``err=True``; ANSI codes
+    must be stripped on that stream as well.
+    """
+
+    @click.command()
+    def cli():
+        click.confirm(click.style("Continue?", fg="green"), err=True)
+
+    result = runner.invoke(cli, input="y\n")
+    assert result.stderr == "Continue? [y/N]: y\n"


### PR DESCRIPTION
Since 8.4.0, `_readline_prompt` passes the full prompt text to `input()` so readline handles line editing correctly (#2969). That bypasses `echo()` and its ANSI handling, so `click.prompt()` and `click.confirm()` leak styling codes when color is disabled — `click.confirm` as reported, and `click.prompt` equally (same code path).

The fix strips the codes in `_readline_prompt` using the same `should_strip_ansi(stream, resolve_color_default())` decision `echo()` uses, with the stream chosen by `err`, restoring the pre-8.4 behavior where the prompt went through `echo`. The lookup goes through the `_compat` module attribute because `CliRunner` replaces `should_strip_ansi` during isolation.

Tests cover `prompt` and `confirm` with color disabled and enabled (codes must survive `color=True`), and the `err=True` stderr path; the three stripping tests fail without the change.

fixes #3572