### PR TITLE
Restore `test_echo_color_flag` from #3505

### DIFF
--- a/tests/test_utils/test_echo.py
+++ b/tests/test_utils/test_echo.py
@@ -74,22 +74,18 @@ def test_echo_color_flag(monkeypatch, capfd):
     out, err = capfd.readouterr()
     assert out == f"{styled_text}\n"
 
-    isatty = True
     click.echo(styled_text)
     out, err = capfd.readouterr()
     assert out == f"{styled_text}\n"
 
     isatty = False
-    # Faking isatty() is not enough on Windows;
-    # the implementation caches the colorama wrapped stream
-    # so we have to use a new stream for each test
-    stream = StringIO()
-    click.echo(styled_text, file=stream)
-    assert stream.getvalue() == f"{text}\n"
+    click.echo(styled_text)
+    out, err = capfd.readouterr()
+    assert out == f"{text}\n"
 
-    stream = StringIO()
-    click.echo(styled_text, file=stream, color=True)
-    assert stream.getvalue() == f"{styled_text}\n"
+    click.echo(styled_text, color=True)
+    out, err = capfd.readouterr()
+    assert out == f"{styled_text}\n"
 
 
 @pytest.mark.skipif(WIN, reason="Test too complex to make work windows.")


### PR DESCRIPTION
In #3674 to push split of `test_utils.py`, a test change in #3505 while dropping Colorama has been lost.

This restore it.

See recent @Rowlando13 `main` <-> `stable` dance in:
- https://github.com/pallets/click/pull/3672
- https://github.com/pallets/click/pull/3673
- https://github.com/pallets/click/pull/3674