### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Unreleased
 - A {func}`progressbar` with `show_pos=True` and an `update_min_steps` that
   does not divide the length evenly reports the full position at the end
   instead of stopping short (e.g. `20/20` instead of `14/20`). {issue}`3571`
+  {pr}`3600`
 
 ## Version 8.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- A {func}`progressbar` with `show_pos=True` and an `update_min_steps` that
+  does not divide the length evenly reports the full position at the end
+  instead of stopping short (e.g. `20/20` instead of `14/20`). {issue}`3571`
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,14 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush any steps that were below the ``update_min_steps`` threshold
+        # so the final position reflects all completed work. Otherwise, with
+        # an ``update_min_steps`` that does not divide ``length`` evenly,
+        # ``pos`` would stop short of ``length`` (e.g. showing ``14/20``).
+        if self._completed_intervals:
+            self.pos += self._completed_intervals
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,27 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_final_pos(runner, monkeypatch):
+    """When ``update_min_steps`` does not divide ``length`` evenly, the final
+    position should still reach ``length`` instead of stopping short, so that
+    ``show_pos`` reports full completion."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+            assert progress.pos == 20
+            assert progress.format_pos() == "20/20"
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    result = runner.invoke(cli, [], standalone_mode=False, catch_exceptions=False)
+    assert "20/20" in result.output
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
A `click.progressbar` with `show_pos=True` and an `update_min_steps` that
doesn't divide the length evenly never shows full completion. For example:

```python
with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
    for i in bar:
        ...
```

ends on `14/20` instead of `20/20`.

The cause is in `ProgressBar`: `update()` only folds the accumulated steps
into `pos` once they reach `update_min_steps`, so the final partial batch
(here the last 6 steps) is left in `_completed_intervals` and never added to
`pos`. The bar fill and percentage look complete because `pct` returns `1.0`
once `finished`, but `format_pos()` reads the raw `pos`, which is still short.

The fix flushes any pending `_completed_intervals` into `pos` in `finish()`,
so the final position reflects all completed work.

fixes #3571

I added a regression test in `tests/test_termui.py` that iterates a bar with
`update_min_steps=7` over a length of 20 and asserts the final position is
`20/20`; it fails without the change. Full test suite, ruff (check + format)
and mypy pass locally, and I added a CHANGES.md entry.
