### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- {class}`LazyFile` no longer eagerly opens FIFO paths when initialized for
+  reading. {issue}`2645`
 
 ## Version 8.4.2
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import os
 import re
+import stat
 import sys
 import typing as t
 from functools import update_wrapper
@@ -141,7 +142,7 @@ class LazyFile:
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
         else:
-            if "r" in mode:
+            if "r" in mode and not stat.S_ISFIFO(os.stat(filename).st_mode):
                 # Open and close the file in case we're opening it for
                 # reading so that we can catch at least some errors in
                 # some cases early.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -785,6 +785,29 @@ def test_iter_lazyfile(tmpdir):
                 assert e_line == a_line.strip()
 
 
+def test_lazyfile_read_fifo_skips_eager_open(monkeypatch):
+    fifo_mode = stat.S_IFIFO | 0o644
+    opened = []
+
+    monkeypatch.setattr(
+        click.utils.os,
+        "stat",
+        lambda filename: os.stat_result((fifo_mode, *([0] * 9))),
+    )
+
+    def record_open(*args, **kwargs):
+        opened.append((args, kwargs))
+        raise AssertionError("FIFO should not be opened during LazyFile init")
+
+    monkeypatch.setattr("builtins.open", record_open)
+
+    lf = click.utils.LazyFile("fifo", "rb")
+
+    assert lf._f is None
+    assert lf.should_close
+    assert opened == []
+
+
 class MockMain:
     __slots__ = "__package__"
 


### PR DESCRIPTION
﻿Fixes #2645.

`LazyFile` currently opens and closes files during initialization when it is set up for reading. That early check is useful for normal files, but it can consume or disrupt a FIFO before the caller actually reads from it.

This keeps the existing eager check for regular readable paths, but skips it when `os.stat()` reports a FIFO. The file is still opened lazily on first IO through the existing `open_stream()` path.

Validation:
- `PYTHONPATH=src python -m pytest tests\test_utils.py::test_lazyfile_read_fifo_skips_eager_open tests\test_utils.py::test_iter_lazyfile -q`
- `PYTHONPATH=src python -m pytest tests\test_utils.py -q`
- `PYTHONPATH=src python -m pytest tests\test_basic.py::test_file_lazy_mode -q -o "filterwarnings=ignore::pytest.PytestRemovedIn10Warning"`
- `python -m ruff check src\click\utils.py tests\test_utils.py`
- `python -m ruff format --check src\click\utils.py tests\test_utils.py`
- `git diff --check`
