### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,23 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_finish_updates_pending_min_steps(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    final_line = output.rsplit("\r", 1)[-1]
+    assert "20/20" in final_line
+    assert "14/20" not in final_line
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

When `update_min_steps` does not divide the progressbar length, the last pending steps were not applied before rendering the completed bar. That could show a full bar with an outdated position, for example `14/20` instead of `20/20`.

This flushes pending intervals in `finish()` and adds a regression test for `show_pos=True`.