### PR TITLE
AI spam

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -352,6 +352,10 @@ class ProgressBar(t.Generic[V]):
         self.current_item = None
         self.finished = True
 
+        if self._completed_intervals > 0:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar
         during construction, and updates the progress bar *after* the

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -304,6 +304,23 @@ def test_progressbar_update(runner, monkeypatch):
     assert "100%          " in lines[4]
 
 
+def test_progressbar_update_min_steps_show_pos(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(range(20), show_pos=True, update_min_steps=7) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    lines = [line for line in output.split("\r") if "[" in line]
+    assert "0/20" in lines[0]
+    assert "7/20" in lines[1]
+    assert "14/20" in lines[2]
+    assert "20/20" in lines[3]
+
+
 def test_progressbar_item_show_func(runner, monkeypatch):
     """item_show_func should show the current item being yielded."""
 


### PR DESCRIPTION
When `update_min_steps` is configured with a value that is not a divisor of the progress bar's total `length`, any remaining updates at the end that are fewer than `update_min_steps` are not flushed to `self.pos`. When `show_pos=True`, this leaves the final display at less than the total count (e.g. `14/20` instead of `20/20`), even though `self.finished` becomes True and percentage shows `100%`.

This PR updates the `finish` method of `ProgressBar` to flush any remaining uncompleted intervals to `self.pos` by calling `make_step()`.

A regression test has been added to `tests/test_termui.py`.