### PR TITLE
Fix double-bracketing of choices in synopsis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- Fix CLI usage symopsis for optional arguments producing double square brackets
+  `[[a|b|c]]...` whose type already brackets their metavar. {pr}`3578`
 
 ## Version 8.4.1
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3571,9 +3571,14 @@ class Argument(Parameter):
         var = self.type.get_metavar(param=self, ctx=ctx)
         if not var:
             var = self.name.upper()
+        # Types like ``Choice`` and ``DateTime`` already surround their metavar
+        # with square brackets to enumerate the allowed values. Reuse those
+        # outer brackets as the optional-argument indicator instead of wrapping
+        # the metavar in a second pair, which would produce ``[[a|b|c]]``.
+        already_bracketed = var.startswith("[") and var.endswith("]")
         if self.deprecated:
             var += "!"
-        if not self.required:
+        if not self.required and not already_bracketed:
             var = f"[{var}]"
         if self.nargs != 1:
             var += "..."

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -569,6 +569,46 @@ def test_choice_argument_none(runner):
     assert result.output.startswith("Usage: cli [OPTIONS] {not-none|none}\n")
 
 
+def test_choice_argument_optional_metavar(runner):
+    """Optional Choice arguments reuse the type's brackets instead of doubling.
+
+    Without this the usage line for a ``Choice`` argument with ``nargs=-1`` or
+    ``required=False`` rendered as ``[[a|b|c]]``: one pair from ``Choice`` to
+    enumerate values, a second pair from ``Argument`` to mark it optional.
+    """
+
+    @click.command()
+    @click.argument("method", type=click.Choice(["foo", "bar", "baz"]), nargs=-1)
+    def cli_variadic(method):
+        pass
+
+    @click.command()
+    @click.argument("method", type=click.Choice(["foo", "bar", "baz"]), required=False)
+    def cli_optional(method):
+        pass
+
+    variadic = runner.invoke(cli_variadic, ["--help"]).output
+    assert "Usage: cli-variadic [OPTIONS] [foo|bar|baz]...\n" in variadic
+    assert "[[foo|bar|baz]]" not in variadic
+
+    optional = runner.invoke(cli_optional, ["--help"]).output
+    assert "Usage: cli-optional [OPTIONS] [foo|bar|baz]\n" in optional
+    assert "[[foo|bar|baz]]" not in optional
+
+
+def test_datetime_argument_optional_metavar(runner):
+    """``DateTime`` arguments behave the same way as ``Choice``."""
+
+    @click.command()
+    @click.argument("when", type=click.DateTime(formats=["%Y-%m-%d"]), required=False)
+    def cli(when):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert "Usage: cli [OPTIONS] [%Y-%m-%d]\n" in result.output
+    assert "[[%Y-%m-%d]]" not in result.output
+
+
 def test_datetime_option_default(runner):
     @click.command()
     @click.option("--start_date", type=click.DateTime())


### PR DESCRIPTION
A small rendering issue of choices being enclosed into double-brackets when argument is optional.

Issue was likely unnoticed in the original https://github.com/pallets/click/issues/1272 / https://github.com/pallets/click/issues/1273 PR.

This mirrors the similar fix I implemented for commands in https://github.com/pallets/click/pull/3507