### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   {issue}`2819` {pr}`3678`
 - `unstyle` and the ANSI handling behind help-text wrapping now strip the full
   CSI escape-sequence grammar.
+- `progressbar` advances to its final position when the last steps are
+  smaller than `update_min_steps`, so a bar with `show_pos=True` no longer
+  finishes showing a stale count. {issue}`3571`
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -336,13 +336,26 @@ class ProgressBar(t.Generic[V]):
         .. versionchanged:: 8.0
             Only render when the number of steps meets the
             ``update_min_steps`` threshold.
+
+        .. versionchanged:: 8.5
+            The bar advances to its final position when the remaining
+            steps are smaller than ``update_min_steps``, instead of
+            finishing on a stale position.
         """
         if current_item is not None:
             self.current_item = current_item
 
         self._completed_intervals += n_steps
 
-        if self._completed_intervals >= self.update_min_steps:
+        # Also flush when the bar reaches its end, otherwise a trailing
+        # interval smaller than ``update_min_steps`` is never applied and
+        # the bar finishes showing a stale position (e.g. "18/20" at 100%).
+        reached_end = (
+            self.length is not None
+            and self.pos + self._completed_intervals >= self.length
+        )
+
+        if self._completed_intervals >= self.update_min_steps or reached_end:
             self.make_step(self._completed_intervals)
             self.render_progress()
             self._completed_intervals = 0

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -142,6 +142,18 @@ def test_progressbar_format_pos(runner, pos, length):
         assert result == f"{pos}/{length}"
 
 
+def test_progressbar_update_min_steps_reaches_end(runner):
+    # A trailing interval smaller than update_min_steps must still advance
+    # the bar to its end, otherwise it finishes on a stale position.
+    with click.progressbar(length=20, update_min_steps=6) as progress:
+        for _ in range(20):
+            progress.update(1)
+
+    assert progress.pos == 20
+    assert progress.finished
+    assert progress.format_pos() == "20/20"
+
+
 @pytest.mark.parametrize(
     "length, finished, pos, avg, expected",
     [


### PR DESCRIPTION
This fixes #3571.

`ProgressBar.update()` only flushes accumulated steps once `_completed_intervals` reaches `update_min_steps`. A trailing interval smaller than that threshold was never applied, so a bar using `show_pos=True` could finish showing a stale position — e.g. `18/20` while the percentage already reads `100%`.

`update()` now also flushes when the position reaches the length, so the final step is always rendered. This covers both the generator and the manual `bar.update()` paths.

- Added a regression test in `tests/test_termui.py` that fails without the change (feeds 20 single steps with `update_min_steps=6` and asserts the bar ends at `20/20`).
- Added a `CHANGES.md` entry and a `versionchanged` note on `update()`.

Verified locally: `pytest tests/test_termui.py` (222 passed), ruff and mypy clean.