### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,20 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_finish_flushes_pending_steps(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(range(20), show_pos=True, update_min_steps=7) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    lines = [line for line in output.split("\n") if "[" in line]
+
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
## Summary

Flush pending `update_min_steps` progress before `ProgressBar.finish()` renders the final line.

## Root Cause

`update_min_steps` batches increments in `_completed_intervals`, but `finish()` previously marked the bar finished without applying any remaining pending steps to `pos`. When `show_pos=True`, the final rendered output could therefore show a stale position like `14/20` instead of `20/20`.

## Changes

- flush pending buffered steps in `ProgressBar.finish()`
- add a regression test covering `show_pos=True` with `update_min_steps=7`

## Validation

- `env PYTHONPATH=src .venv/bin/python -m pytest tests/test_termui.py`

Closes #3571
