### PR TITLE
Fix Windows prompt err=True stdout leak in_readline_prompt

### DIFF
--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -94,11 +94,15 @@ def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
         echo(text[:-1], nl=False, err=err)
         # Echo the last character to stdout to work around an issue
         # where readline causes backspace to clear the whole line.
-        
         if err:
             with redirect_stdout(sys.stderr):
-                return func(text)
-        return func(text)
+                return func(text[-1:])
+
+        return func(text[-1:])
+    if err:
+        with redirect_stdout(sys.stderr):
+            return func(text)
+    return func(text)
 
 
 def _build_prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+from ._compat import WIN
 import collections.abc as cabc
 import inspect
 import io
@@ -82,15 +82,14 @@ def hidden_prompt_func(prompt: str) -> str:
 
 
 def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
-    """Call a prompt function, passing the full prompt on non-Windows so
-    readline can handle line editing and cursor positioning correctly.
+    """Call a prompt function, passing full prompt or WIN workaround."""
 
-    The prompt is handed to *func* (such as :func:`input`) rather than
-    written through :func:`echo`, so it has to strip ANSI color and style
-    codes itself when the destination stream does not support them. Without
-    this the prompt would keep codes that :func:`echo` removes from the
-    rest of the output.
-    """
+    stream = sys.stderr if err else sys.stdout
+
+    # IMPORTANT: always strip ANSI consistently first
+    if _compat.should_strip_ansi(stream, resolve_color_default()):
+        text = strip_ansi(text)
+
     if WIN:
         echo(text[:-1], nl=False, err=err)
 
@@ -105,7 +104,6 @@ def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
             return func(text)
 
     return func(text)
-
 def _build_prompt(
     text: str,
     suffix: str,

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -94,11 +94,11 @@ def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
         echo(text[:-1], nl=False, err=err)
         # Echo the last character to stdout to work around an issue
         # where readline causes backspace to clear the whole line.
-        return func(text[-1:])
-    if err:
-        with redirect_stdout(sys.stderr):
-            return func(text)
-    return func(text)
+        
+        if err:
+            with redirect_stdout(sys.stderr):
+                return func(text)
+        return func(text)
 
 
 def _build_prompt(

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from ._compat import WIN
+
 import collections.abc as cabc
 import inspect
 import io
@@ -14,6 +14,7 @@ from gettext import gettext as _
 from . import _compat
 from ._compat import isatty
 from ._compat import strip_ansi
+from ._compat import WIN
 from .exceptions import Abort
 from .exceptions import UsageError
 from .globals import resolve_color_default
@@ -104,6 +105,8 @@ def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
             return func(text)
 
     return func(text)
+
+
 def _build_prompt(
     text: str,
     suffix: str,


### PR DESCRIPTION
Fixes issue where Windows _readline_prompt bypassed stderr redirection when err=True,
causing prompt output to leak into stdout in CliRunner-based tests.

This change ensures consistent behavior with POSIX by correctly applying
redirect_stdout(sys.stderr) for prompt execution when err=True.

Fixes #3662