### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- The test suite no longer relies on warnings being treated as errors, so it
+  passes when run with the default warning filter. {issue}`3476`
 
 ## Version 8.4.1
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3320,10 +3320,8 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match="used more than once"):
+        runner.invoke(cli, [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3476.

`test_flag_group_competition_duplicate_option_name` asserted on
`result.exception`, which only works because the test suite turns warnings
into errors (`filterwarnings = ["error"]`). When the test runs under the
default warning filter (`pytest -W default`), the `UserWarning` is emitted
but not raised, so the command exits 0 and the assertions fail. This breaks
downstream packagers who run the suite with different warning filters.

This uses `pytest.warns(UserWarning, match="used more than once")` to assert
the warning directly, so the test passes regardless of the active warning
filter (it still passes under the project's warnings-as-errors config).

- [x] Reproduced the failure with `pytest -W default`
- [x] Test passes under both `-W default` and the default warnings-as-errors config
- [x] Full `tests/test_options.py` suite passes (644 passed)
- [x] `ruff check` and `ruff format` clean
- [x] Changelog entry added