### PR TITLE
AI junk

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -330,9 +330,9 @@ class BashComplete(ShellComplete):
             match = re.search(r"^(\d+)\.(\d+)\.\d+", output.stdout.decode())
 
         if match is not None:
-            major, minor = match.groups()
+            major, minor = (int(x) for x in match.groups())
 
-            if major < "4" or major == "4" and minor < "4":
+            if major < 4 or major == 4 and minor < 4:
                 echo(
                     _(
                         "Shell completion is not supported for Bash"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -258,9 +258,11 @@ def test_boolean_flag(runner, default, args, expect):
 
 @pytest.mark.parametrize(
     ("value", "expect"),
-    chain(
-        ((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
-        ((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
+    list(
+        chain(
+            ((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
+            ((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
+        )
     ),
 )
 def test_boolean_conversion(runner, value, expect):

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -2,6 +2,7 @@ import io
 import textwrap
 import warnings
 from collections.abc import Mapping
+from types import SimpleNamespace
 
 import pytest
 
@@ -343,6 +344,34 @@ def _patch_for_completion(monkeypatch):
     monkeypatch.setattr(
         "click.shell_completion.BashComplete._check_version", lambda self: True
     )
+
+
+@pytest.mark.parametrize(
+    ("version", "expect_stderr"),
+    [
+        ("4.3.0(1)-release", "Shell completion is not supported for Bash"),
+        ("4.4.0(1)-release", ""),
+        ("4.10.0(1)-release", ""),
+        ("10.0.0(1)-release", ""),
+    ],
+)
+def test_bash_check_version_uses_numeric_version(
+    monkeypatch, capsys, version, expect_stderr
+) -> None:
+    def run(args, stdout):
+        return SimpleNamespace(stdout=f"{version}\n".encode())
+
+    monkeypatch.setattr("shutil.which", lambda name: "/bin/bash")
+    monkeypatch.setattr("subprocess.run", run)
+
+    click.shell_completion.BashComplete._check_version()
+
+    output = capsys.readouterr()
+
+    if expect_stderr:
+        assert expect_stderr in output.err
+    else:
+        assert output.err == ""
 
 
 @pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])


### PR DESCRIPTION
## Summary
- Compare Bash shell completion versions as numbers so 4.10 and 10.0 are not treated as older than 4.4.

## Validation
- shell completion tests, full pytest, and ruff passed.

## Notes
- Opened as a draft PR for maintainer review.
