### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,11 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush any steps held by update_min_steps so show_pos / percent
+        # reach the true end (e.g. length=20, update_min_steps=7).
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1610,3 +1610,22 @@ def test_hide_input_value_never_leaks_when_err_true(runner):
     result = runner.invoke(cli, input="leaky\n", mix_stderr=False)
     assert "leaky" not in result.stdout
     assert "leaky" not in result.stderr
+
+
+def test_progressbar_show_pos_with_update_min_steps(runner, monkeypatch):
+    """Remaining steps under update_min_steps must still reach full show_pos."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+        ) as bar:
+            for _ in bar:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    assert "20/20" in output
+


### PR DESCRIPTION
## Summary
When `update_min_steps` is greater than 1, leftover intervals under the threshold were never applied on finish, so `show_pos` could stop short of the true end (e.g. length=20, `update_min_steps=7` never shows `20/20`).

Flush remaining `_completed_intervals` in `finish()` before marking the bar finished.

## Testing
- `pytest tests/test_termui.py::test_progressbar_show_pos_with_update_min_steps tests/test_termui.py::test_progress_bar_update_min_steps` (2 passed)
