### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
   a `Positional arguments` section when argument help is available. {issue}`2983` {pr}`3473`
+- Shell completion for long options with values written as `--option=value`
+  keeps the `--option=` prefix when completing the value. {issue}`2847`
 - `confirm()` and `prompt()` strip ANSI color and style codes from the
   prompt when the output stream does not support them, matching `echo()`.
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -300,8 +300,26 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            prefixed_completions = []
+
+            for item in completions:
+                if item.type == "plain":
+                    item = CompletionItem(
+                        f"{completion_prefix}{item.value}",
+                        item.type,
+                        item.help,
+                        **item._info,
+                    )
+
+                prefixed_completions.append(item)
+
+            completions = prefixed_completions
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the
@@ -659,15 +677,19 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str]:
     """Find the Click object that will handle the completion of the
-    incomplete value. Return the object and the incomplete value.
+    incomplete value.
 
     :param ctx: Invocation context for the command represented by
         the parsed complete args.
     :param args: List of complete args before the incomplete value.
     :param incomplete: Value being completed. May be empty.
+    :return: The completion object, incomplete value, and any prefix
+        that should be added back to plain completions.
     """
+    completion_prefix = ""
+
     # Different shells treat an "=" between a long option name and
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
@@ -677,13 +699,14 @@ def _resolve_incomplete(
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, completion_prefix
 
     params = ctx.command.get_params(ctx)
 
@@ -691,14 +714,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, completion_prefix

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,49 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        (
+            "bash",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\n",
+        ),
+        (
+            "fish",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "--color=a"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_option_value_with_equals(
+    runner, shell: str, env: Mapping[str, str], expect: str
+) -> None:
+    cli = Command(
+        "cli",
+        params=[
+            Option(
+                ["--color"],
+                type=Choice(["auto", "always", "never"]),
+            )
+        ],
+    )
+    result = runner.invoke(
+        cli,
+        env={
+            **env,
+            "_CLI_COMPLETE": f"{shell}_complete",
+        },
+    )
+    assert result.output == expect
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
## Summary

- preserve the `--option=` prefix when completing values for long options written with `=`
- add bash, zsh, and fish regression coverage for `--color=a` style completion
- add a changelog entry for the shell-completion fix

## Why

For #2847, Click already resolves `--color=a` as option `--color` with incomplete value `a`, but the shell completion output only returned `auto` / `always`. Shells replace the current word with that value, which drops the original `--color=` prefix.

This keeps the existing generated shell scripts compatible and adds the prefix back to plain completions after resolving the option value.

Fixes #2847

## Validation

- `uv run pytest tests/test_shell_completion.py -q -k option_value_with_equals` — failed before the fix, passed after
- `uv run pytest tests/test_shell_completion.py -q` — passed
- `uv run pytest -q` — passed
- `uv run ruff check src/click/shell_completion.py tests/test_shell_completion.py` — passed
- `uv run mypy src tests/typing` — passed

## Notes

I did not manually test interactive shell tab completion.