### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -382,6 +382,10 @@ class ProgressBar(t.Generic[V]):
                 yield rv
                 self.update(1)
 
+            if self._completed_intervals:
+                self.make_step(self._completed_intervals)
+                self._completed_intervals = 0
+
             self.finish()
             self.render_progress()
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,22 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_update_min_steps_shows_final_pos(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli).output
+    lines = [line for line in output.splitlines() if "[" in line]
+
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

When `update_min_steps` is greater than 1, the iterator can finish with a few completed intervals still below the render threshold. Those remaining intervals were not applied before the final render, so `show_pos=True` could leave the displayed position behind even though the bar itself was complete.

This applies any remaining intervals after the iterable is exhausted and before the final progress render. A regression test covers the reported `show_pos=True` case with `update_min_steps=7`.

Tests run:

- `python -m pytest tests/test_termui.py -q`
- `python -m pytest -q`
- `python -m ruff check src/click/_termui_impl.py tests/test_termui.py`
