### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ Unreleased
   {issue}`2819` {pr}`3678`
 - `unstyle` and the ANSI handling behind help-text wrapping now strip the full
   CSI escape-sequence grammar.
+- `prompt()` accepts a non-empty `default` when `confirmation_prompt` is
+  enabled and the user presses enter at both prompts, matching the existing
+  behavior for an empty-string default. Previously the confirmation prompt
+  repeated forever because the accepted default was never treated as an empty
+  confirmation. {issue}`3702` {pr}`3703`
 - Streamline `Option` flag handling: the flag-kind, type, lazy-default and
   validation steps in `Option.__init__` move into focused helpers, and
   `flag_value` and `default` keep their unset sentinel at construction

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -217,12 +217,14 @@ def prompt(
         confirmation_prompt = _build_prompt(confirmation_prompt, prompt_suffix)
 
     while True:
+        used_default = False
         while True:
             value = prompt_func(prompt)
             if value:
                 break
             elif default is not None:
                 value = default
+                used_default = True
                 break
         try:
             result = value_proc(value)
@@ -234,8 +236,14 @@ def prompt(
             return result
         while True:
             value2 = prompt_func(confirmation_prompt)
-            is_empty = not value and not value2
-            if value2 or is_empty:
+            # An empty confirmation re-confirms a default that was itself
+            # selected by pressing enter at the first prompt. Match it against
+            # ``value`` so the equality check below passes; otherwise a
+            # non-empty default could never be confirmed and the confirmation
+            # prompt would repeat forever.
+            if not value2 and used_default:
+                value2 = value
+            if value2 or used_default:
                 break
         if value == value2:
             return result

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -999,6 +999,9 @@ def test_prompt_required_false(runner, args, expect):
         (True, "password\npassword", None, "password"),
         ("Confirm Password", "password\npassword\n", None, "password"),
         (True, "\n\n", "", ""),
+        # A non-empty default is accepted by pressing enter at both the
+        # value and the confirmation prompt, just like an empty default.
+        (True, "\n\n", "the-default", "the-default"),
         (False, None, None, None),
     ],
 )


### PR DESCRIPTION
Fixes #3702

### What / why

When `prompt()` has `confirmation_prompt=True` **and a non-empty `default`**, pressing Enter to accept the shown default can never be confirmed — the confirmation prompt repeats forever:

```python
@click.command()
@click.option("--password", prompt=True, confirmation_prompt=True, default="sekret")
def cli(password):
    click.echo(f"RESULT={password}")

CliRunner().invoke(cli, input="\n\n", standalone_mode=False)   # Enter, Enter
# before: "Repeat for confirmation: " repeats forever -> Abort()
# after:  RESULT=sekret
```

The empty-input special case from #2158 checked `value` *after* it had already been reassigned to the default (`is_empty = not value and not value2`), so it only fired when the default itself was falsy (`""`). Any non-empty default looped.

### Fix

Track whether the first input used the default (`used_default`) and treat an empty confirmation as re-confirming that default. Empty-string defaults, typed values (which still require re-typing), and mismatches are all unchanged.

### Tests

Added the non-empty-default case to the `test_confirmation_prompt` parametrization — it fails on the previous code and passes with the fix. Full `tests/test_termui.py` and the suite pass (1906 passed); `ruff check`/`format` clean.
