### PR TITLE
Parametrize deprecation tests and check targets

### DIFF
--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,28 +1,70 @@
+import importlib.metadata
+
 import pytest
 
 import click
-
-
-@pytest.mark.parametrize("module", [click, click.utils], ids=["click", "click.utils"])
-@pytest.mark.parametrize("name", ["get_binary_stream", "get_text_stream"])
-def test_stream_helper_deprecated(module, name):
-    with pytest.warns(DeprecationWarning, match=name):
-        getattr(module, name)
+import click.core
+import click.parser
+import click.shell_completion
+import click.utils
 
 
 @pytest.mark.parametrize(
-    "name",
+    ("module", "name", "target"),
     [
-        "LazyFile",
-        "KeepOpenFile",
-        "make_default_short_help",
-        "PacifyFlushWrapper",
-        "safecall",
+        # Stream helpers, re-exported from both `click` and `click.utils`.
+        (click, "get_binary_stream", click.utils._get_binary_stream),
+        (click, "get_text_stream", click.utils._get_text_stream),
+        (click.utils, "get_binary_stream", click.utils._get_binary_stream),
+        (click.utils, "get_text_stream", click.utils._get_text_stream),
+        # Command-class aliases, re-exported from `click` and `click.core`.
+        (click, "BaseCommand", click.core._BaseCommand),
+        (click, "MultiCommand", click.core._MultiCommand),
+        (click.core, "BaseCommand", click.core._BaseCommand),
+        (click.core, "MultiCommand", click.core._MultiCommand),
+        # Old parser API (moved to `optparse`); `OptionParser` is also
+        # re-exported from the top-level `click` namespace.
+        (click, "OptionParser", click.parser._OptionParser),
+        (click.parser, "OptionParser", click.parser._OptionParser),
+        (click.parser, "Argument", click.parser._Argument),
+        (click.parser, "Option", click.parser._Option),
+        (click.parser, "split_opt", click.parser._split_opt),
+        (click.parser, "normalize_opt", click.parser._normalize_opt),
+        (click.parser, "ParsingState", click.parser._ParsingState),
+        (click.parser, "split_arg_string", click.shell_completion.split_arg_string),
+        # Deprecated `click.utils` utilities.
+        (click.utils, "LazyFile", click.utils._LazyFile),
+        (click.utils, "KeepOpenFile", click.utils._KeepOpenFile),
+        (click.utils, "make_default_short_help", click.utils._make_default_short_help),
+        (click.utils, "PacifyFlushWrapper", click.utils._PacifyFlushWrapper),
+        (click.utils, "safecall", click.utils._safecall),
+        # Version metadata attribute.
+        (click, "__version__", importlib.metadata.version("click")),
     ],
+    ids=lambda v: getattr(v, "__name__", v),
 )
-def test_utilities_deprecated(name):
+def test_attr_deprecated(module, name, target):
     with pytest.warns(DeprecationWarning, match=name):
-        getattr(click.utils, name)
+        value = getattr(module, name)
+
+    assert value == target
+
+
+@pytest.mark.parametrize(
+    "module",
+    [click, click.core, click.parser, click.utils],
+    ids=lambda m: m.__name__,
+)
+def test_unknown_attribute_raises(module):
+    with pytest.raises(AttributeError, match="no_such_attribute"):
+        _ = module.no_such_attribute
+
+
+def test_context_protected_args_deprecated():
+    ctx = click.Context(click.Command("cli"))
+
+    with pytest.warns(DeprecationWarning, match="protected_args"):
+        assert ctx.protected_args == []
 
 
 def test_isolated_filesystem_deprecated(runner):


### PR DESCRIPTION
This PR parametrize similar tests to check:
- that deprecation warnings are properly triggered in various places of imports
- and that the right symbol or attribute is properly targeted

This is a follow up on recent changes from:
- https://github.com/pallets/click/pull/3695
-  https://github.com/pallets/click/pull/3704