### PR TITLE
Do not trigger a `BytesWarning` under `python -bb`

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1104,7 +1104,8 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
     ) -> str | bytes | os.PathLike[str]:
         rv = value
 
-        is_dash = self.file_okay and self.allow_dash and rv in (b"-", "-")
+        dash = b"-" if isinstance(rv, bytes) else "-"
+        is_dash = self.file_okay and self.allow_dash and rv == dash
 
         if not is_dash:
             if self.resolve_path:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,8 @@
 import os.path
 import pathlib
 import platform
+import subprocess
+import sys
 import tempfile
 
 import pytest
@@ -123,6 +125,29 @@ def test_path_type(runner, cls, expect):
     result = runner.invoke(cli, ["a/b/c.txt"], standalone_mode=False)
     assert result.exception is None
     assert result.return_value == expect
+
+
+def test_path_dash_no_byteswarning():
+    """Detecting the ``-`` dash sentinel must not compare ``bytes`` against
+    ``str``, which raises a ``BytesWarning`` under ``python -bb``.
+
+    The warning is only emitted when the interpreter runs with ``-b``, so this
+    has to be checked in a subprocess. ``-bb`` turns the warning into an error,
+    so a clean exit means no mismatched comparison happened.
+    """
+    program = (
+        "import click\n"
+        "convert = click.Path(allow_dash=True).convert\n"
+        "for value in ('-', '', b'-', b''):\n"
+        "    convert(value, None, None)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-bb", "-c", program],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "BytesWarning" not in result.stderr
 
 
 def _symlinks_supported():


### PR DESCRIPTION
This fix a strict exception being raised when the hard-coded `-` path is compared with unmatching types.