### PR TITLE
AI junk

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from click._utils import UNSET, FLAG_NEEDS_VALUE, Sentinel
+
+
+class TestSentinel:
+    def test_unset_is_not_flag_needs_value(self):
+        assert Sentinel.UNSET is not Sentinel.FLAG_NEEDS_VALUE
+
+    def test_unset_not_equal_flag_needs_value(self):
+        assert Sentinel.UNSET != Sentinel.FLAG_NEEDS_VALUE
+
+    @pytest.mark.parametrize(
+        "value", [None, "", 0, False, [], object()]
+    )
+    def test_unset_not_equal_common_values(self, value: object) -> None:
+        assert Sentinel.UNSET != value
+
+    @pytest.mark.parametrize(
+        "value", [None, "", 0, False, [], object()]
+    )
+    def test_flag_needs_value_not_equal_common_values(self, value: object) -> None:
+        assert Sentinel.FLAG_NEEDS_VALUE != value
+
+    def test_unset_equals_itself(self):
+        assert Sentinel.UNSET == Sentinel.UNSET
+
+    def test_flag_needs_value_equals_itself(self):
+        assert Sentinel.FLAG_NEEDS_VALUE == Sentinel.FLAG_NEEDS_VALUE
+
+    def test_unset_constant_is_sentinel_unset(self):
+        assert UNSET is Sentinel.UNSET
+
+    def test_flag_needs_value_constant_is_sentinel_flag_needs_value(self):
+        assert FLAG_NEEDS_VALUE is Sentinel.FLAG_NEEDS_VALUE


### PR DESCRIPTION
## Code Quality

### Problem
Sentinel is an enum where each member is initialized with a unique object() value. The whole purpose of using object() rather than a plain sentinel like None or a string is identity-based comparison and the guarantee that no user-provided value can collide with it. This is load-bearing behavior: Option.consume_value and many other call sites use `is UNSET` / `== UNSET` checks. No tests verify that the two members are distinct from each other, from None, from empty strings, or from arbitrary objects passed by users.

**Severity**: `high`
**File**: `src/click/_utils.py`

### Solution
Add tests verifying: (1) Sentinel.UNSET is not Sentinel.FLAG_NEEDS_VALUE; (2) Sentinel.UNSET != Sentinel.FLAG_NEEDS_VALUE; (3) Sentinel.UNSET != None, '', 0, False; (4) Sentinel.UNSET == Sentinel.UNSET; (5) the module-level UNSET constant is identical to Sentinel.UNSET (using `is`); (6) the module-level FLAG_NEEDS_VALUE constant is identical to Sentinel.FLAG_NEEDS_VALUE. These guard against accidental refactors to e.g. a plain enum that would lose uniqueness guarantees.

### Changes
- `tests/test_utils.py` (modified)



<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->


Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #3716