### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Shell completion callbacks for option values can access parsed arguments in
+  `ctx.params`. {issue}`2184`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,6 +283,13 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        incomplete_option = _find_incomplete_option(ctx, args)
+
+        if incomplete_option is not None and not _start_of_option(ctx, incomplete):
+            ctx = _resolve_context(
+                self.cli, self.ctx_args, self.prog_name, args[:incomplete_option]
+            )
+
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
         return obj.shell_complete(ctx, incomplete)
 
@@ -548,29 +555,45 @@ def _start_of_option(ctx: Context, value: str) -> bool:
     return c in ctx._opt_prefixes
 
 
-def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bool:
+def _find_incomplete_option_for_param(
+    ctx: Context, args: list[str], param: Parameter
+) -> int | None:
     """Determine if the given parameter is an option that needs a value.
 
     :param args: List of complete args before the incomplete value.
     :param param: Option object being checked.
     """
     if not isinstance(param, Option):
-        return False
+        return None
 
     if param.is_flag or param.count:
-        return False
-
-    last_option = None
+        return None
 
     for index, arg in enumerate(reversed(args)):
         if index + 1 > param.nargs:
             break
 
         if _start_of_option(ctx, arg):
-            last_option = arg
+            if arg in param.opts:
+                return len(args) - index - 1
+
             break
 
-    return last_option is not None and last_option in param.opts
+    return None
+
+
+def _find_incomplete_option(ctx: Context, args: list[str]) -> int | None:
+    for param in ctx.command.get_params(ctx):
+        index = _find_incomplete_option_for_param(ctx, args, param)
+
+        if index is not None:
+            return index
+
+    return None
+
+
+def _is_incomplete_option(ctx: Context, args: list[str], param: Parameter) -> bool:
+    return _find_incomplete_option_for_param(ctx, args, param) is not None
 
 
 def _resolve_context(

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -127,6 +127,44 @@ def test_argument_order():
     assert _get_words(cli, ["x", "b"], "d") == ["d"]
 
 
+def test_option_complete_has_parsed_argument():
+    seen = []
+
+    def complete(ctx, param, incomplete):
+        seen.append(dict(ctx.params))
+        return ["x"]
+
+    cli = Command(
+        "cli",
+        params=[
+            Argument(["kind"]),
+            Option(["--test"], shell_complete=complete),
+        ],
+    )
+
+    assert _get_words(cli, ["foo", "--test"], "") == ["x"]
+    assert seen == [{"kind": "foo", "test": None}]
+
+
+def test_argument_complete_has_parsed_option():
+    seen = []
+
+    def complete(ctx, param, incomplete):
+        seen.append(dict(ctx.params))
+        return ["x"]
+
+    cli = Command(
+        "cli",
+        params=[
+            Option(["--test"]),
+            Argument(["kind"], shell_complete=complete),
+        ],
+    )
+
+    assert _get_words(cli, ["--test", "bar"], "") == ["x"]
+    assert seen == [{"test": "bar", "kind": None}]
+
+
 def test_argument_default():
     cli = Command(
         "cli",


### PR DESCRIPTION
﻿Fixes #2184.

During shell completion, Click resolves a context from the completed words before deciding which parameter should provide completions. If the completed words ended with an option that still needed a value, that incomplete option was included in the resilient parse. In that state, already typed arguments could stay unset in `ctx.params`, so an option completion callback could not see them.

This detects the trailing option segment that is waiting for a value and leaves it out only while building the callback context. The original words are still used to decide that the option should provide completions. If the current incomplete word starts with an option prefix, the existing option-name completion behavior is left alone.

Validation:
- `PYTHONPATH=src python -m pytest tests\test_shell_completion.py::test_option_complete_has_parsed_argument tests\test_shell_completion.py::test_argument_complete_has_parsed_option -q`
- `PYTHONPATH=src python -m pytest tests\test_shell_completion.py -q`
- `python -m ruff check src\click\shell_completion.py tests\test_shell_completion.py`
- `python -m ruff format --check src\click\shell_completion.py tests\test_shell_completion.py`
- `git diff --check`
