### PR TITLE
AI spam

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ Unreleased
   tabs in option help text are now escaped, keeping the original completion
   format while still supporting multi-line help. {issue}`3502`
   {issue}`3043` {pr}`3504` {pr}`3508`
+- Zsh shell completion escapes newlines in the completion value and help
+  text. The zsh script reads each completion as exactly three newline
+  delimited fields, so an unescaped newline shifted every following item.
+  Mirrors the Fish fix in {pr}`3504`.
 - Deprecated commands and options with empty or missing help text no longer
   render a stray leading space before the `(DEPRECATED)` label. {pr}`3509`
 - A {class}`Group` with `invoke_without_command=True` marks its subcommand as

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -399,6 +399,14 @@ class ZshComplete(ShellComplete):
         #
         # See issue #1812 and issue #2703 for further context.
         value = item.value.replace(":", r"\:") if help_ != "_" else item.value
+        # The zsh completion script reads the response with `(@f)`, which
+        # splits on newlines, and consumes exactly three newline-delimited
+        # fields (type, value, help) per item. A literal newline in the
+        # value or help adds an extra field and desyncs every item that
+        # follows, so escape newlines to the two-character sequence "\n"
+        # to keep each item on three lines, mirroring :class:`FishComplete`.
+        value = value.replace("\n", r"\n")
+        help_ = help_.replace("\n", r"\n")
         return f"{item.type}\n{value}\n{help_}"
 
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -15,6 +15,7 @@ from click.shell_completion import CompletionItem
 from click.shell_completion import FishComplete
 from click.shell_completion import shell_complete
 from click.shell_completion import ShellComplete
+from click.shell_completion import ZshComplete
 from click.types import Choice
 from click.types import File
 from click.types import Path
@@ -585,3 +586,21 @@ def test_fish_format_completion_escapes_help():
     # The newline is escaped to the literal characters backslash-n and the tab
     # becomes a space, so each completion stays on one line for fish.
     assert fc.format_completion(item) == "plain,--at\tfirst\\nsecond third"
+
+
+def test_zsh_format_completion_escapes_newlines():
+    zc = ZshComplete(Command("x"), {}, "x", "_X_COMPLETE")
+    item = CompletionItem("--at", help="first\nsecond")
+    # The zsh script consumes exactly three newline-delimited fields per item,
+    # so newlines in the value/help are escaped to backslash-n to keep the
+    # frame intact. Without escaping the help newline would add a fourth field
+    # and desync every following completion.
+    assert zc.format_completion(item) == "plain\n--at\nfirst\\nsecond"
+    assert zc.format_completion(item).count("\n") == 2
+
+
+def test_zsh_format_completion_escapes_newline_in_value():
+    zc = ZshComplete(Command("x"), {}, "x", "_X_COMPLETE")
+    item = CompletionItem("a\nb", help="help")
+    assert zc.format_completion(item) == "plain\na\\nb\nhelp"
+    assert zc.format_completion(item).count("\n") == 2


### PR DESCRIPTION
`ZshComplete.format_completion` returns `f"{type}\n{value}\n{help_}"` without escaping newlines. The frozen zsh script reads each response with `(@f)` and consumes exactly three newline-separated fields per item, so a `\n` in a value or help string adds a fourth field and desyncs every following completion.

This is the zsh counterpart of #3504, which fixed the same corruption class for fish by escaping `\n`/`\t`; the zsh formatter was left unmirrored. #3502 proposes this same approach.

The fix escapes `\n` in the value and help fields, with two tests mirroring the existing `test_fish_format_completion_escapes_help`. Verified both ways: without the fix the two new tests fail (the probe shows the four-field corrupt frame); with it, `test_shell_completion.py` passes and the full suite is 1603 passed / 0 failed.