### PR TITLE
AI junk

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -299,9 +299,18 @@ class ShellComplete:
         :param args: List of complete args before the incomplete value.
         :param incomplete: Value being completed. May be empty.
         """
+        original_incomplete = incomplete
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if isinstance(obj, Option) and "=" in original_incomplete:
+            option, _, _ = original_incomplete.partition("=")
+
+            for item in completions:
+                item.value = f"{option}={item.value}"
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -373,6 +373,30 @@ def test_full_complete(runner, shell, env, expect):
     assert result.output == expect
 
 
+@pytest.mark.parametrize(
+    ("shell", "expect"),
+    [
+        ("bash", "plain,--color=always\n"),
+        ("zsh", "plain\n--color=always\n_\n"),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_option_value_complete_with_equals(runner, shell, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli --color=al",
+            "COMP_CWORD": "1",
+            "_CLI_COMPLETE": f"{shell}_complete",
+        },
+    )
+    assert result.output == expect
+
+
 def test_source_uses_lf_line_endings(monkeypatch):
     stdout = io.BytesIO()
     stream = io.TextIOWrapper(stdout, encoding="utf-8", newline="\r\n")


### PR DESCRIPTION
## Summary

- preserve the `--option=` prefix when completing an option value
- cover the Bash and Zsh completion protocols

Fixes #2847.

## Validation

- `PYTHONPATH=src python -m pytest -q` (1834 passed, 94 skipped, 1 xfailed)
- `python -m ruff check src/click/shell_completion.py tests/test_shell_completion.py`
- `python -m ruff format --check src/click/shell_completion.py tests/test_shell_completion.py`
- `PYTHONPATH=src python -m mypy src/click/shell_completion.py`
- `git diff --check`
