### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- Options that share a callback destination no longer let an uninvoked
+  sibling override the value returned by an invoked flag option's callback.
+  {issue}`2786`
 
 ## Version 8.4.1
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -312,6 +312,7 @@ class Context:
     args: list[str]
     _protected_args: list[str]
     _opt_prefixes: set[str]
+    _parser_invoked_params: frozenset[Parameter]
     obj: t.Any
     _meta: dict[str, t.Any]
     default_map: cabc.MutableMapping[str, t.Any] | None
@@ -370,6 +371,7 @@ class Context:
         self._protected_args = []
         #: the collected prefixes of the command's options.
         self._opt_prefixes = set(parent._opt_prefixes) if parent else set()
+        self._parser_invoked_params = frozenset()
 
         if obj is None and parent is not None:
             obj = parent.obj
@@ -1320,6 +1322,7 @@ class Command:
 
         parser = self.make_parser(ctx)
         opts, args, param_order = parser.parse_args(args=args)
+        ctx._parser_invoked_params = frozenset(param_order)
 
         for param in iter_params_for_processing(param_order, self.get_params(ctx)):
             _, args = param.handle_parse_result(ctx, opts, args)
@@ -3474,6 +3477,9 @@ class Option(Parameter):
 
         :meta private:
         """
+        if self not in ctx._parser_invoked_params and self.name in opts:
+            opts = {key: value for key, value in opts.items() if key != self.name}
+
         value, source = super().consume_value(ctx, opts)
 
         # The parser will emit a sentinel value if the option is allowed to as a flag

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3250,6 +3250,32 @@ def test_flag_group_competition_non_boolean(runner, opts, args, expected):
     assert result.output == repr(expected)
 
 
+def test_shared_dest_option_does_not_override_flag_callback_value(runner):
+    sentinel = "$_fetch"
+    calls = 0
+
+    def callback(ctx, param, value):
+        nonlocal calls
+
+        if value == sentinel:
+            calls += 1
+            return "fetched"
+
+        return value
+
+    @click.command()
+    @click.option("--custom", "custom")
+    @click.option("--fetch", "custom", flag_value=sentinel, callback=callback)
+    def cli(custom):
+        click.echo(custom)
+
+    result = runner.invoke(cli, ["--fetch"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "fetched\n"
+    assert calls == 1
+
+
 @pytest.mark.parametrize(
     ("default_a", "default_b", "args", "expected"),
     [


### PR DESCRIPTION
Fixes #2786

When multiple options share the same callback destination, the parser stores the latest raw value under that destination name. A sibling option that was not actually invoked could still read that shared value from `opts`, mark it as `COMMANDLINE`, and overwrite the callback result from the option that was invoked.

This records the parser's invoked parameter objects on the context and makes `Option.consume_value()` ignore a shared parser value when the current option was not part of the invocation order. That lets the uninvoked sibling fall back to its real default/env/default-map handling instead of consuming another option's raw value.

The regression covers the reported `--fetch` case where a flag callback returns a replacement value for a shared destination.

Validation:

- `PYTHONPATH=src python -m pytest tests\test_options.py::test_shared_dest_option_does_not_override_flag_callback_value tests\test_options.py::test_flag_group_competition_non_boolean tests\test_options.py::test_flag_group_unset_vs_none_vs_explicit -q`
- `PYTHONPATH=src python -m pytest tests\test_options.py -q`
- `PYTHONPATH=src python -m pytest tests\test_defaults.py -q`
- `python -m ruff check src\click\core.py tests\test_options.py`
- `git diff --check`