### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Unreleased
 
+- The "Command Aliases" documentation example for a custom
+  `resolve_command` now guards against `cmd` being `None`, matching the
+  behavior of `Group.resolve_command` itself. Following the example
+  as originally written could raise `AttributeError: 'NoneType' object
+  has no attribute 'name'` during shell completion of an unmatched
+  command name. {issue}`2402`
 - Add built-in shell completion support for PowerShell (Windows PowerShell
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate

--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -86,6 +86,51 @@ def test_group_command_same_option():
     assert _get_words(cli, ["-a", "a", "x", "-a", "a"], "-") == ["--help"]
 
 
+def test_aliased_group_resolve_command_no_match():
+    """Regression test for issue #2402.
+
+    A ``Group`` subclass that overrides ``resolve_command`` to always
+    return the full command name (as shown in the "Command Aliases"
+    documentation) must not crash when no command matches during shell
+    completion. ``super().resolve_command()`` returns ``cmd=None``
+    (rather than raising) when ``ctx.resilient_parsing`` is set, which
+    is the case while resolving context for completions, so overrides
+    must guard against ``cmd`` being ``None`` before accessing
+    ``cmd.name``.
+    """
+
+    class AliasedGroup(Group):
+        def get_command(self, ctx, cmd_name):
+            rv = super().get_command(ctx, cmd_name)
+
+            if rv is not None:
+                return rv
+
+            matches = [x for x in self.list_commands(ctx) if x.startswith(cmd_name)]
+
+            if not matches:
+                return None
+
+            if len(matches) == 1:
+                return Group.get_command(self, ctx, matches[0])
+
+            ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+
+        def resolve_command(self, ctx, args):
+            # always return the full command name
+            _, cmd, args = super().resolve_command(ctx, args)
+            return cmd.name if cmd else None, cmd, args
+
+    cli = AliasedGroup(
+        "cli", commands=[Group("workspace", commands=[Command("add")])]
+    )
+
+    # A typo'd subcommand name that doesn't match any prefix must not
+    # raise AttributeError: 'NoneType' object has no attribute 'name'.
+    # Completion falls back to the root context's visible commands.
+    assert _get_words(cli, ["workspaceTYPO"], "") == ["workspace"]
+
+
 def test_chained():
     cli = Group(
         "cli",


### PR DESCRIPTION
The 'Command Aliases' documentation example overrides resolve_command to always return the full command name via 'return cmd.name, cmd, args'. Group.resolve_command's own implementation can legitimately return cmd=None (rather than raising) when ctx.resilient_parsing is set, which is the case while resolving context for shell completion. Following the documented example as written therefore crashes with 'AttributeError: NoneType object has no attribute name' whenever shell completion is invoked for a subcommand name that doesn't match any prefix (e.g. a typo).

Guard the example the same way core.py's own resolve_command already does: 'cmd.name if cmd else None'.

Added a regression test that exercises this exact path through click.shell_completion.ShellComplete.get_completions, confirmed it reproduces the original AttributeError without the guard, and confirmed it passes with the guard restored. Full existing test suite unaffected (pre-existing unrelated pager-test failures in this sandbox are due to the 'less' binary not being installed, not this change).

Fixes #2402

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
