### PR TITLE
AI spam

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -87,7 +87,7 @@ The following common subclasses exist:
 
 ## Help Pages and Exit Codes
 
-Triggering the a help page intentionally (by passing in ``--help``)
+Triggering a help page intentionally (by passing in ``--help``)
 returns exit code 0. If a help page is displayed due to incorrect user
 input, the program returns exit code 2. See {ref}`exit-codes` for more
 general information.

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -225,7 +225,7 @@ class MyshComplete(ShellComplete):
         return args, ""
 ```
 
-Finally, implement {meth}`~ShellComplete.format_completion`. This is called to format each {class}`CompletionItem` into a string. For example, the Bash implementation returns `f"{item.type},{item.value}` (it doesn't support help strings), and the Zsh implementation returns each part separated by a newline, replacing empty help with a `_` placeholder. This format is entirely up to what you parse with your completion script.
+Finally, implement {meth}`~ShellComplete.format_completion`. This is called to format each {class}`CompletionItem` into a string. For example, the Bash implementation returns `f"{item.type},{item.value}"` (it doesn't support help strings), and the Zsh implementation returns each part separated by a newline, replacing empty help with a `_` placeholder. This format is entirely up to what you parse with your completion script.
 
 The `type` value is usually `plain`, but it can be another value that the completion script can switch on. For example,
 `file` or `dir` can tell the shell to handle path completion, since the shell is better at that than Click.


### PR DESCRIPTION
## What

Fix two small typos in the documentation:

1. **`docs/exceptions.md`** line 90: remove duplicate article
   - Before: `Triggering the a help page intentionally...`
   - After: `Triggering a help page intentionally...`

2. **`docs/shell-completion.md`** line 228: add missing closing `"` in the f-string code example
   - Before: `` `f"{item.type},{item.value}` `` (invalid Python — unclosed string)
   - After: `` `f"{item.type},{item.value}"` `` (matches the actual source in `shell_completion.py:366`)

## Why

The double article "the a" is a clear grammatical error. The missing `"` in the f-string example makes the documented return value look like invalid Python syntax — the real implementation (`shell_completion.py` line 366) correctly has the closing quote.