### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ Unreleased
   {issue}`2819` {pr}`3678`
 - `unstyle` and the ANSI handling behind help-text wrapping now strip the full
   CSI escape-sequence grammar.
+- `progressbar` with `show_pos=True` reports the full `length/length` position
+  on completion even when `update_min_steps` does not evenly divide the total
+  number of steps, matching the full bar and percentage. {issue}`3571`
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -351,6 +351,13 @@ class ProgressBar(t.Generic[V]):
         self.eta_known = False
         self.current_item = None
         self.finished = True
+        # A finished determinate bar is by definition at 100%. ``pct`` already
+        # reports 1.0 once finished (so the bar and percentage render full), but
+        # ``pos`` can lag behind when ``update_min_steps`` does not evenly divide
+        # the total number of steps, leaving the final interval unflushed. Sync
+        # ``pos`` so ``show_pos`` output agrees with the bar and percentage.
+        if self.length is not None:
+            self.pos = self.length
 
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -304,6 +304,36 @@ def test_progressbar_update(runner, monkeypatch):
     assert "100%          " in lines[4]
 
 
+def test_progressbar_update_min_steps_shows_full_completion(runner, monkeypatch):
+    """When ``update_min_steps`` does not evenly divide the total number of
+    steps, the final partial interval is not flushed during iteration. On
+    completion the bar must still report ``length/length`` with ``show_pos``,
+    consistent with the full bar and 100% that a finished bar already shows.
+
+    https://github.com/pallets/click/issues/3571
+    """
+    fake_clock = FakeClock()
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                fake_clock.advance_time()
+                print("")
+
+    monkeypatch.setattr(time, "time", fake_clock.time)
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+
+    lines = [line for line in output.split("\n") if "[" in line]
+
+    # The final rendered line reflects the finished bar: full position, not
+    # the stale "14/20" left over from the last flushed interval.
+    assert "20/20" in lines[-1]
+
+
 def test_progressbar_item_show_func(runner, monkeypatch):
     """item_show_func should show the current item being yielded."""
 


### PR DESCRIPTION
Fixes #3571.

When a `click.progressbar` is created with `show_pos=True` and an `update_min_steps` that does not evenly divide the total number of steps, the bar never displays full completion — e.g. `range(20)` with `update_min_steps=7` ends at `14/20` instead of `20/20`.

### Cause

`update()` batches steps and only calls `make_step()` (which advances `pos`) once `update_min_steps` is reached. The final partial interval — 6 steps in the example — is never flushed, so `pos` stops at 14. Meanwhile the bar fill and percentage are derived from the `pct` property, which returns `1.0` as soon as the bar is `finished`. The result is an internally inconsistent finished bar: full bar + 100%, but a stale `14/20` position.

### Fix

Sync `pos` to `length` in `finish()` when the length is known. A finished determinate bar is at 100% by definition (as `pct` already reflects), so the position-based display should agree. Indeterminate bars (`length is None`) are unaffected.

### Tests

Adds `test_progressbar_update_min_steps_shows_full_completion`, which reproduces the issue (asserts the final rendered line shows `20/20`). It fails on `main` and passes with this change. The full test suite passes and `ruff` check/format are clean.
