### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`
   {pr}`3533`
+- `CliRunner` now strips ANSI sequences from `confirm` prompts captured with
+  `color=False`, matching other isolated prompt and output helpers.
+  {issue}`3572`
 
 ## Version 8.4.1
 

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -471,9 +471,16 @@ class CliRunner:
             errors="backslashreplace",
         )
 
+        def write_prompt(prompt: str | None) -> None:
+            if prompt is None:
+                return
+            if should_strip_ansi(sys.stdout):
+                prompt = _compat.strip_ansi(prompt)
+            sys.stdout.write(prompt)
+
         @_pause_echo(echo_input)  # type: ignore
         def visible_input(prompt: str | None = None) -> str:
-            sys.stdout.write(prompt or "")
+            write_prompt(prompt)
             try:
                 val = next(text_input).rstrip("\r\n")
             except StopIteration as e:
@@ -484,7 +491,8 @@ class CliRunner:
 
         @_pause_echo(echo_input)  # type: ignore
         def hidden_input(prompt: str | None = None) -> str:
-            sys.stdout.write(f"{prompt or ''}\n")
+            write_prompt(prompt)
+            sys.stdout.write("\n")
             sys.stdout.flush()
             try:
                 return next(text_input).rstrip("\r\n")

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -225,6 +225,38 @@ def test_with_color():
     assert not result.exception
 
 
+@pytest.mark.parametrize(
+    ("command", "user_input", "expected"),
+    [
+        (
+            lambda: click.prompt(click.style("Name", fg="green")),
+            "alice\n",
+            "Name: alice\n",
+        ),
+        (
+            lambda: click.prompt(click.style("Password", fg="green"), hide_input=True),
+            "secret\n",
+            "Password: \n",
+        ),
+        (
+            lambda: click.confirm(click.style("Hello World!", fg="green"), abort=True),
+            "Y\n",
+            "Hello World! [y/N]: Y\n",
+        ),
+    ],
+    ids=["prompt", "hidden-prompt", "confirm"],
+)
+def test_prompt_strips_ansi_when_color_disabled(command, user_input, expected):
+    @click.command()
+    def cli():
+        command()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, input=user_input, color=False)
+    assert result.output == expected
+    assert result.exit_code == 0
+
+
 def test_with_color_errors():
     class CLIError(ClickException):
         def format_message(self) -> str:


### PR DESCRIPTION
Fixes #3572

## Summary
- strip ANSI sequences from isolated prompt writers when `color=False`
- cover visible prompt, hidden prompt, and `click.confirm` regression cases
- document the 8.4.2 bug fix in `CHANGES.md`

## Verification
- `uv run --project contributions/pallets-click-3572 --python 3.12 pytest contributions/pallets-click-3572/tests/test_testing.py -q`
- `uv run --project contributions/pallets-click-3572 --python 3.12 pytest contributions/pallets-click-3572/tests/test_utils.py -q -k "full_prompt_passed_to_readline or echo_writing_to_standard_error"`