### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -683,9 +683,43 @@ class Editor:
                 return editor
         return "vi"
 
+    def _normalize_editor_args(
+        self, editor: str, filenames: cabc.Iterable[str]
+    ) -> list[str]:
+        """Normalize editor arguments, adding ``--wait`` when needed.
+
+        On Windows, VS Code's ``code`` CLI exits immediately after
+        handing the file path to the editor process. Without ``--wait``
+        the temp file is deleted before the user can edit it. This
+        automatically inserts ``--wait`` for ``code`` and
+        ``code-insiders`` when it is not already present.
+        """
+        import shlex
+        from pathlib import Path
+
+        editor_parts = shlex.split(editor)
+        files = list(filenames)
+
+        if not editor_parts:
+            return files
+
+        exe = Path(editor_parts[0]).name.lower()
+        for ext in (".exe", ".cmd", ".bat"):
+            if exe.endswith(ext):
+                exe = exe[: -len(ext)]
+                break
+
+        if exe not in {"code", "code-insiders"}:
+            return editor_parts + files
+
+        flags = set(editor_parts[1:])
+        if "--wait" in flags or "-w" in flags:
+            return editor_parts + files
+
+        return editor_parts + ["--wait"] + files
+
     def edit_files(self, filenames: cabc.Iterable[str]) -> None:
         """Open files in the user's editor."""
-        import shlex
         import subprocess
 
         editor = self.get_editor()
@@ -696,11 +730,8 @@ class Editor:
             environ.update(self.env)
 
         try:
-            # Split in POSIX mode (the default) for the same reasons as
-            # in pager(): strips quotes from tokens and preserves quoted
-            # Windows paths.
             c = subprocess.Popen(
-                args=shlex.split(editor) + list(filenames),
+                args=self._normalize_editor_args(editor, filenames),
                 env=environ,
             )
             exit_code = c.wait()

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -571,6 +571,72 @@ def test_editor_nonexistent_exception():
 
 
 @pytest.mark.parametrize(
+    ("editor_cmd", "expected_args"),
+    [
+        pytest.param(
+            "code",
+            ["code", "--wait", "f.txt"],
+            id="code-adds-wait",
+        ),
+        pytest.param(
+            "code --new-window",
+            ["code", "--new-window", "--wait", "f.txt"],
+            id="code-with-flags-adds-wait",
+        ),
+        pytest.param(
+            "code --wait",
+            ["code", "--wait", "f.txt"],
+            id="code-already-has-wait",
+        ),
+        pytest.param(
+            "code -w",
+            ["code", "-w", "f.txt"],
+            id="code-already-has-short-wait",
+        ),
+        pytest.param(
+            "code.cmd",
+            ["code.cmd", "--wait", "f.txt"],
+            id="code-cmd-adds-wait",
+        ),
+        pytest.param(
+            "code.exe",
+            ["code.exe", "--wait", "f.txt"],
+            id="code-exe-adds-wait",
+        ),
+        pytest.param(
+            "notepad",
+            ["notepad", "f.txt"],
+            id="non-code-unchanged",
+        ),
+        pytest.param(
+            "vim",
+            ["vim", "f.txt"],
+            id="vim-unchanged",
+        ),
+        pytest.param(
+            "code-insiders",
+            ["code-insiders", "--wait", "f.txt"],
+            id="code-insiders-adds-wait",
+        ),
+        pytest.param(
+            "/usr/bin/code",
+            ["/usr/bin/code", "--wait", "f.txt"],
+            id="code-abs-path-adds-wait",
+        ),
+    ],
+)
+def test_editor_vscode_wait_flag(editor_cmd, expected_args):
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+        Editor(editor=editor_cmd).edit_files(["f.txt"])
+
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
+        assert args == expected_args
+        assert mock_popen.call_args[1].get("shell") is None
+
+
+@pytest.mark.parametrize(
     ("pager_env", "expected_parts"),
     [
         # Simple commands.


### PR DESCRIPTION
## Summary

Fix `click.edit()` on Windows when the editor is Visual Studio Code (`code`).

## Motivation / Root cause

`Editor.edit()` writes a temporary file, launches the editor via `subprocess.Popen(...).wait()`, then always `os.unlink`s the temp file in a `finally` block.

VS Code's `code` CLI returns immediately after forwarding the path to the editor process. Click therefore deletes the temp file before the user can edit it, which produces an empty / missing-file tab.

This is independent of `require_save` / mtime handling (see discussion on #2582 and #1050).

## Changes

| File | Change |
|------|--------|
| `src/click/_termui_impl.py` | When the editor executable is `code` / `code-insiders` (incl. `.cmd`/`.exe`), automatically insert `--wait` unless `-w`/`--wait` is already present |
| `tests/test_termui.py` | Unit tests mocking `Popen` for VS Code wait injection and non-VS Code unchanged behavior |

## Testing

- `uv run pytest tests/test_termui.py -k "edit or Editor or editor or vscode" -v` — 30 passed, 2 skipped
- `uv run pytest tests/ -v` — 1857 passed, 95 skipped, 1 xfailed, full suite green
- (optional) manual: `EDITOR=code uv run python -c "import click; print(click.edit('hello'))"` on Windows

## Checklist

- [x] Minimal change; no unrelated refactors
- [x] Existing editor argument normalization tests still pass
- [x] Does not alter non-VS Code editors
- [x] Does not duplicate `--wait` if the user already passed it

## Related issue

Fixes #2582
