### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Released 2026-06-24
 
+- `progressbar` shows the correct final position when `update_min_steps`
+  doesn't evenly divide the total length. {issue}`3571`
 - Fix Fish shell completion broken in `8.4.0` by {pr}`3126`. Newlines and
   tabs in option help text are now escaped, keeping the original completion
   format while still supporting multi-line help. {issue}`3502`

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -156,6 +156,10 @@ class ProgressBar(t.Generic[V]):
     def render_finish(self) -> None:
         if self.hidden or not self._is_atty:
             return
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+            self.render_progress()
         self.file.write(AFTER_BAR)
         self.file.flush()
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,20 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_shows_full_completion(runner, monkeypatch):
+    """render_finish must flush remaining steps so final position is shown."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(length=20, show_pos=True, update_min_steps=7) as bar:
+            for _ in range(20):
+                bar.update(1)
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    assert "20/20" in output
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571

When `update_min_steps` doesn't evenly divide the total length, the last batch of steps never reaches the threshold in `update()` so `render_progress()` is never called for them. `render_finish()` now flushes any remaining steps and renders once more before writing the closing newline.

Added a regression test: `length=20`, `update_min_steps=7`, 20 individual `update(1)` calls — confirms `20/20` appears in the output.