### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -352,6 +352,13 @@ class ProgressBar(t.Generic[V]):
         self.current_item = None
         self.finished = True
 
+        # Render any remaining steps that didn't meet the update_min_steps
+        # threshold. This ensures the progress bar shows full completion
+        # when show_pos=True and update_min_steps is not a divisor of length.
+        if self._completed_intervals > 0:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar
         during construction, and updates the progress bar *after* the


### PR DESCRIPTION
## Description

This PR fixes a bug where `click.progressbar` wouldn't show full completion when using `show_pos=True` combined with `update_min_steps` that isn't a divisor of `length`.

### Problem

When using a `click.progressbar` with:
- `update_min_steps` which isn't a divisor of `length`
- `show_pos=True`

The progress bar wouldn't show full completion at the end. For example:

```python
import time
import click

with click.progressbar(
    range(20),
    show_pos=True,
    update_min_steps=7,
) as bar:
    for i in bar:
        time.sleep(0.1)
```

Would show `14/20` instead of `20/20` at the end.

### Root Cause

The `update` method only renders when `_completed_intervals >= update_min_steps`. When the final batch of steps is smaller than `update_min_steps`, those steps are never rendered.

### Solution

This fix ensures that any remaining steps are rendered when `finish()` is called:

```python
def finish(self) -> None:
    self.eta_known = False
    self.current_item = None
    self.finished = True

    # Render any remaining steps that didn't meet the update_min_steps
    # threshold. This ensures the progress bar shows full completion
    # when show_pos=True and update_min_steps is not a divisor of length.
    if self._completed_intervals > 0:
        self.make_step(self._completed_intervals)
        self._completed_intervals = 0
```

### Testing

The fix can be verified with the reproduction script from issue #3571:

```python
import time
import click

with click.progressbar(
    range(20),
    show_pos=True,
    update_min_steps=7,
) as bar:
    for i in bar:
        time.sleep(0.1)
```

After the fix, the progress bar should show `20/20` at the end.

### References

- Fixes #3571

Co-Authored-By: Claude <noreply@anthropic.com>