### PR TITLE
Strip ANSI from `confirm()` and `prompt()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- `confirm()` and `prompt()` strip ANSI color and style codes from the
+  prompt when the output stream does not support them, matching `echo()`.
+  This stripping was lost in `8.4.0` when {pr}`2969` began writing the
+  prompt with `input()` directly. {issue}`3572` {pr}`3653`
 
 ## Version 8.4.2
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -11,6 +11,7 @@ from contextlib import AbstractContextManager
 from contextlib import redirect_stdout
 from gettext import gettext as _
 
+from . import _compat
 from ._compat import isatty
 from ._compat import strip_ansi
 from .exceptions import Abort
@@ -83,7 +84,20 @@ def hidden_prompt_func(prompt: str) -> str:
 def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
     """Call a prompt function, passing the full prompt on non-Windows so
     readline can handle line editing and cursor positioning correctly.
+
+    The prompt is handed to *func* (such as :func:`input`) rather than
+    written through :func:`echo`, so it has to strip ANSI color and style
+    codes itself when the destination stream does not support them. Without
+    this the prompt would keep codes that :func:`echo` removes from the
+    rest of the output.
     """
+    stream = sys.stderr if err else sys.stdout
+
+    # Look up ``should_strip_ansi`` on the module so that ``CliRunner``,
+    # which patches it there during test isolation, is honored.
+    if _compat.should_strip_ansi(stream, resolve_color_default()):
+        text = strip_ansi(text)
+
     if err:
         with redirect_stdout(sys.stderr):
             return func(text)

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1022,6 +1022,56 @@ def test_confirmation_prompt(runner, prompt, input, default, expect):
         assert "Confirm Password: " in result.output
 
 
+@pytest.mark.parametrize(
+    ("call", "user_input", "color", "expect"),
+    [
+        pytest.param(
+            lambda: click.confirm(click.style("Hello World!", fg="green")),
+            "y",
+            False,
+            "Hello World! [y/N]: y\n",
+            id="confirm-no-color",
+        ),
+        pytest.param(
+            lambda: click.confirm(click.style("Hello World!", fg="green")),
+            "y",
+            True,
+            "\x1b[32mHello World!\x1b[0m [y/N]: y\n",
+            id="confirm-color",
+        ),
+        pytest.param(
+            lambda: click.prompt(click.style("Name", fg="green")),
+            "Bob",
+            False,
+            "Name: Bob\n",
+            id="prompt-no-color",
+        ),
+        pytest.param(
+            lambda: click.prompt(click.style("Name", fg="green")),
+            "Bob",
+            True,
+            "\x1b[32mName\x1b[0m: Bob\n",
+            id="prompt-color",
+        ),
+    ],
+)
+def test_prompt_and_confirm_ansi_respects_color(
+    runner, call, user_input, color, expect
+):
+    """``confirm`` and ``prompt`` strip ANSI color and style codes from the
+    prompt when color is disabled and keep them when it is enabled, like
+    ``echo``. The prompt is written by ``input`` rather than ``echo``, so it
+    used to keep the codes regardless (issue 3572).
+    """
+
+    @click.command()
+    def cli():
+        call()
+
+    result = runner.invoke(cli, input=user_input, color=color)
+    assert result.output == expect
+
+
 def test_false_show_default_cause_no_default_display_in_prompt(runner):
     @click.command()
     @click.option("--arg1", show_default=False, prompt=True, default="my-default-value")


### PR DESCRIPTION
This is a regression introduced by #2969 in Click 8.4.0.

This PR closes #3572.