### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+- `edit()` accepts path-like objects for its `filename` parameter.
+  {issue}`2869`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -683,7 +683,9 @@ class Editor:
                 return editor
         return "vi"
 
-    def edit_files(self, filenames: cabc.Iterable[str]) -> None:
+    def edit_files(
+        self, filenames: cabc.Iterable[str | os.PathLike[str]]
+    ) -> None:
         """Open files in the user's editor."""
         import shlex
         import subprocess
@@ -700,7 +702,8 @@ class Editor:
             # in pager(): strips quotes from tokens and preserves quoted
             # Windows paths.
             c = subprocess.Popen(
-                args=shlex.split(editor) + list(filenames),
+                args=shlex.split(editor)
+                + [os.fspath(filename) for filename in filenames],
                 env=environ,
             )
             exit_code = c.wait()

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -4,6 +4,7 @@ import collections.abc as cabc
 import inspect
 import io
 import itertools
+import os
 import re
 import sys
 import typing as t
@@ -794,7 +795,9 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: (
+        str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None
+    ) = None,
 ) -> None: ...
 
 
@@ -804,7 +807,9 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: (
+        str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None
+    ) = None,
 ) -> str | bytes | bytearray | None:
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating
@@ -837,6 +842,9 @@ def edit(
                      if multiple files cannot be managed at once or editing the
                      files serially is desired.
 
+    .. versionchanged:: 8.5.0
+        ``filename`` accepts :class:`os.PathLike` objects.
+
     .. versionchanged:: 8.2.0
         ``filename`` now accepts any ``Iterable[str]`` in addition to a ``str``
         if the ``editor`` supports editing multiple files at once.
@@ -849,7 +857,7 @@ def edit(
     if filename is None:
         return ed.edit(text)
 
-    if isinstance(filename, str):
+    if isinstance(filename, (str, os.PathLike)):
         filename = (filename,)
 
     ed.edit_files(filenames=filename)

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -412,6 +413,20 @@ def test_edit(runner):
             # end of last line.  Hence the input data (see above) should be
             # terminated by newline too.
             assert reopened_file.read() == "aTest\nbTest\n"
+
+
+def test_edit_pathlike(monkeypatch):
+    captured_filenames = None
+
+    def edit_files(self, filenames):
+        nonlocal captured_filenames
+        captured_filenames = tuple(filenames)
+
+    monkeypatch.setattr(Editor, "edit_files", edit_files)
+
+    filename = Path("example.txt")
+    assert click.edit(filename=filename) is None
+    assert captured_filenames == (filename,)
 
 
 @pytest.mark.parametrize(

--- a/tests/typing/typing_termui.py
+++ b/tests/typing/typing_termui.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import click
+
+path = Path("example.txt")
+click.edit(filename=path)
+click.edit(filename=[path, "other.txt"])


### PR DESCRIPTION
## What changed

- accept a single `os.PathLike[str]` or an iterable containing path-like filenames in `click.edit`
- normalize path-like values with `os.fspath` before invoking the editor
- cover both runtime behavior and static typing

## Why

`click.edit(filename=Path(...))` was rejected by type checkers and treated the path as an iterable at runtime. This makes the public API consistent with other Click file APIs that already accept path-like objects.

Fixes #2869

## Validation

- `uv run --frozen pytest -q` — 1832 passed, 95 skipped, 1 xfailed
- `uv run --frozen ruff check src tests`
- `uv run --frozen mypy tests/typing/typing_termui.py`
- `git diff --check`
