### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- {func}`edit` accepts {class}`os.PathLike` objects, such as
+  {class}`pathlib.Path`, for the `filename` argument. {issue}`2869`
 
 ## Version 8.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Unreleased
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
 - {func}`edit` accepts {class}`os.PathLike` objects, such as
-  {class}`pathlib.Path`, for the `filename` argument. {issue}`2869`
+  {class}`pathlib.Path`, for the `filename` argument. {issue}`2869` {pr}`3622`
 
 ## Version 8.4.2
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -4,6 +4,7 @@ import collections.abc as cabc
 import inspect
 import io
 import itertools
+import os
 import re
 import sys
 import typing as t
@@ -768,7 +769,10 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: str
+    | os.PathLike[str]
+    | cabc.Iterable[str | os.PathLike[str]]
+    | None = None,
 ) -> None: ...
 
 
@@ -778,7 +782,10 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: str
+    | os.PathLike[str]
+    | cabc.Iterable[str | os.PathLike[str]]
+    | None = None,
 ) -> str | bytes | bytearray | None:
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating
@@ -815,6 +822,10 @@ def edit(
         ``filename`` now accepts any ``Iterable[str]`` in addition to a ``str``
         if the ``editor`` supports editing multiple files at once.
 
+    .. versionchanged:: 8.5.0
+        ``filename`` now accepts :class:`os.PathLike` objects, such as
+        :class:`pathlib.Path`, in addition to strings.
+
     """
     from ._termui_impl import Editor
 
@@ -823,10 +834,10 @@ def edit(
     if filename is None:
         return ed.edit(text)
 
-    if isinstance(filename, str):
+    if isinstance(filename, (str, os.PathLike)):
         filename = (filename,)
 
-    ed.edit_files(filenames=filename)
+    ed.edit_files(filenames=[os.fspath(name) for name in filename])
     return None
 
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -517,6 +518,29 @@ def test_editor_path_normalization(editor_cmd, filenames, expected_args):
         args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
         assert args == expected_args
         assert mock_popen.call_args[1].get("shell") is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_filenames"),
+    [
+        pytest.param("f.txt", ["f.txt"], id="str"),
+        pytest.param(Path("f.txt"), ["f.txt"], id="pathlib.Path"),
+        pytest.param(["a.txt", "b.txt"], ["a.txt", "b.txt"], id="iterable of str"),
+        pytest.param(
+            [Path("a.txt"), Path("b.txt")],
+            ["a.txt", "b.txt"],
+            id="iterable of pathlib.Path",
+        ),
+    ],
+)
+def test_edit_filename_pathlike(filename, expected_filenames):
+    """``edit(filename=...)`` accepts str and os.PathLike, single or iterable."""
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+        click.edit(filename=filename, editor="editor")
+
+        args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
+        assert args == ["editor", *expected_filenames]
 
 
 @pytest.mark.skipif(not WIN, reason="Windows-specific editor paths")


### PR DESCRIPTION
`click.edit()` typed its `filename` parameter as `str | Iterable[str] | None`, so passing a `pathlib.Path` raised a type-checker error (the `reportArgumentType` reported in the issue). For a single `Path` it also failed at runtime, since a `Path` is neither a `str` nor an iterable and reached `edit_files()` unwrapped, breaking on `list()`.

`filename` now accepts `os.PathLike[str]` (a single one or within an iterable), and every entry is normalised with `os.fspath()` before being handed to the editor. A test (which fails without the change) and a `CHANGES.md` entry are included, along with a `.. versionchanged::` note.

fixes #2869
