### PR TITLE
Fix incorrect variable name in pipeline example

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -228,7 +228,7 @@ def cli(fin):
 
 @cli.result_callback()
 def process_pipeline(processors, fin):
-    iterator = (x.rstrip("\r\n") for x in input)
+    iterator = (x.rstrip("\r\n") for x in fin)
 
     for processor in processors:
         iterator = processor(iterator)


### PR DESCRIPTION
Fixed input to in in the command pipeline example. The variable in is passed as an argument and should be used in the generator expression.