### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- Progress bars with `show_pos=True` and `update_min_steps` greater than 1
+  now render the final position when the last update is smaller than the
+  update threshold. {issue}`3571`
 
 ## Version 8.4.1
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -342,7 +342,12 @@ class ProgressBar(t.Generic[V]):
 
         self._completed_intervals += n_steps
 
-        if self._completed_intervals >= self.update_min_steps:
+        complete = (
+            self.length is not None
+            and self.pos + self._completed_intervals >= self.length
+        )
+
+        if complete or self._completed_intervals >= self.update_min_steps:
             self.make_step(self._completed_intervals)
             self.render_progress()
             self._completed_intervals = 0

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -340,6 +340,23 @@ def test_progressbar_update_with_item_show_func(runner, monkeypatch):
     assert "Custom 4" in lines[2]
 
 
+def test_progressbar_update_min_steps_shows_final_position(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    lines = [line for line in output.split("\n") if "[" in line]
+
+    assert "20/20" in lines[-1]
+
+
 def test_progress_bar_update_min_steps(runner):
     bar = _create_progress(update_min_steps=5)
     bar.update(3)
@@ -348,6 +365,17 @@ def test_progress_bar_update_min_steps(runner):
     bar.update(2)
     assert bar._completed_intervals == 0
     assert bar.pos == 5
+
+
+def test_progress_bar_update_min_steps_flushes_at_length(runner):
+    bar = _create_progress(length=20, update_min_steps=7)
+    bar.update(7)
+    bar.update(7)
+    bar.update(6)
+
+    assert bar._completed_intervals == 0
+    assert bar.pos == 20
+    assert bar.finished
 
 
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))


### PR DESCRIPTION
Fixes #3571

Progress bars throttle redraws with `update_min_steps`, but the final update can be smaller than that threshold. In that case the pending interval stayed buffered, so `show_pos=True` rendered the last flushed position, such as `14/20`, even though the bar was complete.

This updates `ProgressBar.update()` to flush pending intervals when they complete a bounded bar. The normal threshold behavior is unchanged for intermediate updates.

Tests added cover the reported rendered output and the manual update path.

Validation:

- `PYTHONPATH=src python -m pytest tests\test_termui.py::test_progressbar_update_min_steps_shows_final_position tests\test_termui.py::test_progress_bar_update_min_steps tests\test_termui.py::test_progress_bar_update_min_steps_flushes_at_length -q`
- `PYTHONPATH=src python -m pytest tests\test_termui.py -q`
- `python -m ruff check src\click\_termui_impl.py tests\test_termui.py`
- `git diff --check`