### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Unreleased
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
+- The usage line no longer breaks a long option at one of its internal
+  hyphens when wrapping; options are only wrapped at spaces. {issue}`3362`
 
 ## Version 8.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Unreleased
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
 - The usage line no longer breaks a long option at one of its internal
-  hyphens when wrapping; options are only wrapped at spaces. {issue}`3362`
+  hyphens when wrapping; options are only wrapped at spaces. {issue}`3362` {pr}`3664`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -67,6 +68,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +188,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +198,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -501,6 +501,30 @@ def test_write_usage_styled_prefix_keeps_options_on_one_line():
     assert visible == "Usage: cli [OPTIONS]\n"
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    """Issue #3362: a long option wrapped onto a new line must not be split
+    at one of its internal hyphens.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    rendered = formatter.getvalue()
+
+    # Wrapping only ever happens between options (at spaces), so no line ends
+    # in a hyphen from a broken option name.
+    assert not any(line.rstrip().endswith("-") for line in rendered.splitlines())
+    # Every option still appears intact.
+    for option in options:
+        assert option in rendered.replace("\n", " ")
+
+
 @pytest.mark.parametrize(
     ("formatter_kwargs", "current_indent", "prog", "args", "prefix", "expected"),
     [


### PR DESCRIPTION
Fixes #3362.

`HelpFormatter.write_usage` wrapped the arguments string with the default `break_on_hyphens=True`, so a long option that got pushed onto a new line could be split at one of its internal hyphens:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location
```

This adds a `break_on_hyphens` parameter to `wrap_text` and passes `break_on_hyphens=False` from `write_usage`, so the usage line only ever wraps between options (at spaces):

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location
```

Other `wrap_text` callers are unaffected — the default stays `True`.

Added `test_write_usage_does_not_break_options_at_hyphens`. Full `tests/test_formatting.py` passes (36) and a broader run of `test_formatting.py` + `test_basic.py` (129) is green.
