### PR TITLE
AI junk

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -326,18 +326,19 @@ Example usage:
 ```python
 import os
 import click
-import ConfigParser
+import configparser
 
 APP_NAME = 'My Application'
+
 def read_config():
-cfg = os.path.join(click.get_app_dir(APP_NAME), 'config.ini')
-parser = ConfigParser.RawConfigParser()
-parser.read([cfg])
-rv = {}
-for section in parser.sections():
-    for key, value in parser.items(section):
-        rv[f"{section}.{key}"] = value
-return rv
+    cfg = os.path.join(click.get_app_dir(APP_NAME), 'config.ini')
+    parser = configparser.RawConfigParser()
+    parser.read([cfg])
+    rv = {}
+    for section in parser.sections():
+        for key, value in parser.items(section):
+            rv[f"{section}.{key}"] = value
+    return rv
 ```
 
 ## Showing Progress Bars


### PR DESCRIPTION
The `get_app_dir` example in `docs/utils.md` isn't valid Python: the body of `read_config()` lost its indentation (it looks like this happened during the docs migration to Markdown), so the snippet raises `IndentationError` as written.

While fixing that, I also updated the Python 2 `import ConfigParser` to `import configparser` — the example already uses f-strings, so it can only run on Python 3, where the module was renamed.

Found by [devdoctor](https://github.com/funtechnologywith-source/devdoctor), a documentation drift checker I'm building that compiles fenced code blocks in docs to catch exactly this kind of thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)