### PR TITLE
Fix tests to not rely on `-Wdefault` option

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3320,10 +3320,8 @@ def test_flag_group_competition_duplicate_option_name(runner):
     def cli(xyz):
         click.echo(repr(xyz), nl=False)
 
-    result = runner.invoke(cli, [])
-    assert result.exit_code == 1
-    assert isinstance(result.exception, UserWarning)
-    assert "used more than once" in str(result.exception)
+    with pytest.warns(UserWarning, match="used more than once"):
+        runner.invoke(cli, [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use a context manager to explicitly check for the exception message.

This is a non-idiomatic way of checking the behavior that rely on running tests with `-Wdefault` option. It was introduced by me in https://github.com/pallets/click/pull/3404 (commit 0f71fe77).

Closes #3476.