### PR TITLE
Fix `sdist` include to ship `CHANGES.md` after changelog rename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ name = "click"
 include = [
     "docs/",
     "tests/",
-    "CHANGES.rst",
+    "CHANGES.md",
     "uv.lock"
 ]
 exclude = [


### PR DESCRIPTION
#3559 renamed `CHANGES.rst` to `CHANGES.md`, but the `[tool.flit.sdist]` include list in `pyproject.toml` still references the old name. Flit silently skips include patterns that match nothing, so sdists no longer contain the changelog, and building the docs from an sdist fails because `docs/changes.md` includes `../CHANGES.md`.

Verified after the change: `uv build --sdist` produces a tarball containing `CHANGES.md`, and `sphinx-build -E -W` from the extracted sdist passes again.