### PR TITLE
Don't parameterize tests using non-Collection iterables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Fix test failures when using pytest >= 9.1. {pr}`3656`
 
 ## Version 8.4.2
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import enum
 import os
-from itertools import chain
 
 import pytest
 
@@ -258,10 +257,10 @@ def test_boolean_flag(runner, default, args, expect):
 
 @pytest.mark.parametrize(
     ("value", "expect"),
-    chain(
-        ((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
-        ((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
-    ),
+    [
+        *((x, "True") for x in ("1", "true", "t", "yes", "y", "on")),
+        *((x, "False") for x in ("0", "false", "f", "no", "n", "off")),
+    ],
 )
 def test_boolean_conversion(runner, value, expect):
     @click.command()


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize.