### PR TITLE
AI spam

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -13,6 +13,7 @@ from gettext import gettext as _
 
 from ._compat import isatty
 from ._compat import strip_ansi
+from . import _compat
 from .exceptions import Abort
 from .exceptions import UsageError
 from .globals import resolve_color_default
@@ -196,11 +197,17 @@ def prompt(
         text, prompt_suffix, show_default, default, show_choices, type
     )
 
+    if _compat.should_strip_ansi(sys.stderr if err else sys.stdout):
+        prompt = strip_ansi(prompt)
+
     if confirmation_prompt:
         if confirmation_prompt is True:
             confirmation_prompt = _("Repeat for confirmation")
 
         confirmation_prompt = _build_prompt(confirmation_prompt, prompt_suffix)
+
+        if _compat.should_strip_ansi(sys.stderr if err else sys.stdout):
+            confirmation_prompt = strip_ansi(confirmation_prompt)
 
     while True:
         while True:
@@ -266,6 +273,9 @@ def confirm(
         show_default,
         "y/n" if default is None else ("Y/n" if default else "y/N"),
     )
+
+    if _compat.should_strip_ansi(sys.stderr if err else sys.stdout):
+        prompt = strip_ansi(prompt)
 
     while True:
         try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,6 +217,56 @@ def test_confirm_repeat(runner):
     assert result.output == "A [y/n]: \nError: invalid input\nA [y/n]: y\n"
 
 
+def test_confirm_strips_ansi_with_color_false(runner):
+    """confirm() should strip ANSI codes from styled text when color=False."""
+
+    @click.command()
+    def cli():
+        if click.confirm(click.style("Hello World!", fg="green"), abort=True):
+            click.echo("yes")
+
+    result = runner.invoke(cli, input="y\n", color=False)
+    assert "\x1b[" not in result.output
+    assert result.output == "Hello World! [y/N]: y\nyes\n"
+
+
+def test_confirm_preserves_ansi_with_color_true(runner):
+    """confirm() should preserve ANSI codes in styled text when color=True."""
+
+    @click.command()
+    def cli():
+        if click.confirm(click.style("Hello World!", fg="green"), abort=True):
+            click.echo("yes")
+
+    result = runner.invoke(cli, input="y\n", color=True)
+    assert "\x1b[" in result.output
+
+
+def test_prompt_strips_ansi_with_color_false(runner):
+    """prompt() should strip ANSI codes from styled text when color=False."""
+
+    @click.command()
+    def cli():
+        value = click.prompt(click.style("Name", fg="blue"))
+        click.echo(f"Got: {value}")
+
+    result = runner.invoke(cli, input="test\n", color=False)
+    assert "\x1b[" not in result.output
+    assert result.output == "Name: test\nGot: test\n"
+
+
+def test_prompt_preserves_ansi_with_color_true(runner):
+    """prompt() should preserve ANSI codes in styled text when color=True."""
+
+    @click.command()
+    def cli():
+        value = click.prompt(click.style("Name", fg="blue"))
+        click.echo(f"Got: {value}")
+
+    result = runner.invoke(cli, input="test\n", color=True)
+    assert "\x1b[" in result.output
+
+
 @pytest.mark.skipif(WIN, reason="Different behavior on windows.")
 def test_prompts_abort(monkeypatch, capsys):
     def f(_):


### PR DESCRIPTION
## Summary

Fixes #3572 — ANSI codes are not stripped from `click.confirm()` and `click.prompt()` prompt text when `color=False` is set on `CliRunner`.

## Problem

In Click 8.4+, when using `CliRunner` with `color=False`, `click.echo()` correctly strips ANSI codes from styled text, but `click.confirm()` and `click.prompt()` do not. This is a regression from Click 8.3.

**Reproduction:**

```python
import click
from click.testing import CliRunner

@click.command()
def cmd():
    click.confirm(click.style("Hello World!", fg="green"), abort=True)

runner = CliRunner()
result = runner.invoke(cmd, input="Y", color=False)
# Expected: "Hello World! [y/N]: Y\n"
# Actual: "\x1b[32mHello World!\x1b[0m [y/N]: Y\n"
```

## Root Cause

`click.echo()` strips ANSI codes by calling `should_strip_ansi()` before writing output. However, `confirm()` and `prompt()` build their prompt text and pass it directly to `visible_prompt_func` (or `hidden_prompt_func`), which writes to stdout without going through `echo()`. This bypasses the ANSI-stripping logic entirely.

In `CliRunner.isolation()`, the `visible_input` function writes prompts via `sys.stdout.write(prompt)` directly, never passing through `echo()`.

## Fix

After building the prompt string in `confirm()` and `prompt()`, conditionally strip ANSI codes using `_compat.should_strip_ansi()` — the same function `echo()` uses. This uses a module-level attribute reference (`_compat.should_strip_ansi`) rather than a local import, ensuring the function correctly resolves to the patched version when used inside `CliRunner`.

Changes:
- `src/click/termui.py`: Import `_compat` module. In `confirm()` and `prompt()`, after `_build_prompt()`, strip ANSI from the prompt text when `should_strip_ansi()` returns `True`. Also handle the `confirmation_prompt` case in `prompt()`.
- `tests/test_utils.py`: Add 4 tests covering both stripping (color=False) and preservation (color=True) for `confirm()` and `prompt()`.

## Why `_compat.should_strip_ansi()` instead of local import

`CliRunner.isolation()` patches `should_strip_ansi` on the `_compat` and `utils` modules at runtime. Using `_compat.should_strip_ansi()` (module attribute lookup) ensures the patched version is called during tests, while a direct `from ._compat import should_strip_ansi` would create a local reference that bypasses the patch.