### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,22 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_renders_final_position(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    final_line = output.rsplit("\r", 1)[-1]
+
+    assert "20/20" in final_line
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
## Problem

`click.progressbar` can render a stale final position when `show_pos=True` is combined with an `update_min_steps` value that does not evenly divide the iterable length.

For example, `range(20)` with `update_min_steps=7` renders the final bar as `14/20` even though the bar itself is finished.

Fixes pallets/click#3571.

## Solution

Flush any pending batched progress intervals in `ProgressBar.finish()` before marking the bar finished and rendering the final line.

## Tests run

- `PYTHONPATH=src python -m pytest tests/test_termui.py -k progressbar -v`
- `PYTHONPATH=src python -m pytest tests/test_termui.py -v`
- `PYTHONPATH=src python -m pytest -v`
- `python -m ruff check src/click/_termui_impl.py tests/test_termui.py`
- `python -m ruff format --check src/click/_termui_impl.py tests/test_termui.py`

## Files changed

- `src/click/_termui_impl.py`
- `tests/test_termui.py`

## Notes for reviewer

I tested on Windows with Python 3.14.2. `uv` and `tox` were not available in this local environment, so pytest was run directly with `PYTHONPATH=src` to import the checkout.