### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -347,6 +347,9 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -349,6 +349,22 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_show_pos_update_min_steps(runner, monkeypatch):
+    """show_pos=True must display the true final position even when
+    update_min_steps doesn't evenly divide the total length."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
+            for _ in bar:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    lines = [line for line in output.split("\n") if "[" in line]
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

## Problem

When `click.progressbar` is used with `show_pos=True` and an `update_min_steps` value that doesn't evenly divide the total `length`, the final frame shows a stale position rather than the true total. For example, with `length=20` and `update_min_steps=7`, the last render shows `14/20` instead of `20/20` even though the full bar is drawn.

## Root Cause

`update()` batches steps and only calls `make_step()` when `_completed_intervals >= update_min_steps`. If the last batch is smaller than the threshold, those steps are never forwarded to `self.pos`. When the generator finishes and calls `self.finish()` followed by `self.render_progress()`, `self.pos` is still at the last rendered step, not at the true final position.

Note that the progress *bar* itself renders correctly at 100% (because `pct` returns `1.0` when `finished=True`), but `format_pos()` reads `self.pos` directly, so it shows the old value.

## Fix

`finish()` now flushes any pending `_completed_intervals` by calling `make_step()` before marking the bar as finished:

```python
def finish(self) -> None:
    if self._completed_intervals:
        self.make_step(self._completed_intervals)
        self._completed_intervals = 0
    self.eta_known = False
    self.current_item = None
    self.finished = True
```

## Tests

Added `test_progress_bar_show_pos_update_min_steps` which reproduces the exact scenario from the issue report (`range(20)`, `update_min_steps=7`) and asserts the final output line contains `20/20`.