### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -382,6 +382,9 @@ class ProgressBar(t.Generic[V]):
                 yield rv
                 self.update(1)
 
+            if self._completed_intervals > 0:
+                self.make_step(self._completed_intervals)
+                self._completed_intervals = 0
             self.finish()
             self.render_progress()
 


### PR DESCRIPTION
## Problem

`click.progressbar` with `show_pos=True` and `update_min_steps > 1` shows an incorrect position at the end when `length` is not evenly divisible by `update_min_steps`.

```python
with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
    for i in bar:
        pass
# Shows:  [####################################]  14/20
# Expected: [####################################]  20/20
```

The percentage bar is correct (100%), but the position counter is wrong.

## Root cause

`update()` accumulates steps in `_completed_intervals` and only calls `make_step()` — which advances `self.pos` — when `_completed_intervals >= update_min_steps`. With `length=20` and `update_min_steps=7`:

- Step 7 → `make_step(7)` → `pos = 7`
- Step 14 → `make_step(7)` → `pos = 14`  
- Steps 15–20 → `_completed_intervals = 6` (never reaches 7, `make_step` never called)

When the loop ends, `generator()` calls `self.finish()` then `self.render_progress()`. At this point `self.pos` is still `14`, so `format_pos()` returns `"14/20"`. The progress bar itself shows 100% correctly (because `pct` returns `1.0` when `finished=True`), but `show_pos` reads `self.pos` directly.

## Fix

Flush any pending `_completed_intervals` into `self.pos` via `make_step()` **before** calling `finish()` in `generator()`:

```python
# Before
self.finish()
self.render_progress()

# After
if self._completed_intervals > 0:
    self.make_step(self._completed_intervals)
    self._completed_intervals = 0
self.finish()
self.render_progress()
```

This ensures the final `render_progress()` always sees the correct `self.pos` regardless of whether `length` is divisible by `update_min_steps`.

Closes #3571