### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@ Unreleased
   `DeprecationWarning` until Click 9.0: `LazyFile`, `KeepOpenFile`,
   `make_default_short_help`, `PacifyFlushWrapper`, and `safecall`.
   {issue}`3099` {pr}`3695`
+- Bash and Zsh completion for long option values written as `--option=value`
+  keeps the `--option=` prefix when replacing the current word. {issue}`2847`
 
 ## Version 8.4.2
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -362,8 +362,24 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        completion_prefix = _option_value_completion_prefix(ctx, incomplete)
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            completions = [
+                CompletionItem(
+                    f"{completion_prefix}{item.value}",
+                    type=item.type,
+                    help=item.help,
+                    **item._info,
+                )
+                if item.type == "plain"
+                else item
+                for item in completions
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the
@@ -799,3 +815,22 @@ def _resolve_incomplete(
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
     return ctx.command, incomplete
+
+
+def _option_value_completion_prefix(ctx: Context, incomplete: str) -> str:
+    """Return the long option prefix needed to replace ``--opt=value``."""
+    if "=" not in incomplete:
+        return ""
+
+    name, _, _ = incomplete.partition("=")
+
+    if not name:
+        return ""
+
+    params = ctx.command.get_params(ctx)
+
+    for param in params:
+        if isinstance(param, Option) and name in param.opts:
+            return f"{name}="
+
+    return ""

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -150,6 +150,20 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+def test_long_option_equals_value():
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    assert _get_words(cli, [], "--color=") == [
+        "--color=auto",
+        "--color=always",
+        "--color=never",
+    ]
+    assert _get_words(cli, [], "--color=a") == ["--color=auto", "--color=always"]
+    assert _get_words(cli, ["--color"], "a") == ["auto", "always"]
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]
@@ -386,6 +400,32 @@ def test_full_source_powershell(runner):
 @pytest.mark.usefixtures("_patch_for_completion")
 def test_full_complete(runner, shell, env, expect):
     cli = Group("cli", commands=[Command("a"), Command("b", help="bee")])
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        (
+            "bash",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_full_complete_long_option_equals_value(runner, shell, env, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
     env["_CLI_COMPLETE"] = f"{shell}_complete"
     result = runner.invoke(cli, env=env)
     assert result.output == expect


### PR DESCRIPTION
Fix bash and zsh completion for long option values typed with `=`, such as
`--color=a`.

Click already resolves `--color=a` as a value completion for `--color`, but the
completion result was returned as `auto` or `always`. Bash and zsh replace the
current word with the returned value, so the `--color=` prefix was lost. This
adds the long option prefix back to plain completion items while preserving the
existing space-separated form, `--color a`.

fixes #2847

Tests:

- `uv run pytest tests/test_shell_completion.py`
- `uv run pytest`
- `uv run ruff check`
