### PR TITLE
AI junk

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -131,7 +131,7 @@ class _FixupStream:
             self._stream.write(b"")
         except Exception:
             try:
-                self._stream.write(b"")
+                self._stream.write("")  # type: ignore[call-overload]
             except Exception:
                 return False
         return True

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -16,6 +16,45 @@ def test_is_jupyter_kernel_output():
     assert click._compat._is_jupyter_kernel_output(stream=JupyterKernelFakeStream())
 
 
+class _TextOnlyNoWritable:
+    """A writable text stream with no native ``writable()`` method."""
+
+    def write(self, s: str) -> int:
+        if isinstance(s, (bytes, bytearray)):
+            raise TypeError("expected str")
+        return len(s)
+
+
+class _BinaryOnlyNoWritable:
+    """A writable binary stream with no native ``writable()`` method."""
+
+    def write(self, b: bytes) -> int:
+        if not isinstance(b, (bytes, bytearray)):
+            raise TypeError("expected bytes")
+        return len(b)
+
+
+class _NotWritableNoWritable:
+    def write(self, x: object) -> int:
+        raise OSError("stream is closed")
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (_TextOnlyNoWritable(), True),
+        (_BinaryOnlyNoWritable(), True),
+        (_NotWritableNoWritable(), False),
+    ],
+)
+def test_fixupstream_writable_probe(stream: object, expected: bool) -> None:
+    # When the wrapped stream has no native ``writable()``, ``_FixupStream``
+    # probes with a binary then a text write. The text fallback must actually
+    # write ``str`` (not ``bytes`` again), otherwise a text-only stream is
+    # wrongly reported as not writable.
+    assert click._compat._FixupStream(stream).writable() is expected
+
+
 @pytest.mark.parametrize(
     "stream",
     [None, sys.stdin, sys.stderr, sys.stdout],


### PR DESCRIPTION
The 'try a binary write, then fall back to a text write' probe in `_FixupStream.writable()` had both branches writing `b""`, so the text fallback was dead: a writable text stream that lacks a native `writable()` method (the 'badly patched objects on sys' case the class exists for) was reported as not writable.

The primary probe was changed from `write("")` to `write(b"")` in a 2024 type-cleanup (fde47b4b) without updating the fallback. Restore the fallback to a text write, matching the sibling `_is_binary_writer` helper which probes `write(b"")` then `write("")`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
