### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Shell completion for long option values typed with `=` keeps the option
+  prefix when offering plain completions. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,15 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix is not None and isinstance(obj, Option):
+            for item in completions:
+                if item.type == "plain":
+                    item.value = f"{completion_prefix}{item.value}"
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -636,7 +643,7 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str | None]:
     """Find the Click object that will handle the completion of the
     incomplete value. Return the object and the incomplete value.
 
@@ -645,22 +652,27 @@ def _resolve_incomplete(
     :param args: List of complete args before the incomplete value.
     :param incomplete: Value being completed. May be empty.
     """
+    completion_prefix = None
+
     # Different shells treat an "=" between a long option name and
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
     # split and discard the "=" to make completion easier.
     if incomplete == "=":
         incomplete = ""
+        if args and _start_of_option(ctx, args[-1]):
+            completion_prefix = f"{args[-1]}="
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, None
 
     params = ctx.command.get_params(ctx)
 
@@ -668,14 +680,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, None
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, None

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -373,6 +373,42 @@ def test_full_complete(runner, shell, env, expect):
     assert result.output == expect
 
 
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        (
+            "bash",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\n",
+        ),
+        (
+            "fish",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "--color=a"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_long_option_value_with_equals(runner, shell, env, expect):
+    cli = Command(
+        "cli",
+        params=[
+            Option(
+                ["--color"],
+                type=Choice(["auto", "always", "never"]),
+            )
+        ],
+    )
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
 def test_source_uses_lf_line_endings(monkeypatch):
     stdout = io.BytesIO()
     stream = io.TextIOWrapper(stdout, encoding="utf-8", newline="\r\n")


### PR DESCRIPTION
Fixes #2847.

This preserves the long option prefix when shell completion handles values typed as `--option=value`, so plain completions replace the full token with `--option=<value>` instead of dropping the option name.

Tests:
- `uv run pytest tests\test_shell_completion.py -q`
- `uv run pytest -q`
- `uv run ruff check src\click\shell_completion.py tests\test_shell_completion.py`
