### PR TITLE
AI junk

### DIFF
--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:

--- a/examples/aliases/aliases.py
+++ b/examples/aliases/aliases.py
@@ -70,7 +70,7 @@ class AliasedGroup(click.Group):
     def resolve_command(self, ctx, args):
         # always return the command's name, not the alias
         _, cmd, args = super().resolve_command(ctx, args)
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 def read_config(ctx, param, value):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -333,7 +333,7 @@ def test_aliased_command_canonical_name(runner):
 
         def resolve_command(self, ctx, args):
             _, command, args = super().resolve_command(ctx, args)
-            return command.name, command, args
+            return command.name if command else None, command, args
 
     cli = AliasedGroup()
 

--- a/tests/typing/typing_aliased_group.py
+++ b/tests/typing/typing_aliased_group.py
@@ -21,11 +21,10 @@ class AliasedGroup(click.Group):
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
-    ) -> tuple[str | None, click.Command, list[str]]:
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         # always return the full command name
         _, cmd, args = super().resolve_command(ctx, args)
-        assert cmd is not None
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 @click.command(cls=AliasedGroup)


### PR DESCRIPTION
## Summary
- Document and test that `AliasedGroup.resolve_command` can return `cmd is None`; examples use `cmd.name if cmd else None`.

Fixes #2402.

Opened as draft due to the open (non-draft) PR limit while #3705 is open.