### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Shell completion for long option values written as `--option=value` keeps the
+  option prefix when returning plain value completions. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,23 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, value_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if value_prefix:
+            completions = [
+                CompletionItem(
+                    f"{value_prefix}{item.value}",
+                    type=item.type,
+                    help=item.help,
+                    **item._info,
+                )
+                if item.type == "plain"
+                else item
+                for item in completions
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -636,15 +651,18 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str]:
     """Find the Click object that will handle the completion of the
-    incomplete value. Return the object and the incomplete value.
+    incomplete value. Return the object, incomplete value, and value
+    prefix to restore when a shell passes an option value as one token.
 
     :param ctx: Invocation context for the command represented by
         the parsed complete args.
     :param args: List of complete args before the incomplete value.
     :param incomplete: Value being completed. May be empty.
     """
+    value_prefix = ""
+
     # Different shells treat an "=" between a long option name and
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
@@ -654,13 +672,14 @@ def _resolve_incomplete(
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        value_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, value_prefix
 
     params = ctx.command.get_params(ctx)
 
@@ -668,14 +687,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, value_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, value_prefix
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, value_prefix

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,26 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+@pytest.mark.parametrize(
+    ("incomplete", "expect"),
+    [
+        ("--color=", ["--color=auto", "--color=always", "--color=never"]),
+        ("--color=a", ["--color=auto", "--color=always"]),
+        ("--color=al", ["--color=always"]),
+    ],
+)
+def test_long_option_eq_value_choice(incomplete, expect):
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--color"], type=Choice(["auto", "always", "never"])),
+        ],
+    )
+
+    assert _get_words(cli, [], incomplete) == expect
+    assert _get_words(cli, ["--color"], "al") == ["always"]
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
﻿Fixes #2847.

When a shell passes an incomplete long option value as one token, such as `--color=al`, Click already splits the token so the option can provide value completions. The returned completion values were still bare choices, so shells could replace the whole token with `always` instead of `--color=always`.

This keeps the `--option=` prefix for plain value completions that came from an equals-separated option value. Space-separated option completion, such as `--color al`, is unchanged. File and directory completions keep their existing shell-specific handling.

Validation:
- `PYTHONPATH=src python -m pytest tests\test_shell_completion.py::test_long_option_eq_value_choice -q`
- `PYTHONPATH=src python -m pytest tests\test_shell_completion.py -q`
- `python -m ruff check src\click\shell_completion.py tests\test_shell_completion.py`
- `python -m ruff format --check src\click\shell_completion.py tests\test_shell_completion.py`
- `git diff --check`
