### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Unreleased
   [discussion #3527](https://github.com/pallets/click/discussions/3527). {pr}`3581`
 - `style()` and `secho()` no longer silently drop the 256-color index `0`
   (black) passed as `fg` or `bg`, and now validate color arguments. {pr}`3677`
+- Shell completion for long options with values joined by `=`, such as
+  `--color=a`, keeps the option name in generated completions. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -300,8 +300,23 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        original_incomplete = incomplete
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if isinstance(obj, Option) and "=" in original_incomplete and _start_of_option(
+            ctx, original_incomplete
+        ):
+            prefix, _, value = original_incomplete.partition("=")
+            completions = [
+                CompletionItem(
+                    f"{prefix}={item.value}", item.type, item.help, **item._info
+                )
+                for item in completions
+                if item.type == "plain" or item.value == value
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -304,8 +304,10 @@ class ShellComplete:
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
         completions = obj.shell_complete(ctx, incomplete)
 
-        if isinstance(obj, Option) and "=" in original_incomplete and _start_of_option(
-            ctx, original_incomplete
+        if (
+            isinstance(obj, Option)
+            and "=" in original_incomplete
+            and _start_of_option(ctx, original_incomplete)
         ):
             prefix, _, value = original_incomplete.partition("=")
             completions = [

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -149,6 +149,21 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+def test_type_choice_with_long_option_equals():
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+
+    assert _get_words(cli, [], "--color=") == [
+        "--color=auto",
+        "--color=always",
+        "--color=never",
+    ]
+    assert _get_words(cli, [], "--color=a") == ["--color=auto", "--color=always"]
+    assert _get_words(cli, [], "--color=al") == ["--color=always"]
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
Preserve the long option prefix when completing values entered with `=`.

Given an incomplete value like `--color=a`, Click already resolves `--color` as the option whose value is being completed, but the generated completion values were only `auto` and `always`. Shells can then replace the whole current word with the bare value, dropping the option name.

This keeps generated completions as `--color=auto`, `--color=always`, etc. for long option values entered as `--option=value`.

fixes #2847

Tests:
- `uv run pytest tests/test_shell_completion.py::test_type_choice_with_long_option_equals tests/test_shell_completion.py -q`
- `uv run pytest -q`
- `uv run ruff check CHANGES.md src/click/shell_completion.py tests/test_shell_completion.py`
- `uv run mypy src/click/shell_completion.py`

