### PR TITLE
AI junk

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from click._utils import FLAG_NEEDS_VALUE, Sentinel, UNSET
+
+
+class TestSentinel:
+    def test_repr_unset(self) -> None:
+        assert repr(Sentinel.UNSET) == "Sentinel.UNSET"
+
+    def test_repr_flag_needs_value(self) -> None:
+        assert repr(Sentinel.FLAG_NEEDS_VALUE) == "Sentinel.FLAG_NEEDS_VALUE"
+
+    def test_str_equals_repr(self) -> None:
+        assert str(Sentinel.UNSET) == repr(Sentinel.UNSET)
+        assert str(Sentinel.FLAG_NEEDS_VALUE) == repr(Sentinel.FLAG_NEEDS_VALUE)
+
+    def test_repr_stable(self) -> None:
+        assert repr(Sentinel.UNSET) == repr(Sentinel.UNSET)
+        assert repr(Sentinel.FLAG_NEEDS_VALUE) == repr(Sentinel.FLAG_NEEDS_VALUE)


### PR DESCRIPTION
## Code Quality

### Problem
The Sentinel enum's __repr__ method returns f"{self.__class__.__name__}.{self.name}", producing strings like "Sentinel.UNSET" and "Sentinel.FLAG_NEEDS_VALUE". This format is part of Click's public debug/error output contract — the docstring on FLAG_NEEDS_VALUE explicitly references it appearing in Option.consume_value flow. A change to this repr format would silently break user debug output and log parsing but go unnoticed without a test.

**Severity**: `medium`
**File**: `src/click/_utils.py`

### Solution
Add tests in tests/test_utils.py asserting repr(Sentinel.UNSET) == "Sentinel.UNSET" and repr(Sentinel.FLAG_NEEDS_VALUE) == "Sentinel.FLAG_NEEDS_VALUE". Also assert str(sentinel) == repr(sentinel) since they share the default Enum behavior, and verify the format is stable across instances (e.g., repr(Sentinel.UNSET) is identical on each call).

### Changes
- `tests/test_utils.py` (modified)



<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->


Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #3718