### PR TITLE
Update documentation following Colorama removal

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -52,13 +52,9 @@ click.echo('Hello World!', err=True)
 ```{versionadded} 2.0
 ```
 
-The {func}`echo` function supports ANSI colors and styles.
-
-Primarily this means that:
-
-- Click's {func}`echo` function will automatically strip ANSI color codes if the stream is not connected to a terminal.
-- the {func}`echo` function will transparently connect to the terminal on Windows and translate ANSI codes to terminal
-  API calls. This means that colors will work on Windows the same way they do on other operating systems.
+The {func}`echo` function supports ANSI colors and styles. It will
+automatically strip ANSI color codes if the stream is not connected to a
+terminal.
 
 :::{admonition} Older Windows Support
 :class: note

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -82,8 +82,8 @@ def hidden_prompt_func(prompt: str) -> str:
 
 
 def _readline_prompt(func: t.Callable[[str], str], text: str, err: bool) -> str:
-    """Call a prompt function, passing the full prompt on non-Windows so
-    readline can handle line editing and cursor positioning correctly.
+    """Call a prompt function, passing the full prompt so readline can
+    handle line editing and cursor positioning correctly.
 
     The prompt is handed to *func* (such as :func:`input`) rather than
     written through :func:`echo`, so it has to strip ANSI color and style

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -259,7 +259,6 @@ def echo(
     -   Supports Unicode in the Windows console.
     -   Supports writing to binary outputs, and supports writing bytes
         to text outputs.
-    -   Supports colors and styles on Windows.
     -   Removes ANSI color and style codes if the output does not look
         like an interactive terminal.
     -   Always flushes the output.


### PR DESCRIPTION
After Colorama removal in #3505 and @davidism's hint about `echo()` at https://github.com/pallets/click/pull/3581#issuecomment-4904825324, here is a cleanup of some documentation and docstrings about Windows special treatment.