### PR TITLE
tests/test_basic: Fix to work with newer versions of pytest

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -258,9 +258,11 @@ def test_boolean_flag(runner, default, args, expect):
 
 @pytest.mark.parametrize(
     ("value", "expect"),
-    chain(
-        ((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
-        ((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
+    tuple(
+        chain(
+            ((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
+            ((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
+        )
     ),
 )
 def test_boolean_conversion(runner, value, expect):


### PR DESCRIPTION
Fix an error with newer versions of pytest (9.1.0) by converting the generator into a tuple to resolve:

E   pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
E   Test: tests/test_basic.py::test_boolean_conversion, argvalues type: chain
E   Please convert to a list or tuple.
E   See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
ERROR: tests/test_basic.py:tests/test_basic.py

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
