### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- `progressbar` shows the final position when `update_min_steps` is not a
+  divisor of `length`, instead of stalling short of completion (for example
+  showing `20/20` rather than `14/20` with `show_pos=True`). {issue}`3571`
+  {pr}`XXXX`
 
 ## Version 8.4.1
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,15 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Apply any steps that were recorded but not yet rendered because
+        # they did not meet ``update_min_steps``. Without this the final
+        # position can lag behind the real progress (e.g. showing "14/20"
+        # instead of "20/20") when ``update_min_steps`` is not a divisor of
+        # ``length``.
+        if self._completed_intervals:
+            self.pos += self._completed_intervals
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,39 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_update_min_steps_finish(runner):
+    """``finish`` applies steps recorded below the ``update_min_steps``
+    threshold so the final position is accurate (issue #3571)."""
+    bar = _create_progress(length=20, update_min_steps=7)
+    for _ in range(20):
+        bar.update(1)
+    # 20 == 7 + 7 + 6; the last 6 steps did not reach the threshold and so
+    # were not yet applied to ``pos``.
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+    bar.finish()
+    assert bar.pos == 20
+    assert bar._completed_intervals == 0
+
+
+def test_progressbar_show_pos_final_completion(runner, monkeypatch):
+    """With ``show_pos`` and an ``update_min_steps`` that does not divide
+    ``length``, the final render still shows full completion (issue #3571)."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    lines = [line for line in output.split("\n") if "[" in line]
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571. When `update_min_steps` is not a divisor of `length`, the steps accumulated below the threshold at the end of iteration were never applied to the bar position, so the final render showed e.g. `14/20` (while the bar itself rendered full, since `pct` is `1.0` once finished). `ProgressBar.finish()` now flushes the pending steps so the final position is accurate. `finish()` only runs after full iteration, so early `with`-block exits are unaffected. Added a unit test and an end-to-end render test.

Closes #3571
