### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,11 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Apply any steps held back by update_min_steps so format_pos and
+        # other pos-based displays match the completed bar / 100% state.
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,23 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_show_pos_flushes_update_min_steps(runner):
+    """Leftover steps under update_min_steps must apply on finish.
+
+    Otherwise show_pos can report e.g. 14/20 while the bar and percent
+    already show completion (finished forces pct to 1.0).
+    """
+    bar = _create_progress(length=20, show_pos=True, update_min_steps=7)
+    for _ in range(20):
+        bar.update(1)
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+    bar.finish()
+    assert bar._completed_intervals == 0
+    assert bar.pos == 20
+    assert bar.format_pos() == "20/20"
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
﻿## Summary
- Flush buffered `_completed_intervals` in `ProgressBar.finish()` so `pos` catches up when `update_min_steps` is not a divisor of `length`.
- Fixes `show_pos` reporting e.g. `14/20` while the bar / percent already show completion (`finished` forces `pct` to 1.0).

## Test plan
- [x] `pytest tests/test_termui.py::test_progress_bar_show_pos_flushes_update_min_steps tests/test_termui.py::test_progress_bar_update_min_steps`
- [ ] Repro from #3571 now ends at `20/20`

Fixes #3571
