### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -350,6 +350,8 @@ class ProgressBar(t.Generic[V]):
     def finish(self) -> None:
         self.eta_known = False
         self.current_item = None
+        if self.length is not None:
+            self.pos = self.length
         self.finished = True
 
     def generator(self) -> cabc.Iterator[V]:


### PR DESCRIPTION
Fix #3571

## Problem

When using `click.progressbar` with `show_pos=True` and `update_min_steps` that does not evenly divide `length`, the progress bar never shows full completion. For example, with `length=20` and `update_min_steps=7`:

```
  [####################################]  14/20
```

The bar is rendered full (because `pct` returns 1.0 when `finished` is True), but the position counter shows `14/20` instead of `20/20`. This happens because pending steps accumulate in `_completed_intervals` and `self.pos` never reaches `self.length`.

## Fix

In `ProgressBar.finish()`, set `self.pos = self.length` when `self.length` is known, ensuring the final rendered position matches the total.

## Verification

- `bar.pos` is correctly set to `self.length` after finish
- `bar.format_pos()` returns `20/20` instead of `14/20`
- Existing behavior for `length=None` is preserved (position is left unchanged)
- `update_min_steps=1` (default) continues to work correctly