### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Unreleased
 
 Unreleased
 
+- ANSI codes are stripped from prompts (including `click.confirm`) when `color=False` in `CliRunner.invoke`. {issue}`3572`
 - Fix Fish shell completion broken in `8.4.0` by {pr}`3126`. Newlines and
   tabs in option help text are now escaped, keeping the original completion
   format while still supporting multi-line help. {issue}`3502`

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -473,6 +473,8 @@ class CliRunner:
 
         @_pause_echo(echo_input)  # type: ignore
         def visible_input(prompt: str | None = None) -> str:
+            if prompt and not color:
+                prompt = _compat.strip_ansi(prompt)
             sys.stdout.write(prompt or "")
             try:
                 val = next(text_input).rstrip("\r\n")


### PR DESCRIPTION
…ick 8.4 (closes #3572)

In click 8.4, the prompt function was refactored to use _readline_prompt() which calls visible_prompt_func() directly (bypassing echo()). In the CliRunner test isolation, visible_input() writes the prompt directly to sys.stdout without stripping ANSI codes, causing styled prompts from click.confirm() to contain ANSI codes even when color=False.

Fix: strip ANSI codes from the prompt in visible_input() when color=False.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
