### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+- `progressbar` applies any steps held by `update_min_steps` when finishing,
+  so `show_pos` reaches the full `length/length` display. {issue}`3571`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,11 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush steps held by update_min_steps so show_pos reaches length.
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,45 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_finish_applies_pending_update_min_steps(runner):
+    """Pending steps under update_min_steps must apply on finish.
+
+    Otherwise show_pos can end below length while the bar is finished.
+    """
+    bar = _create_progress(length=20, update_min_steps=7, show_pos=True)
+    bar.update(7)
+    bar.update(7)
+    bar.update(6)
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+    bar.finish()
+    assert bar._completed_intervals == 0
+    assert bar.pos == 20
+    assert bar.finished
+    assert bar.format_pos() == "20/20"
+
+
+def test_progressbar_show_pos_with_update_min_steps(runner, monkeypatch):
+    """Regression: final render must show length/length with show_pos."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+            show_eta=False,
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    lines = [line for line in output.split("\n") if "[" in line]
+    assert lines
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
When `update_min_steps` holds back the final partial interval, `finish()` marked the bar complete without applying those steps. Percentage display still looked finished because `finished` forces 100%, but `show_pos` kept the last flushed position (for example `14/20`).

Apply any pending `_completed_intervals` in `finish()` before the final render so `show_pos` reaches `length/length`.

fixes #3571
