### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -351,6 +351,8 @@ class ProgressBar(t.Generic[V]):
         self.eta_known = False
         self.current_item = None
         self.finished = True
+        if self.length is not None:
+            self.pos = self.length
 
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,29 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_show_pos_with_update_min_steps(runner, monkeypatch):
+    """show_pos should show full completion when update_min_steps doesn't
+    divide length evenly. Regression test for pallets/click#3571."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+        ) as bar:
+            for _ in bar:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    # The final rendered line should show 20/20, not 14/20.
+    lines = [line for line in output.split("\n") if "[" in line]
+    last_bar_line = lines[-1]
+    assert "20/20" in last_bar_line
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
## Description

Fixes `click.progressbar` not showing full completion when using `show_pos=True` combined with `update_min_steps` that doesn't divide `length` evenly.

**Before this fix:** With `show_pos=True` and `update_min_steps=7` on a progress bar of length 20, the final output would show `14/20` instead of `20/20`.

**Root cause:** The `finish()` method set `self.finished = True` but didn't update `self.pos` to match `self.length`. When `update_min_steps` doesn't divide `length` evenly, the last batch of steps never gets applied via `make_step()`, leaving `pos` at an intermediate value.

**Fix:** Set `self.pos = self.length` in `finish()` when `length` is known, ensuring `format_pos()` displays the correct final position.

Fixes #3571

## Changes

- `src/click/_termui_impl.py`: Update `finish()` to set `pos = length` when length is known
- `tests/test_termui.py`: Add regression test for `show_pos=True` with non-divisor `update_min_steps`

## Testing

All existing tests pass, plus new regression test added:
```
218 passed, 23 skipped in test_termui.py
148 passed in test_utils.py
```