### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,11 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush any steps held back by update_min_steps so show_pos reaches
+        # length/length (percentage already uses finished=True → 100%).
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,22 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_finish_flushes_update_min_steps(runner):
+    """Remainder under update_min_steps must apply so show_pos reaches length (#3571)."""
+    bar = _create_progress(length=20, update_min_steps=7, show_pos=True)
+    # Simulate generator: 20 single-step updates leave 6 held back (20 % 7).
+    for _ in range(20):
+        bar.update(1)
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+    bar.finish()
+    bar.render_progress()
+    assert bar.pos == 20
+    assert bar._completed_intervals == 0
+    assert bar.format_pos() == "20/20"
+    assert bar.pct == 1.0
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
## Summary

Fixes #3571.

When `update_min_steps` is not a divisor of the total length, remaining intervals were never applied in `finish()`. `format_pct()` still showed 100% because `finished=True` forces `pct == 1.0`, but `format_pos()` (`show_pos=True`) stopped short (e.g. `14/20`).

### Change
- Flush `_completed_intervals` via `make_step()` inside `finish()` before marking the bar finished.
- Add a regression test that reproduces the `length=20`, `update_min_steps=7` case.

## Test plan
- [x] `pytest tests/test_termui.py::test_progress_bar_update_min_steps tests/test_termui.py::test_progress_bar_finish_flushes_update_min_steps -q`