### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- `confirm` and `prompt` strip ANSI style codes from the prompt text
+  when the output stream does not support them (e.g. `color=False` in
+  `CliRunner`), restoring the behavior from before 8.4.0. {issue}`3572`
 
 ## Version 8.4.1
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -11,6 +11,7 @@ from contextlib import AbstractContextManager
 from contextlib import redirect_stdout
 from gettext import gettext as _
 
+from . import _compat
 from ._compat import isatty
 from ._compat import strip_ansi
 from .exceptions import Abort
@@ -81,9 +82,13 @@ def hidden_prompt_func(prompt: str) -> str:
 
 
 def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
-    """Call a prompt function, passing the full prompt on non-Windows so
-    readline can handle line editing and cursor positioning correctly.
+    """Call a prompt function, passing the full prompt so readline can
+    handle line editing and cursor positioning correctly. ANSI codes are
+    stripped when the output stream does not support them.
     """
+    stream = sys.stderr if err else sys.stdout
+    if _compat.should_strip_ansi(stream):
+        text = strip_ansi(text)
     if err:
         with redirect_stdout(sys.stderr):
             return func(text)
@@ -155,6 +160,10 @@ def prompt(
                          For example if type is a Choice of either day or week,
                          show_choices is true and text is "Group by" then the
                          prompt will be "Group by (day, week): ".
+
+    .. versionchanged:: 8.4.2
+        ANSI codes in the prompt text are stripped when the output stream
+        does not support them, restoring the behavior from before 8.4.0.
 
     .. versionchanged:: 8.3.3
         ``show_default`` can be a string to show a custom value instead
@@ -250,6 +259,10 @@ def confirm(
     :param show_default: shows or hides the default value in the prompt.
     :param err: if set to true the file defaults to ``stderr`` instead of
                 ``stdout``, the same as with echo.
+
+    .. versionchanged:: 8.4.2
+        ANSI codes in the prompt text are stripped when the output stream
+        does not support them, restoring the behavior from before 8.4.0.
 
     .. versionchanged:: 8.3.1
         A space is no longer appended to the prompt.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -264,6 +264,20 @@ def test_full_prompt_passed_to_readline(monkeypatch, call, expected_prompt):
     assert received == [expected_prompt]
 
 
+def test_confirm_strips_ansi_with_color_false(runner):
+    """ANSI style codes in the confirm prompt are stripped when color=False.
+
+    https://github.com/pallets/click/issues/3572
+    """
+
+    @click.command()
+    def cmd():
+        click.confirm(click.style("Hello World!", fg="green"), abort=True)
+
+    result = runner.invoke(cmd, input="Y", color=False)
+    assert result.output == "Hello World! [y/N]: Y\n"
+
+
 def test_prompts_eof(runner):
     """If too few lines of input are given, prompt should exit, not hang."""
 


### PR DESCRIPTION
In 8.4.0, `_readline_prompt` was introduced to unify prompt handling. On
non-Windows, it passed the full prompt string (including ANSI codes) directly to
`visible_prompt_func`, which wrote it verbatim without checking the color
setting. This broke `confirm()` and `prompt()` when styled text was used with
`color=False` in `CliRunner`.

Fix `_readline_prompt` to call `_compat.should_strip_ansi` on the output stream
before passing the prompt to the prompt function, restoring the behaviour from
before 8.4.0. Module-level attribute access is used so `CliRunner`'s
monkey-patch is picked up at call time.

fixes #3572