### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -349,6 +349,7 @@ class ProgressBar(t.Generic[V]):
 
     def finish(self) -> None:
         self.eta_known = False
+	self.make_step(self._completed_intervals)
         self.current_item = None
         self.finished = True
 


### PR DESCRIPTION
Fixes #3571

ProgressBar.finish() now flushes remaining _completed_intervals via make_step() before setting finished=True, so the final render shows the correct position (20/20 instead of 14/20).