### PR TITLE
Validate `style()` color arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Unreleased
   produced by a callback, covering cases {func}`version_option` intentionally
   does not. The feature set of {func}`version_option` is now frozen; see
   [discussion #3527](https://github.com/pallets/click/discussions/3527). {pr}`3581`
+- `style()` and `secho()` no longer silently drop the 256-color index `0`
+  (black) passed as `fg` or `bg`, and now validate color arguments. {pr}`3677`
 
 ## Version 8.4.2
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -570,14 +570,28 @@ def clear() -> None:
 
 
 def _interpret_color(color: int | tuple[int, int, int] | str, offset: int = 0) -> str:
-    if isinstance(color, int):
-        return f"{38 + offset};5;{color:d}"
+    """Interprets a color value and returns the corresponding ANSI code."""
+    if isinstance(color, str) and color in _ansi_colors:
+        return str(_ansi_colors[color] + offset)
 
-    if isinstance(color, (tuple, list)):
+    # bool is an int subclass: without the exclusion, True and False would
+    # silently render as the palette indices 1 and 0.
+    elif isinstance(color, int) and not isinstance(color, bool):
+        if 0 <= color <= 255:
+            return f"{38 + offset};5;{color:d}"
+
+    elif (
+        isinstance(color, (tuple, list))
+        and len(color) == 3
+        and all(
+            isinstance(c, int) and not isinstance(c, bool) and 0 <= c <= 255
+            for c in color
+        )
+    ):
         r, g, b = color
         return f"{38 + offset};2;{r:d};{g:d};{b:d}"
 
-    return str(_ansi_colors[color] + offset)
+    raise ValueError(_("Unknown color {colour!r}").format(colour=color))
 
 
 def style(
@@ -655,6 +669,10 @@ def style(
                   string which means that styles do not carry over.  This
                   can be disabled to compose styles.
 
+    .. versionchanged:: 8.5
+        All invalid color values raise :exc:`ValueError`. 256-color index
+        ``0`` is not ignored
+
     .. versionchanged:: 8.0
         A non-string ``message`` is converted to a string.
 
@@ -675,17 +693,11 @@ def style(
 
     bits = []
 
-    if fg:
-        try:
-            bits.append(f"\033[{_interpret_color(fg)}m")
-        except KeyError:
-            raise TypeError(_("Unknown color {colour!r}").format(colour=fg)) from None
+    if fg is not None:
+        bits.append(f"\033[{_interpret_color(fg)}m")
 
-    if bg:
-        try:
-            bits.append(f"\033[{_interpret_color(bg, 10)}m")
-        except KeyError:
-            raise TypeError(_("Unknown color {colour!r}").format(colour=bg)) from None
+    if bg is not None:
+        bits.append(f"\033[{_interpret_color(bg, 10)}m")
 
     if bold is not None:
         bits.append(f"\033[{1 if bold else 22}m")

--- a/tests/test_utils/test_style.py
+++ b/tests/test_utils/test_style.py
@@ -6,6 +6,7 @@ import click
 @pytest.mark.parametrize(
     ("styles", "ref"),
     [
+        ({}, "x y\x1b[0m"),
         ({"fg": "black"}, "\x1b[30mx y\x1b[0m"),
         ({"fg": "red"}, "\x1b[31mx y\x1b[0m"),
         ({"fg": "green"}, "\x1b[32mx y\x1b[0m"),
@@ -14,6 +15,15 @@ import click
         ({"fg": "magenta"}, "\x1b[35mx y\x1b[0m"),
         ({"fg": "cyan"}, "\x1b[36mx y\x1b[0m"),
         ({"fg": "white"}, "\x1b[37mx y\x1b[0m"),
+        ({"fg": "bright_black"}, "\x1b[90mx y\x1b[0m"),
+        ({"fg": "bright_red"}, "\x1b[91mx y\x1b[0m"),
+        ({"fg": "bright_green"}, "\x1b[92mx y\x1b[0m"),
+        ({"fg": "bright_yellow"}, "\x1b[93mx y\x1b[0m"),
+        ({"fg": "bright_blue"}, "\x1b[94mx y\x1b[0m"),
+        ({"fg": "bright_magenta"}, "\x1b[95mx y\x1b[0m"),
+        ({"fg": "bright_cyan"}, "\x1b[96mx y\x1b[0m"),
+        ({"fg": "bright_white"}, "\x1b[97mx y\x1b[0m"),
+        ({"fg": "reset"}, "\x1b[39mx y\x1b[0m"),
         ({"bg": "black"}, "\x1b[40mx y\x1b[0m"),
         ({"bg": "red"}, "\x1b[41mx y\x1b[0m"),
         ({"bg": "green"}, "\x1b[42mx y\x1b[0m"),
@@ -22,8 +32,28 @@ import click
         ({"bg": "magenta"}, "\x1b[45mx y\x1b[0m"),
         ({"bg": "cyan"}, "\x1b[46mx y\x1b[0m"),
         ({"bg": "white"}, "\x1b[47mx y\x1b[0m"),
+        ({"bg": "bright_black"}, "\x1b[100mx y\x1b[0m"),
+        ({"bg": "bright_red"}, "\x1b[101mx y\x1b[0m"),
+        ({"bg": "bright_green"}, "\x1b[102mx y\x1b[0m"),
+        ({"bg": "bright_yellow"}, "\x1b[103mx y\x1b[0m"),
+        ({"bg": "bright_blue"}, "\x1b[104mx y\x1b[0m"),
+        ({"bg": "bright_magenta"}, "\x1b[105mx y\x1b[0m"),
+        ({"bg": "bright_cyan"}, "\x1b[106mx y\x1b[0m"),
+        ({"bg": "bright_white"}, "\x1b[107mx y\x1b[0m"),
+        ({"bg": "reset"}, "\x1b[49mx y\x1b[0m"),
+        ({"fg": 91}, "\x1b[38;5;91mx y\x1b[0m"),
         ({"bg": 91}, "\x1b[48;5;91mx y\x1b[0m"),
+        ({"fg": 255}, "\x1b[38;5;255mx y\x1b[0m"),
+        ({"bg": 255}, "\x1b[48;5;255mx y\x1b[0m"),
+        ({"fg": (135, 0, 175)}, "\x1b[38;2;135;0;175mx y\x1b[0m"),
         ({"bg": (135, 0, 175)}, "\x1b[48;2;135;0;175mx y\x1b[0m"),
+        ({"bg": [135, 0, 175]}, "\x1b[48;2;135;0;175mx y\x1b[0m"),
+        ({"fg": (0, 0, 0)}, "\x1b[38;2;0;0;0mx y\x1b[0m"),
+        ({"fg": (255, 255, 255)}, "\x1b[38;2;255;255;255mx y\x1b[0m"),
+        # 256-color index 0 (black) is valid and must not be dropped by a
+        # truthiness check on fg/bg.
+        ({"fg": 0}, "\x1b[38;5;0mx y\x1b[0m"),
+        ({"bg": 0}, "\x1b[48;5;0mx y\x1b[0m"),
         ({"bold": True}, "\x1b[1mx y\x1b[0m"),
         ({"dim": True}, "\x1b[2mx y\x1b[0m"),
         ({"underline": True}, "\x1b[4mx y\x1b[0m"),
@@ -46,6 +76,35 @@ import click
 def test_styling(styles, ref):
     assert click.style("x y", **styles) == ref
     assert click.unstyle(ref) == "x y"
+
+
+@pytest.mark.parametrize("param", ["fg", "bg"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "banana",
+        "BLACK",
+        b"red",
+        True,
+        False,
+        -1,
+        256,
+        0.0,
+        (),
+        [],
+        (0, 0),
+        (0, 0, 0, 0),
+        ("0", "0", "0"),
+        (True, False, True),
+        (-1, 0, 0),
+        (0, 256, 0),
+        (0.0, 0.0, 0.0),
+    ],
+)
+def test_styling_invalid_color(param, value):
+    with pytest.raises(ValueError, match="Unknown color"):
+        click.style("x y", **{param: value})
 
 
 @pytest.mark.parametrize(("text", "expect"), [("\x1b[?25lx y\x1b[?25h", "x y")])


### PR DESCRIPTION
Also fix an explicit black color argument (`0`) being ignored.