### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Long option shell completion preserves the option name when completing values
+  written with `=`, such as `--color=al`. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,20 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        equal_completion_prefix = _equal_option_completion_prefix(ctx, incomplete)
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if (
+            equal_completion_prefix is not None
+            and isinstance(obj, Option)
+            and equal_completion_prefix[:-1] in obj.opts
+        ):
+            completions = _prefix_plain_completions(
+                completions, equal_completion_prefix
+            )
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -546,6 +558,37 @@ def _start_of_option(ctx: Context, value: str) -> bool:
 
     c = value[0]
     return c in ctx._opt_prefixes
+
+
+def _equal_option_completion_prefix(ctx: Context, incomplete: str) -> str | None:
+    """Return the ``--option=`` prefix from an incomplete option value."""
+    if "=" not in incomplete or not _start_of_option(ctx, incomplete):
+        return None
+
+    name, _, _ = incomplete.partition("=")
+    return f"{name}="
+
+
+def _prefix_plain_completions(
+    completions: list[CompletionItem], prefix: str
+) -> list[CompletionItem]:
+    prefixed_completions = []
+
+    for item in completions:
+        if item.type != "plain":
+            prefixed_completions.append(item)
+            continue
+
+        prefixed_completions.append(
+            CompletionItem(
+                f"{prefix}{item.value}",
+                type=item.type,
+                help=item.help,
+                **item._info,
+            )
+        )
+
+    return prefixed_completions
 
 
 def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bool:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,21 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+def test_long_option_equal_choice():
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    assert _get_words(cli, [], "--color=") == [
+        "--color=auto",
+        "--color=always",
+        "--color=never",
+    ]
+    assert _get_words(cli, [], "--color=a") == ["--color=auto", "--color=always"]
+    assert _get_words(cli, [], "--color=al") == ["--color=always"]
+    assert _get_words(cli, ["--color"], "al") == ["always"]
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]
@@ -370,6 +385,30 @@ def test_full_complete(runner, shell, env, expect):
     cli = Group("cli", commands=[Command("a"), Command("b", help="bee")])
     env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("shell", "expect"),
+    [
+        ("bash", "plain,--color=always\n"),
+        ("zsh", "plain\n--color=always\n_\n"),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_long_option_equal_choice(runner, shell, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli --color=al",
+            "COMP_CWORD": "1",
+            "_CLI_COMPLETE": f"{shell}_complete",
+        },
+    )
     assert result.output == expect
 
 


### PR DESCRIPTION
## What

Fixes shell completion for long option values written with `=`, such as `--color=al`. Click already resolves the incomplete value against the option and computes the right choice (`always`), but bash and zsh received only `always`, so accepting the completion replaced the whole current word and dropped `--color=`.

This preserves the `--option=` prefix for plain completion items when the incomplete word is a recognized option value written with `=`. File and directory completion items keep their existing special shell handling.

Fixes #2847

## Testing

- `python -m pytest tests/test_shell_completion.py::test_long_option_equal_choice tests/test_shell_completion.py::test_full_complete_long_option_equal_choice -q`
- Regression proof: those new tests fail on the old code with completions like `always` instead of `--color=always`.
- `python -m pytest -q` (`1674 passed, 25 skipped, 31000 deselected, 1 xfailed`)
- `ruff check . && ruff format --check .`
- `pre-commit run --files CHANGES.md src/click/shell_completion.py tests/test_shell_completion.py uv.lock pyproject.toml`
- `mypy src tests/typing`
- `PYTHONPATH=src pyright --ignoreexternal --verifytypes click`
