### PR TITLE
AI junk

### DIFF
--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -473,6 +473,8 @@ class CliRunner:
 
         @_pause_echo(echo_input)  # type: ignore
         def visible_input(prompt: str | None = None) -> str:
+            if prompt and should_strip_ansi():
+                prompt = strip_ansi(prompt)
             sys.stdout.write(prompt or "")
             try:
                 val = next(text_input).rstrip("\r\n")
@@ -484,6 +486,8 @@ class CliRunner:
 
         @_pause_echo(echo_input)  # type: ignore
         def hidden_input(prompt: str | None = None) -> str:
+            if prompt and should_strip_ansi():
+                prompt = strip_ansi(prompt)
             sys.stdout.write(f"{prompt or ''}\n")
             sys.stdout.flush()
             try:


### PR DESCRIPTION
Fixes #3572

## Problem

`click.confirm()` (and `click.prompt()`) do not strip ANSI codes from the prompt text when `CliRunner.invoke(..., color=False)` is used, even though `click.echo()` correctly strips them in the same situation:

```python
runner = CliRunner()
result = runner.invoke(cmd_confirm, input="Y", color=False)
# result.output contains '\x1b[32mHello World!\x1b[0m [y/N]: Y\n'
# Expected:          'Hello World! [y/N]: Y\n'
```

## Root cause

`CliRunner.isolation()` replaces `termui.visible_prompt_func` with a local `visible_input` function that writes the prompt directly via `sys.stdout.write(prompt or "")`, bypassing the `should_strip_ansi` check that `click.echo` goes through. The same applies to `hidden_input`.

## Fix

In both `visible_input` and `hidden_input`, strip ANSI from the prompt when `should_strip_ansi()` returns `True` (i.e. when `color=False`). The `should_strip_ansi` local function is already defined in the same closure scope and is designed for exactly this purpose.