### PR TITLE
Pre-8.5.0 release changelog and doc fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Unreleased
 - Add built-in shell completion support for PowerShell (Windows PowerShell
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate
-  the completion script.
+  the completion script. {issue}`2672` {pr}`3637`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes
@@ -15,12 +15,16 @@ Unreleased
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
+- {class}`Path` with `allow_dash=True` no longer triggers a `BytesWarning`,
+  an error under `python -bb`, when checking a value against the `-`
+  convention. {issue}`2877` {pr}`3642`
 - Add {func}`custom_version_option`, a `--version` option whose output is
   produced by a callback, covering cases {func}`version_option` intentionally
   does not. The feature set of {func}`version_option` is now frozen; see
   [discussion #3527](https://github.com/pallets/click/discussions/3527). {pr}`3581`
 - `style()` and `secho()` no longer silently drop the 256-color index `0`
-  (black) passed as `fg` or `bg`, and now validate color arguments. {pr}`3677`
+  (black) passed as `fg` or `bg`, and now validate color arguments. Invalid
+  colors raise a `ValueError` instead of a `TypeError`. {pr}`3677`
 - The automatic help option stores its value under the reserved name
   `_click_default_help` instead of `help`, so a parameter named `help` no
   longer breaks parsing. The new name is visible in
@@ -30,12 +34,15 @@ Unreleased
   share a name to compete for the same value (feature switches).
   {issue}`2819` {pr}`3678`
 - `unstyle` and the ANSI handling behind help-text wrapping now strip the full
-  CSI escape-sequence grammar.
+  CSI escape-sequence grammar. {pr}`3681`
 - Streamline `Option` flag handling: the flag-kind, type, lazy-default and
   validation steps in `Option.__init__` move into focused helpers, and
   `flag_value` and `default` keep their unset sentinel at construction
   (resolved lazily on read) so `is UNSET` reliably tells a user-supplied value
-  from an auto-derived one. Behavior is unchanged. {pr}`3641`
+  from an auto-derived one. Runtime behavior is unchanged, but
+  {meth}`Parameter.to_info_dict` now resolves `default=True` on a feature
+  switch to its `flag_value`, matching what the function receives at call
+  time. {pr}`3641`
 - {func}`get_binary_stream` and {func}`get_text_stream` are deprecated and
   will be removed in Click 9.0. {issue}`3481` {pr}`3695`
 - The following `click.utils` names were never intentionally public and are

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -10,7 +10,7 @@ Arguments are:
 * Are positional in nature.
 * Similar to a limited version of {ref}`options <options>` that
   can take an arbitrary number of inputs
-* Can take an optional `help` string shown in the ``Positional arguments``
+* Can take an optional `help` string shown in the `Positional arguments`
   section of the help page, or be {ref}`documented in the command docstring
   <documenting-arguments>`.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -15,7 +15,7 @@ Simple example:
 .. click:example::
 
     @click.command()
-    @click.argument('name', help='The name to print')
+    @click.argument('name', help='The name to print.')
     @click.option('--count', default=1, help='number of greetings')
     def hello(name: str, count: int):
         """This script prints hello and a name one or more times."""
@@ -114,7 +114,7 @@ The help epilog is printed at the end of the help and is useful for showing exam
 ## Documenting Arguments
 
 {class}`click.argument` accepts an optional `help` parameter that is shown in
-the ``Positional arguments`` section of the help page. You can still document
+the `Positional arguments` section of the help page. You can still document
 arguments in the command docstring, especially when you want to describe them
 in the main help text by name.
 

--- a/docs/option-decorators.md
+++ b/docs/option-decorators.md
@@ -84,3 +84,5 @@ replaced with the :func:`confirmation_option` decorator:
 ## Version Option
 
 {func}`version_option` adds a `--version` option which immediately prints the version number and exits the program.
+
+The message and values it can show are intentionally limited, and its feature set is frozen. If you need values it does not expose, such as the Python version or git metadata, use {func}`custom_version_option` and produce the output yourself in a callback.

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -5,8 +5,8 @@
 ```{currentmodule} click.shell_completion
 ```
 
-Click provides tab completion support for Bash (version 4.4 and up), Zsh, and Fish. It is possible to add support for
-other shells too, and suggestions can be customized at multiple levels.
+Click provides tab completion support for Bash (version 4.4 and up), Zsh, Fish, and PowerShell. It is possible to add
+support for other shells too, and suggestions can be customized at multiple levels.
 
 Shell completion suggests command names, option names, and values for choice, file, and path parameter types. Options
 are only listed if at least a dash has been entered. Hidden commands and options are not shown.

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -56,13 +56,14 @@ The {func}`echo` function supports ANSI colors and styles. It will
 automatically strip ANSI color codes if the stream is not connected to a
 terminal.
 
-:::{admonition} Older Windows Support
+```{admonition} Older Windows Support
 :class: note
 
-Recent Windows 11 supports ANSI styling by default, in both Terminal and cmd.exe.
-If you need to support color output on older versions of Windows, install
+Recent versions of Windows 11 support ANSI styling by default, in both
+Windows Terminal and cmd.exe. If you need to support color output on older
+versions of Windows, install
 [colorama](https://pypi.org/project/colorama/) and call `colorama.init()`.
-:::
+```
 
 For styling a string, the {func}`style` function can be used:
 
@@ -124,7 +125,9 @@ that instead:
                 print(idx, file=pager)
 ```
 
-```{hint} Why print instead of echo?
+```{admonition} Why print() instead of echo()?
+:class: hint
+
 The pager object deals with ANSI color and style codes itself: they are kept or
 stripped depending on what the pager supports, exactly as {func}`echo` would do.
 Any code that writes to a file, including plain {func}`print`, can therefore be

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -513,7 +513,7 @@ def should_strip_ansi(
     return not color
 
 
-# double check is needed so mypy does not analyze this on Linux
+# Double check is needed so mypy does not analyze this on Linux.
 if sys.platform.startswith("win") and WIN:
     from ._winconsole import _get_windows_console_stream
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3662,7 +3662,7 @@ class Argument(Parameter):
 
     :param help: the help string.
 
-    .. versionchanged:: 8.5
+    .. versionchanged:: 8.5.0
         Added the ``help`` parameter.
     """
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -521,7 +521,7 @@ class FishComplete(ShellComplete):
 class PowerShellComplete(ShellComplete):
     """Shell completion for PowerShell (Windows PowerShell 5.1+ and pwsh 7+).
 
-    .. versionadded:: 8.5
+    .. versionadded:: 8.5.0
     """
 
     name: t.ClassVar[str] = "powershell"
@@ -623,7 +623,7 @@ def split_arg_string(string: str) -> list[str]:
     lex = shlex.shlex(string, posix=True)
     lex.whitespace_split = True
     lex.commenters = ""
-    out = []  # type: list[str]
+    out: list[str] = []
 
     try:
         out.extend(lex)

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -712,9 +712,9 @@ def style(
                   string which means that styles do not carry over.  This
                   can be disabled to compose styles.
 
-    .. versionchanged:: 8.5
+    .. versionchanged:: 8.5.0
         All invalid color values raise :exc:`ValueError`. 256-color index
-        ``0`` is not ignored
+        ``0`` is no longer ignored.
 
     .. versionchanged:: 8.0
         A non-string ``message`` is converted to a string.

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -279,7 +279,7 @@ def echo(
         default Click will remove color if the output does not look like
         an interactive terminal.
 
-    .. versionchanged:: 8.5
+    .. versionchanged:: 8.5.0
         Colorama is no longer used for color on Windows.
 
     .. versionchanged:: 6.0


### PR DESCRIPTION
> [!IMPORTANT]
> **Keep this PR in draft mode** until we are closing in on 8.5.0 release.

A small PR to accumulate all missing documentation details for the upcoming 8.5.0 release.

- Missing changelog entries and references from:
  - #3637
  - #3681
  - #3642
- Mention of new `custom_version_option` in the docs from #3581
- Rename of camel-cased test files from #3672
- Admonition styling
- `.. versionadded` styling
- Markdown format
- Example CLI consistency
- A rogue type lint

Before removing the `draft` status, review all changes in the pending release diff: https://github.com/pallets/click/compare/8.4.2...main