### PR TITLE
Fix `package_name` resolution when module differs from distribution name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,12 @@ Unreleased
   {pr}`3533`
 - Fix CLI usage symopsis for optional arguments producing double square brackets
   `[[a|b|c]]...` whose type already brackets their metavar. {pr}`3578`
+- {func}`version_option` resolves a `package_name` that does not match an
+  installed distribution as an import (top-level module) name via
+  {func}`importlib.metadata.packages_distributions`. Packages whose
+  top-level module name differs from their distribution name (`PIL` vs
+  `Pillow`, `jwt` vs `PyJWT`) no longer raise `RuntimeError` out of the
+  box. {issue}`2331` {issue}`1884` {issue}`3125` {pr}`3582`
 
 ## Version 8.4.1
 

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -434,8 +434,11 @@ def version_option(
     ``package_name``.
 
     If ``package_name`` is not provided, Click will try to detect it by
-    inspecting the stack frames. This will be used to detect the
-    version, so it must match the name of the installed package.
+    inspecting the stack frames. If the detected (or given) name does
+    not match an installed distribution, Click resolves it as an import
+    (top-level module) name via
+    :func:`importlib.metadata.packages_distributions`, so e.g. ``PIL``
+    resolves to the ``Pillow`` distribution.
 
     :param version: The version number to show. If not provided, Click
         will try to detect it.
@@ -460,6 +463,10 @@ def version_option(
         version is detected based on the package name, not the entry
         point name. The Python package name must match the installed
         package name, or be passed with ``package_name=``.
+
+    .. versionchanged:: 8.4.2
+        When ``package_name`` does not match an installed distribution,
+        Click now resolves it as an import (top-level module).
     """
     if message is None:
         message = _("%(prog)s, version %(version)s")
@@ -487,6 +494,7 @@ def version_option(
 
         nonlocal prog_name
         nonlocal version
+        nonlocal package_name
 
         if prog_name is None:
             prog_name = ctx.find_root().info_name
@@ -497,10 +505,26 @@ def version_option(
             try:
                 version = importlib.metadata.version(package_name)
             except importlib.metadata.PackageNotFoundError:
-                raise RuntimeError(
-                    f"{package_name!r} is not installed. Try passing"
-                    " 'package_name' instead."
-                ) from None
+                # The given name didn't match an installed distribution.
+                # Try resolving it as an import (top-level module) name,
+                # e.g. ``PIL`` is provided by the ``Pillow`` distribution.
+                distributions = importlib.metadata.packages_distributions().get(
+                    package_name, []
+                )
+                if len(distributions) == 1:
+                    package_name = distributions[0]
+                    version = importlib.metadata.version(package_name)
+                elif len(distributions) > 1:
+                    raise RuntimeError(
+                        f"{package_name!r} maps to multiple installed"
+                        f" distributions ({', '.join(distributions)})."
+                        " Pass 'package_name' to disambiguate."
+                    ) from None
+                else:
+                    raise RuntimeError(
+                        f"{package_name!r} is not installed. Try passing"
+                        " 'package_name' instead."
+                    ) from None
 
         if version is None:
             raise RuntimeError(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -779,3 +779,82 @@ def test_help_invalid_default(runner):
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "default: not found" in result.output
+
+
+def test_version_option_resolves_import_name_to_distribution(runner, monkeypatch):
+    """When ``package_name`` (detected or passed) is an import name that
+    differs from its installed distribution name (``PIL`` vs ``Pillow``),
+    ``version_option`` resolves it via ``packages_distributions()`` instead
+    of raising ``RuntimeError``.
+    """
+    import importlib.metadata
+
+    def fake_version(name):
+        if name == "pillow":
+            return "10.4.0"
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "packages_distributions",
+        lambda: {"PIL": ["pillow"]},
+    )
+
+    @click.command()
+    @click.version_option(package_name="PIL")
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--version"], prog_name="imageapp")
+    assert result.exit_code == 0
+    assert "10.4.0" in result.output
+
+
+def test_version_option_ambiguous_import_name_errors(runner, monkeypatch):
+    """When an import name maps to multiple installed distributions, the
+    user must disambiguate. The error names the candidates.
+    """
+    import importlib.metadata
+
+    def fake_version(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "packages_distributions",
+        lambda: {"plug": ["foo-plug", "bar-plug"]},
+    )
+
+    @click.command()
+    @click.version_option(package_name="plug")
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code != 0
+    msg = str(result.exception)
+    assert "multiple installed distributions" in msg
+    assert "foo-plug" in msg
+    assert "bar-plug" in msg
+
+
+def test_version_option_unknown_package_errors(runner, monkeypatch):
+    """When the name resolves to no distribution, keep the existing error."""
+    import importlib.metadata
+
+    def fake_version(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(importlib.metadata, "packages_distributions", lambda: {})
+
+    @click.command()
+    @click.version_option(package_name="nonexistent")
+    def cli():
+        pass
+
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code != 0
+    assert "not installed" in str(result.exception)


### PR DESCRIPTION
There is an issue we glossed over when closing #2331: I analyzed the bug report as requiring a new slot/field to be added to the `@version_option` decorator. I promptly close the issue as we decided in https://github.com/pallets/click/discussions/3527 to freeze `@version_option`.

But looking closely #2331 did not asked for a new `module_name` field. That was my suggestion on how to address the user request.

So reframing it, #2331 is a report that `@version_option` is producing a `RuntimeError` for users in some legitimate situations. This breaks the out-of-the-box experience of `@version_option`.

In fact, the limitation has been pointed out by @davidism a couple of years ago at https://github.com/pallets/click/issues/1884#issuecomment-843693678:
> If someone figures out a way to get the distribution version from the entry point name with `importlib.metadata`, I'd welcome a PR to improve our detection, but from my experiments with it I was not able to find how to do it. For now, I'll update the changelog.

So this is a PR to implement that fix.

Addresses:
- #1884
- #2331
- #3125