### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ Unreleased
 - `echo_via_pager` flushes after each write, so passing a generator streams
   output to the pager incrementally instead of staying hidden until the pipe
   buffer fills. {issue}`3242` {issue}`2542` {pr}`3534`
+- `LazyFile` no longer eagerly opens and closes a FIFO (named pipe) to check
+  for errors. Doing so could consume or desync the FIFO's contents before the
+  real, lazy open happened later, causing reads to hang or fail
+  inconsistently. {issue}`2645`
 - `echo_via_pager` and `get_pager_file` no longer close a borrowed stdout
   stream when no external pager runs, completing the partial
   `I/O operation on closed file` fix from {pr}`3482`. {issue}`3449`

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import os
 import re
+import stat
 import sys
 import typing as t
 from functools import update_wrapper
@@ -109,6 +110,21 @@ def make_default_short_help(help: str, max_length: int = 45) -> str:
     return " ".join(words[:i]) + "..."
 
 
+def _is_fifo(filename: str | os.PathLike[str]) -> bool:
+    """Return whether ``filename`` is a FIFO (named pipe).
+
+    Used to skip the eager open/close error check in :class:`LazyFile`:
+    that check would otherwise consume or desync a FIFO's contents before
+    the real, lazy open happens later. Returns ``False`` (rather than
+    raising) if the path can't be stat'd, since the subsequent real open
+    will surface any such error anyway.
+    """
+    try:
+        return stat.S_ISFIFO(os.stat(filename).st_mode)
+    except OSError:
+        return False
+
+
 class LazyFile:
     """A lazy file works like a regular file but it does not fully open
     the file but it does perform some basic checks early to see if the
@@ -141,10 +157,12 @@ class LazyFile:
         if self.name == "-":
             self._f, self.should_close = open_stream(filename, mode, encoding, errors)
         else:
-            if "r" in mode:
+            if "r" in mode and not _is_fifo(filename):
                 # Open and close the file in case we're opening it for
                 # reading so that we can catch at least some errors in
-                # some cases early.
+                # some cases early. Skip this for FIFOs (named pipes):
+                # opening and closing one for reading can consume or
+                # desync its contents before the real, lazy open happens.
                 open(filename, mode).close()
             self._f = None
             self.should_close = True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -785,6 +785,36 @@ def test_iter_lazyfile(tmpdir):
                 assert e_line == a_line.strip()
 
 
+@pytest.mark.skipif(WIN, reason="fifos are not supported on Windows")
+def test_lazyfile_skips_eager_check_for_fifo(tmpdir):
+    # Regression test for #2645: LazyFile's eager open/close error check
+    # must not be performed on a FIFO, since doing so can consume or
+    # desync its contents before the real, lazy open happens.
+    fifo_path = str(tmpdir.join("test.fifo"))
+    os.mkfifo(fifo_path)
+
+    # If LazyFile eagerly opened the fifo for reading here, this call
+    # would block forever (nothing has written to the fifo yet), since
+    # there would be no writer to pair with that eager open.
+    lf = click.utils.LazyFile(fifo_path, mode="r")
+    assert lf._f is None
+
+    with open(fifo_path, "w") as writer:
+        writer.write("hello\n")
+        writer.flush()
+        assert lf.read() == "hello\n"
+
+
+def test_is_fifo_helper(tmpdir):
+    regular_file = tmpdir.join("regular.txt")
+    regular_file.write("content")
+    assert click.utils._is_fifo(str(regular_file)) is False
+
+    # A path that doesn't exist must not raise - the later real open
+    # will surface the appropriate error instead.
+    assert click.utils._is_fifo(str(tmpdir.join("does-not-exist"))) is False
+
+
 class MockMain:
     __slots__ = "__package__"
 


### PR DESCRIPTION
Fixes #2645

## Bug

`LazyFile` (used by `click.File(..., lazy=True)`) opens and closes the target file once upfront, to surface obvious errors (missing file, bad permissions) before the real, lazy open:

```python
if "r" in mode:
    # Open and close the file in case we're opening it for
    # reading so that we can catch at least some errors in
    # some cases early.
    open(filename, mode).close()
```

For a FIFO (named pipe), this extra open/close pairs with whatever writer is currently blocked on the pipe and can consume or desync its contents before the real open happens later. Depending on timing between the eager check and the real open, reads either hang forever or return stale/incomplete data — non-deterministic and hard to debug, as described in the issue.

## Fix

This implements fix option (1) suggested and validated by the issue reporter: detect FIFOs via `stat.S_ISFIFO` and skip the eager open/close for them. The real, lazy open still happens later and will surface any actual error (missing file, permissions, etc.) at that point.

```python
def _is_fifo(filename):
    try:
        return stat.S_ISFIFO(os.stat(filename).st_mode)
    except OSError:
        return False
```

`LazyFile.__init__` now skips the eager check when `_is_fifo(filename)` is true.

## Tests

- `test_is_fifo_helper`: platform-independent, checks `_is_fifo` against a regular file and a nonexistent path.
- `test_lazyfile_skips_eager_check_for_fifo`: creates a real FIFO with `os.mkfifo` and asserts `LazyFile` doesn't block on construction, then proves the file is genuinely still readable lazily afterward. Marked `@pytest.mark.skipif(WIN, ...)` since FIFOs aren't supported on Windows (matches the existing `skipif(sys.platform != "win32", ...)` convention already used elsewhere in this test file).

## Verification

I developed this on Windows, where `os.mkfifo` doesn't exist, so I can't directly execute the new FIFO test locally — it will run in CI on Linux/macOS. To verify the logic without a real FIFO, I:
- Mocked `os.stat` to return FIFO vs. regular-file `st_mode` bits and confirmed `_is_fifo` returns `True`/`False` correctly.
- Mocked `_is_fifo` itself and confirmed `LazyFile.__init__` takes the skip-eager-open branch when `_is_fifo` is `True`, and still takes the existing eager-open branch when `False` (preserving current behavior for regular files).
- Ran the full test suite (`pytest tests/`): 1602 passed, 96 skipped (including the new FIFO test, skipped on Windows), 1 xfailed — no regressions.
- `ruff check` / `ruff format --check` / `mypy src/click/utils.py`: all clean.

Added a `CHANGES.md` entry per the project's convention.