### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Long option value shell completion preserves the option name when completing
+  values after `=`. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -283,8 +283,23 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix is not None:
+            completions = [
+                CompletionItem(
+                    f"{completion_prefix}{item.value}",
+                    type=item.type,
+                    help=item.help,
+                    **item._info,
+                )
+                if item.type == "plain"
+                else item
+                for item in completions
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem) -> str:
         """Format a completion item into the form recognized by the
@@ -635,7 +650,7 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str | None]:
     """Find the Click object that will handle the completion of the
     incomplete value. Return the object and the incomplete value.
 
@@ -648,18 +663,21 @@ def _resolve_incomplete(
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
     # split and discard the "=" to make completion easier.
+    completion_prefix = None
+
     if incomplete == "=":
         incomplete = ""
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, completion_prefix
 
     params = ctx.command.get_params(ctx)
 
@@ -667,14 +685,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, completion_prefix

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -485,6 +485,21 @@ def test_choice_case_sensitive(value, expect):
     assert completions == expect
 
 
+def test_long_option_equals_value_completion():
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+
+    assert _get_words(cli, [], "--color=") == [
+        "--color=auto",
+        "--color=always",
+        "--color=never",
+    ]
+    assert _get_words(cli, [], "--color=al") == ["--color=always"]
+    assert _get_words(cli, ["--color"], "al") == ["always"]
+
+
 @pytest.fixture()
 def _restore_available_shells(tmpdir):
     prev_available_shells = click.shell_completion._available_shells.copy()


### PR DESCRIPTION
Fixes #2847

This preserves the completed long option prefix when shell completion is requested for values written as `--option=value`. The resolver still strips the prefix before asking the option type for value completions, then prefixes plain completion values before formatting the shell response. Space-separated option value completion remains unchanged.

Tests:
- `python -m pytest tests/test_shell_completion.py -q`
- `ruff format src/click/shell_completion.py tests/test_shell_completion.py`
- `ruff check src/click/shell_completion.py tests/test_shell_completion.py`
- `git diff --check`
- `python -m pytest -q` with pytest 8.4.2: `1672 passed, 25 skipped, 31000 deselected, 1 xfailed`

Note: the full suite with pytest 9.1.1 failed during collection because existing tests trigger `pytest.PytestRemovedIn10Warning` and the project treats warnings as errors; reran with pytest 8.4.2.