### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- A string in `default_map` for a `multiple` option is split into separate
+  values, matching how an environment variable string is split. Previously
+  only `nargs > 1` options were split, so a `multiple` option failed with
+  "Value must be an iterable." {issue}`2745` {pr}`3624`
 
 ## Version 8.4.2
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2461,9 +2461,16 @@ class Parameter(ABC):
                 source = ParameterSource.DEFAULT_MAP
 
                 # A string from default_map must be split for multi-value
-                # parameters, matching value_from_envvar behavior.
-                if isinstance(value, str) and self.nargs != 1:
-                    value = self.type.split_envvar_value(value)
+                # parameters, matching value_from_envvar behavior. This
+                # includes "multiple" options, not just nargs != 1, and
+                # batches the items when both apply.
+                if isinstance(value, str) and (self.nargs != 1 or self.multiple):
+                    split_value = self.type.split_envvar_value(value)
+
+                    if self.multiple and self.nargs != 1:
+                        value = batch(split_value, self.nargs)
+                    else:
+                        value = split_value
 
         if value is UNSET:
             default_value = self.get_default(ctx)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -525,11 +525,23 @@ def test_default_map_with_callable_flag_value(runner, default_map, args, expecte
             ["--point", "10", "20"],
             (10, 20),
         ),
+        # String is split for a multiple option (nargs == 1).
+        ({"point": "a b c"}, {"multiple": True}, [], ("a", "b", "c")),
+        # String is split and batched for a multiple option with nargs > 1.
+        (
+            {"point": "1 2 3 4"},
+            {"multiple": True, "nargs": 2, "type": int},
+            [],
+            ((1, 2), (3, 4)),
+        ),
+        # Already-structured value for a multiple option passes through.
+        ({"point": ["a", "b"]}, {"multiple": True}, [], ("a", "b")),
     ],
 )
 def test_default_map_nargs(runner, default_map, option_kwargs, cli_args, expected):
-    """A string in ``default_map`` for an option with ``nargs > 1`` should be
-    split the same way an environment variable string is split.
+    """A string in ``default_map`` for a multi-value option (``nargs > 1`` or
+    ``multiple``) should be split the same way an environment variable string
+    is split.
 
     Regression test for https://github.com/pallets/click/issues/2745.
     """


### PR DESCRIPTION
When a value comes from `default_map`, a plain string is split into
separate values for multi-value parameters so that it behaves like the
same string coming from an environment variable. This was added in #3364
(for #2745), but the split only triggered for `nargs != 1` and skipped
`multiple` options, which keep the default `nargs == 1`.

As a result, a `multiple` option whose `default_map` value is a string
fails, while the *same* option fed the *same* string via an environment
variable works:

```python
@click.command()
@click.option("--item", multiple=True, envvar="IT")
def cmd(item):
    click.echo(repr(item))
```

- `IT="a b c"` (envvar) -> `('a', 'b', 'c')`
- `default_map={"item": "a b c"}` -> `Error: Invalid value for '--item': Value must be an iterable.`

The string is passed unsplit into `type_cast_value`, which under
`multiple` iterates the value and rejects a bare `str`.

## Root cause

In `Parameter._collect_default_value` (the `default_map` branch of
`consume_value`), the split condition was `self.nargs != 1`.
`value_from_envvar` instead splits when `self.nargs != 1 or self.multiple`
and additionally batches the items into groups of `nargs` when both apply
(`multiple` with `nargs > 1`). The two value sources therefore diverged.

## Fix

Mirror `value_from_envvar`: split the string when `nargs != 1 or
multiple`, and batch into groups of `nargs` when both apply. Single-value
options (`nargs == 1`, not `multiple`) keep the string intact, as before.

After the fix, all multi-value shapes match the environment-variable path:

| option | `default_map` string | result |
| --- | --- | --- |
| `multiple=True` | `"a b c"` | `('a', 'b', 'c')` |
| `multiple=True, nargs=2, type=int` | `"1 2 3 4"` | `((1, 2), (3, 4))` |
| `nargs=2, type=int` | `"3 4"` | `(3, 4)` |
| `--name` (single) | `"a b c"` | `'a b c'` (unchanged) |

## Tests

Extended `test_default_map_nargs` with the `multiple` cases (nargs == 1,
nargs > 1 batching, and an already-structured value passing through). The
two string-splitting cases fail on `main` (exit code 2,
"Value must be an iterable.") and pass with the fix. Existing default,
option, and argument tests remain green; `ruff check`, `ruff format
--check`, and `mypy` on the changed module are clean. Added a `CHANGES.md`
entry.

fixes #2745