### PR TITLE
Add `@custom_version_option`, freeze `@version_option`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Unreleased
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
+- Add {func}`custom_version_option`, a `--version` option whose output is
+  produced by a callback, covering cases {func}`version_option` intentionally
+  does not. The feature set of {func}`version_option` is now frozen; see
+  [discussion #3527](https://github.com/pallets/click/discussions/3527). {pr}`3581`
 
 ## Version 8.4.2
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,10 @@ classes and functions.
 ```
 
 ```{eval-rst}
+.. autofunction:: custom_version_option
+```
+
+```{eval-rst}
 .. autofunction:: help_option
 ```
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -128,6 +128,13 @@ that instead:
                 print(idx, file=pager)
 ```
 
+```{hint} Why print instead of echo?
+The pager object deals with ANSI color and style codes itself: they are kept or
+stripped depending on what the pager supports, exactly as {func}`echo` would do.
+Any code that writes to a file, including plain {func}`print`, can therefore be
+used with it.
+```
+
 ## Screen Clearing
 
 ```{versionadded} 2.0
@@ -383,7 +390,7 @@ import time
 
 with click.progressbar([1, 2, 3]) as bar:
     for x in bar:
-        print(f"sleep({x})...")
+        click.echo(f"sleep({x})...")
         time.sleep(x)
 ```
 

--- a/src/click/__init__.py
+++ b/src/click/__init__.py
@@ -18,6 +18,7 @@ from .core import ParameterSource as ParameterSource
 from .decorators import argument as argument
 from .decorators import command as command
 from .decorators import confirmation_option as confirmation_option
+from .decorators import custom_version_option as custom_version_option
 from .decorators import group as group
 from .decorators import help_option as help_option
 from .decorators import make_pass_decorator as make_pass_decorator

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -440,6 +440,16 @@ def version_option(
     :func:`importlib.metadata.packages_distributions`, so e.g. ``PIL``
     resolves to the ``Pillow`` distribution.
 
+    .. note::
+        The parameters and message variables accepted by this option are
+        frozen: no new slots will be added, to keep the common case simple
+        and predictable. If you need values it does not expose, such as a
+        file path, the Python version, or git metadata, use
+        :func:`custom_version_option` to render the output yourself.
+
+        Rationale: `discussion #3527
+        <https://github.com/pallets/click/discussions/3527>`_.
+
     :param version: The version number to show. If not provided, Click
         will try to detect it.
     :param param_decls: One or more option names. Defaults to the single
@@ -545,6 +555,48 @@ def version_option(
     kwargs.setdefault("is_eager", True)
     kwargs.setdefault("help", _("Show the version and exit."))
     kwargs["callback"] = callback
+    return option(*param_decls, **kwargs)
+
+
+def custom_version_option(
+    callback: t.Callable[[Context], str],
+    *param_decls: str,
+    **kwargs: t.Any,
+) -> t.Callable[[FC], FC]:
+    """Add a ``--version`` option whose output is produced by ``callback``.
+
+    This is the customizable companion to :func:`version_option`. Where
+    :func:`version_option` is intentionally limited to a fixed message and
+    a small set of values, this option calls ``callback`` to build the
+    whole string to print. Use it when you need values that
+    :func:`version_option` does not expose, such as a file path, the
+    Python version, or git metadata.
+
+    :param callback: Called with the current :class:`Context` when the
+        option is invoked. Its return value is printed, then the program
+        exits.
+    :param param_decls: One or more option names. Defaults to the single
+        value ``--version``.
+    :param kwargs: Extra arguments are passed to :func:`option`.
+
+    .. versionadded:: 8.5.0
+    """
+
+    def show_version(ctx: Context, param: Parameter, value: bool) -> None:
+        if not value or ctx.resilient_parsing:
+            return
+
+        echo(callback(ctx), color=ctx.color)
+        ctx.exit()
+
+    if not param_decls:
+        param_decls = ("--version",)
+
+    kwargs.setdefault("is_flag", True)
+    kwargs.setdefault("expose_value", False)
+    kwargs.setdefault("is_eager", True)
+    kwargs.setdefault("help", _("Show the version and exit."))
+    kwargs["callback"] = show_version
     return option(*param_decls, **kwargs)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -857,3 +857,26 @@ def test_version_option_unknown_package_errors(runner, monkeypatch):
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code != 0
     assert "not installed" in str(result.exception)
+
+
+@pytest.mark.parametrize("args", [["--version"], ["-V"]])
+def test_custom_version_option(runner, args):
+    @click.command()
+    @click.custom_version_option(lambda ctx: "custom 9.9.9", "-V", "--version")
+    def cli():
+        pass
+
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0
+    assert result.output == "custom 9.9.9\n"
+
+
+def test_custom_version_option_receives_context(runner):
+    @click.command()
+    @click.custom_version_option(lambda ctx: f"{ctx.info_name} 1.0")
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--version"], prog_name="mytool")
+    assert result.exit_code == 0
+    assert result.output == "mytool 1.0\n"


### PR DESCRIPTION
This is an attempt to address the design discussion we started in #3527 about `@version_option` extensibility.

What's in this PR:
- A `.. note::` admonition to point to `@version_option` freeze.
- A new `@custom_version_option` that mirrors `@help_option` and `@version_option` and takes a callback for a custom message.

I did not take the class-based approach here, as it reminded me of the `HelpOption` class that I was too fast to add in #2563 (v8.1.8) then had to remove in #2832/#2840 (v8.2.0).

If I like the explicitness of the freeze admonition, I don't like the rest of the code: the naming of `@custom_version_option` and the apparent duplication with `@version_option`. But I produced this PR anyway to explore the effect of our policy and to have a concrete example to discuss.
