### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,23 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_update_min_steps_finishes_show_pos(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    assert "  [####################################]  20/20" in output
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

## Summary
- flush pending progress intervals before rendering the final progress bar state
- add a regression test for `show_pos=True` with `update_min_steps` that does not divide the length

## Tests
- `PYTHONPATH=src python3 -m pytest tests/test_termui.py -q -k "update_min_steps_finishes_show_pos"`
- `PYTHONPATH=src python3 -m pytest tests/test_termui.py -q -k "update_min_steps_finishes_show_pos or progress_bar_update_min_steps or progressbar_update"`
- `uv run --frozen ruff check src/click/_termui_impl.py tests/test_termui.py`
- `uv run --frozen pytest tests/test_termui.py -q`