### PR TITLE
AI junk

### DIFF
--- a/src/click/exceptions.py
+++ b/src/click/exceptions.py
@@ -64,6 +64,9 @@ class ClickException(Exception):
             color=self.show_color,
         )
 
+        for note in getattr(self, "__notes__", []):
+            echo(note, file=file, color=self.show_color)
+
 
 class UsageError(ClickException):
     """An internal exception that signals a usage error.  This typically
@@ -94,8 +97,6 @@ class UsageError(ClickException):
             and self.ctx.command.get_help_option(self.ctx) is not None
         ):
             help_names = self.ctx.command.get_help_option_names(self.ctx)
-            # Pick the longest name (like ``--help`` over ``-h``) for
-            # readability in error messages.
             hint = _("Try '{command} {option}' for help.").format(
                 command=self.ctx.command_path,
                 option=max(help_names, key=len),
@@ -109,6 +110,9 @@ class UsageError(ClickException):
             file=file,
             color=color,
         )
+
+        for note in getattr(self, "__notes__", []):
+            echo(note, file=file, color=color)
 
 
 class BadParameter(UsageError):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -739,3 +739,16 @@ def test_help_invalid_default(runner):
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "default: not found" in result.output
+
+def test_click_exception_shows_notes(runner):
+    """ClickException.show() should display __notes__ after the message."""
+
+    @click.command()
+    def cli():
+        exc = click.ClickException("something went wrong")
+        exc.__notes__ = ["here is some additional context"]
+        raise exc
+
+    result = runner.invoke(cli)
+    assert "Error: something went wrong" in result.output
+    assert "here is some additional context" in result.output    


### PR DESCRIPTION
Fixes #2740

Since Python 3.11, exceptions support `add_note()` which appends to
`__notes__`. When a `ClickException` is raised, these notes were
silently ignored.

This change updates `ClickException.show()` and `UsageError.show()`
to display any `__notes__` after the main error message, matching
how Python's default exception display handles notes.