### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -137,6 +137,7 @@ class ProgressBar(t.Generic[V]):
         exc_value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
+        self.finish()
         self.render_finish()
 
     def __iter__(self) -> cabc.Iterator[V]:
@@ -351,6 +352,11 @@ class ProgressBar(t.Generic[V]):
         self.eta_known = False
         self.current_item = None
         self.finished = True
+
+        if self._completed_intervals > 0:
+            self.make_step(self._completed_intervals)
+            self.render_progress()
+            self._completed_intervals = 0
 
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,28 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_finish_renders_remaining(runner):
+    bar = _create_progress(update_min_steps=5)
+    with bar:
+        bar.update(3)
+        assert bar._completed_intervals == 3
+        assert bar.pos == 0
+    assert bar._completed_intervals == 0
+    assert bar.pos == 3
+    assert bar.finished is True
+
+
+def test_progress_bar_finish_no_remaining(runner):
+    bar = _create_progress(update_min_steps=5)
+    with bar:
+        bar.update(5)
+        assert bar._completed_intervals == 0
+        assert bar.pos == 5
+    assert bar._completed_intervals == 0
+    assert bar.pos == 5
+    assert bar.finished is True
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
## What this PR does

Fixes #3571

When using `click.progressbar` with `show_pos=True` and `update_min_steps` that doesn't evenly divide the length, the progress bar shows incomplete progress (e.g., "14/20" instead of "20/20").

## Root cause

The `update()` method only renders when `_completed_intervals >= update_min_steps`. The final batch of steps may be below this threshold, so they are never rendered. Additionally, `finish()` does not flush remaining intervals, and `__exit__` does not call `finish()`.

## Fix

1. **`finish()`**: Added logic to render any remaining unrendered intervals before marking the bar as finished
2. **`__exit__()`**: Now calls `finish()` before `render_finish()` so the context manager path also flushes pending steps

## Tests

Added two test cases:
- `test_progress_bar_finish_renders_remaining` - verifies remaining steps are flushed on exit
- `test_progress_bar_finish_no_remaining` - verifies clean exit when no steps remain
