### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- `echo` and `secho` honor the `NO_COLOR` (<https://no-color.org/>) and
+  `FORCE_COLOR` (<https://force-color.org/>) environment variables when no
+  explicit color preference is given by an argument or the context. A
+  variable counts as set when it has a non-empty value, regardless of the
+  value, and `NO_COLOR` takes precedence over `FORCE_COLOR`. {issue}`3022`
+  {pr}`3629`
 
 ## Version 8.4.2
 
@@ -493,7 +499,7 @@ Released 2023-07-06
 - Make the decorators returned by `@argument()` and `@option()` reusable when the
   `cls` parameter is used. {issue}`2294`
 - Don't fail when writing filenames to streams with strict errors. Replace invalid
-  bytes with the replacement character (`�`). {issue}`2395`
+  bytes with the replacement character (`ï¿½`). {issue}`2395`
 - Remove unnecessary attempt to detect MSYS2 environment. {issue}`2355`
 - Remove outdated and unnecessary detection of App Engine environment. {pr}`2554`
 - `echo()` does not fail when no streams are attached, such as with `pythonw` on

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import typing as t
 from threading import local
 
@@ -54,14 +55,27 @@ def pop_context() -> None:
 def resolve_color_default(color: bool | None = None) -> bool | None:
     """Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
-    the current context.
+    the current context.  If neither provides an explicit preference, the
+    ``NO_COLOR`` and ``FORCE_COLOR`` environment variables are honored.
     """
     if color is not None:
         return color
 
     ctx = get_current_context(silent=True)
 
-    if ctx is not None:
+    if ctx is not None and ctx.color is not None:
         return ctx.color
+
+    # No explicit preference was given, so fall back to the de facto
+    # NO_COLOR (https://no-color.org/) and FORCE_COLOR
+    # (https://force-color.org/) standards. A variable is considered set
+    # when it has a non-empty value, regardless of what that value is.
+    # NO_COLOR takes precedence over FORCE_COLOR, matching the behavior of
+    # the CPython interpreter itself.
+    if os.environ.get("NO_COLOR"):
+        return False
+
+    if os.environ.get("FORCE_COLOR"):
+        return True
 
     return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -555,6 +555,109 @@ def test_echo_color_flag(monkeypatch, capfd):
     assert out == f"{styled_text}\n"
 
 
+@pytest.mark.parametrize(
+    ("no_color", "force_color", "expected"),
+    [
+        # Neither variable set -> no preference, fall back to detection.
+        (None, None, None),
+        # NO_COLOR disables color for any non-empty value, regardless of it.
+        ("1", None, False),
+        ("0", None, False),
+        ("false", None, False),
+        # FORCE_COLOR enables color for any non-empty value, regardless of it.
+        (None, "1", True),
+        (None, "0", True),
+        (None, "false", True),
+        # NO_COLOR takes precedence over FORCE_COLOR (matches CPython).
+        ("1", "1", False),
+        # Empty values do not count as "set".
+        ("", None, None),
+        (None, "", None),
+        ("", "", None),
+    ],
+)
+def test_resolve_color_default_env(monkeypatch, no_color, force_color, expected):
+    for name, value in (("NO_COLOR", no_color), ("FORCE_COLOR", force_color)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    assert click.globals.resolve_color_default() is expected
+
+
+@pytest.mark.parametrize("color", [True, False])
+def test_resolve_color_default_explicit_overrides_env(monkeypatch, color):
+    # An explicit value always wins over the environment variables.
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert click.globals.resolve_color_default(color) is color
+
+
+@pytest.mark.parametrize("isatty", [True, False])
+def test_echo_no_color_env(monkeypatch, capfd, isatty):
+    """``NO_COLOR`` strips style from ``echo`` output regardless of whether
+    the destination is a terminal (https://no-color.org/)."""
+    monkeypatch.setattr(click._compat, "isatty", lambda x: isatty)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    text = "foo"
+    styled_text = click.style(text, fg="red")
+    click.echo(styled_text)
+    out, err = capfd.readouterr()
+    assert out == f"{text}\n"
+
+
+@pytest.mark.parametrize("isatty", [True, False])
+def test_echo_force_color_env(monkeypatch, capfd, isatty):
+    """``FORCE_COLOR`` keeps style in ``echo`` output even when the
+    destination is not a terminal (https://force-color.org/)."""
+    monkeypatch.setattr(click._compat, "isatty", lambda x: isatty)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    styled_text = click.style("foo", fg="red")
+    click.echo(styled_text)
+    out, err = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+
+def test_echo_no_color_precedence_over_force_color(monkeypatch, capfd):
+    """When both are set, ``NO_COLOR`` wins."""
+    monkeypatch.setattr(click._compat, "isatty", lambda x: False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    text = "foo"
+    styled_text = click.style(text, fg="red")
+    click.echo(styled_text)
+    out, err = capfd.readouterr()
+    assert out == f"{text}\n"
+
+
+def test_echo_color_arg_overrides_color_env(monkeypatch, capfd):
+    """An explicit ``color`` argument overrides the environment variables."""
+    monkeypatch.setattr(click._compat, "isatty", lambda x: False)
+
+    text = "foo"
+    styled_text = click.style(text, fg="red")
+
+    # color=True overrides NO_COLOR.
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    click.echo(styled_text, color=True)
+    out, err = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+    # color=False overrides FORCE_COLOR.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    click.echo(styled_text, color=False)
+    out, err = capfd.readouterr()
+    assert out == f"{text}\n"
+
+
 def test_prompt_cast_default(capfd, monkeypatch):
     monkeypatch.setattr(sys, "stdin", StringIO("\n"))
     value = click.prompt("value", default="100", type=int)


### PR DESCRIPTION
Implements #3022. `echo`/`secho` now honor the NO_COLOR and FORCE_COLOR environment variables when no explicit color preference is supplied (via argument or context). A variable counts as set when it has a non-empty value, and NO_COLOR takes precedence over FORCE_COLOR, matching the CPython interpreter. Added unit tests for the precedence rules and end-to-end echo behavior, plus a CHANGES.md entry.

Closes #3022