### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ Unreleased
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
+- `progressbar` with `show_pos=True` reports the full final position (e.g.
+  `20/20`) when `update_min_steps` does not divide `length`, instead of a
+  stale intermediate value. {issue}`3571` {pr}`3675`
 - Add {func}`custom_version_option`, a `--version` option whose output is
   produced by a callback, covering cases {func}`version_option` intentionally
   does not. The feature set of {func}`version_option` is now frozen; see

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,13 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush any steps that accumulated below the ``update_min_steps``
+        # threshold so the final position reflects all completed work. Without
+        # this, ``show_pos`` can report a stale value (e.g. ``14/20``) when
+        # ``update_min_steps`` is not a divisor of ``length``.
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,29 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_finish_flushes_position(runner):
+    """finish() flushes sub-threshold steps so the final position is complete.
+
+    Regression test for a bug where ``update_min_steps`` not dividing
+    ``length`` left ``pos`` at an intermediate value, so ``show_pos`` reported
+    e.g. ``14/20`` at the end while the percentage correctly showed ``100%``.
+    """
+    length = 20
+    bar = _create_progress(length=length, update_min_steps=7, show_pos=True)
+    bar.entered = True
+    for _ in bar.iter:
+        bar.update(1)
+    # Before finish(), the last partial interval has not been flushed.
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+
+    bar.finish()
+
+    assert bar.pos == length
+    assert bar._completed_intervals == 0
+    assert bar.format_pos() == "20/20"
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Closes #3571

## Problem

A `click.progressbar` with `show_pos=True` and an `update_min_steps` that does not divide `length` never shows full completion:

```python
import time
import click

with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
    for i in bar:
        time.sleep(0.1)
```

ends at `14/20` instead of `20/20`. Without `show_pos` the percentage correctly shows `100%`, so the two displays disagree.

## Cause

`update()` only advances `pos` (via `make_step`) once accumulated steps reach `update_min_steps`, buffering the remainder in `_completed_intervals`. For `length=20, update_min_steps=7` the last 6 steps stay buffered and never reach `pos`. `pct` returns `1.0` once `finished` is set (so the percentage shows `100%`), but `format_pos` prints the raw `pos`, which is stuck at `14`.

## Fix

Flush the remaining `_completed_intervals` in `finish()` so the final position reflects all completed work. `finish()` is only called from `generator()` after the loop fully completes (`__exit__` calls `render_finish()`, not `finish()`), so manually-managed bars that exit early are unaffected.

## Tests

Added `test_progressbar_update_min_steps_finish_flushes_position` asserting the buffered state before `finish()` and `20/20` after. Full `tests/test_termui.py` suite passes (222 passed, 23 skipped). Added a CHANGES.md entry.