### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- A `progressbar` with `show_pos=True` and an `update_min_steps` that does not
+  divide the total length shows the full position when it finishes, instead of
+  stopping at the last rendered step. {issue}`3571` {pr}`3632`
 
 ## Version 8.4.1
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,12 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Apply any steps that were completed but not yet rendered because
+        # they didn't reach the update_min_steps threshold, so the final
+        # position reflects all the work that was done.
+        if self._completed_intervals > 0:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,20 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_completes(runner, monkeypatch):
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+
+    # update_min_steps that does not divide the length leaves some steps
+    # below the render threshold when iteration ends. The bar should still
+    # finish at the full position rather than stopping short.
+    with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
+        for _ in bar:
+            pass
+
+    assert bar.pos == bar.length
+    assert bar.format_pos() == "20/20"
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
fixes #3571

This shows up with a progress bar that uses `show_pos=True` and an `update_min_steps` that doesn't divide the length evenly:

    with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
        for _ in bar:
            ...

The last line ends on `14/20` instead of `20/20`. The bar fill and the percentage are both full, only the position is short.

`update()` holds steps in `_completed_intervals` until they reach `update_min_steps`. With length 20 and a min of 7 the position moves at 7 and 14, and the last 6 steps never cross the threshold, so they get dropped when iteration ends. The percentage doesn't show the problem because `pct` returns 1.0 once the bar is finished, while `format_pos` uses the raw position.

I moved those pending steps into the final position in `finish()` so it ends at 20/20. This only runs at the end of iteration, so manual `update()` calls aren't affected.

The test `test_progressbar_update_min_steps_completes` covers it. It fails before the change and passes after.
