### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -382,6 +382,12 @@ class ProgressBar(t.Generic[V]):
                 yield rv
                 self.update(1)
 
+            # Flush any accumulated steps that did not meet the
+            # update_min_steps threshold so the final position is correct.
+            if self._completed_intervals > 0:
+                self.make_step(self._completed_intervals)
+                self._completed_intervals = 0
+
             self.finish()
             self.render_progress()
 

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1560,3 +1560,27 @@ def test_hide_input_value_never_leaks_when_err_true(runner):
     result = runner.invoke(cli, input="leaky\n", mix_stderr=False)
     assert "leaky" not in result.stdout
     assert "leaky" not in result.stderr
+
+
+
+
+
+def test_progressbar_update_min_steps_shows_final_pos(runner, monkeypatch):
+    """progressbar with update_min_steps that doesn't divide length evenly
+    should still show the full final position (GH #3571)."""
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+
+    @click.command()
+    def cli():
+        with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
+            for _ in bar:
+                pass
+
+    result = runner.invoke(cli, catch_exceptions=False).output
+    # The last rendered frame must show 20/20, not a stale partial count.
+    # Output uses carriage returns to overwrite the bar; split on them.
+    frames = [f for f in result.split(chr(13)) if f.strip()]
+    assert frames, "Expected at least one rendered frame"
+    assert "20/20" in frames[-1], (
+        "Expected '20/20' in final frame, got: {!r}".format(frames[-1])
+    )


### PR DESCRIPTION
## Problem

When using `click.progressbar` with `update_min_steps` that doesn't evenly divide the total `length`, the final rendered frame shows a partial count instead of the full position:

```python
with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
    for i in bar:
        pass
# Final output: [####################################]  14/20
# Expected:     [####################################]  20/20
```

The percentage-based rendering is unaffected (`100%` shows correctly) because `self.finished = True` forces `pct` to return `1.0`. But `show_pos=True` reads `self.pos` directly, which is only updated by `make_step()`, and the remaining 6 steps (items 15–20, since 20 − 14 = 6 < update_min_steps=7) are never flushed.

## Root Cause

In `ProgressBar.generator()`, `update(1)` is called after each item. `update()` accumulates `_completed_intervals` and only calls `make_step()` when the threshold is met:

```python
if self._completed_intervals >= self.update_min_steps:
    self.make_step(self._completed_intervals)
    ...
    self._completed_intervals = 0
```

After the loop ends, any remaining `_completed_intervals < update_min_steps` are never flushed, so `self.pos` stays at the last threshold value.

## Fix

Flush the remaining accumulated steps before calling `finish()`:

```python
if self._completed_intervals > 0:
    self.make_step(self._completed_intervals)
    self._completed_intervals = 0

self.finish()
self.render_progress()
```

## Tests

Added `test_progressbar_update_min_steps_shows_final_pos` which asserts that the final rendered frame contains `20/20` when `update_min_steps=7` and `length=20`.

Closes #3571