### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,21 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_update_min_steps_flushes_on_finish(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli).output
+
+    assert "20/20" in output
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

## What changed

Flush any pending `update_min_steps` intervals when a progress bar finishes, before rendering its final state. Add a regression test covering `show_pos=True` with a threshold that does not evenly divide the iterable length.

## Root cause

`update_min_steps` batches position increments in `_completed_intervals`. At the end of iteration, `finish()` marked the progress bar as finished without applying the remaining batched increments. The finished flag made the bar and percentage render as complete, while `show_pos` still read the stale `pos` value (for example, `14/20`).

## Impact

Progress bars now render the correct final absolute position, such as `20/20`, while preserving batched rendering during iteration.

## Validation

- Full test suite: `1672 passed, 25 skipped, 31000 deselected, 1 xfailed`
- `ruff check src/click/_termui_impl.py tests/test_termui.py`
- `ruff format --check src/click/_termui_impl.py tests/test_termui.py`
- `git diff --check`
