### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 Unreleased
 
+- `progressbar` with `show_pos=True` reports the final position as
+  `length/length` when `update_min_steps` is not a divisor of the length,
+  instead of stalling short while the bar and percentage already show
+  complete. {issue}`3571`
+
 - Add built-in shell completion support for PowerShell (Windows PowerShell
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -350,6 +350,12 @@ class ProgressBar(t.Generic[V]):
     def finish(self) -> None:
         self.eta_known = False
         self.current_item = None
+        # Flush any steps recorded below the ``update_min_steps`` threshold
+        # so the final position reflects all completed work. Otherwise a
+        # finished bar can show e.g. ``14/20`` while the bar and percentage
+        # already read complete. See #3571.
+        self.pos += self._completed_intervals
+        self._completed_intervals = 0
         self.finished = True
 
     def generator(self) -> cabc.Iterator[V]:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,27 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_finish_flushes_min_steps(runner):
+    # Trailing steps below update_min_steps must still count once the bar
+    # finishes, so a completed bar shows length/length instead of stalling
+    # short while the bar and percentage already read complete. See #3571.
+    bar = _create_progress(length=20, update_min_steps=7)
+
+    for _ in range(20):
+        bar.update(1)
+
+    # 20 == 7 + 7 + 6; the trailing 6 steps never reached the threshold.
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+
+    bar.finish()
+
+    assert bar.finished
+    assert bar._completed_intervals == 0
+    assert bar.pos == 20
+    assert bar.format_pos() == "20/20"
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571. With show_pos=True and an update_min_steps that isn't a divisor of the length, trailing sub-threshold steps were never applied, so a finished bar showed e.g. 14/20 while the bar and percentage read complete. finish() now flushes the pending steps. Adds a regression test; the full termui suite passes.