### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,9 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -341,7 +341,7 @@ def test_progressbar_update_with_item_show_func(runner, monkeypatch):
 
 
 def test_progressbar_update_min_steps_show_pos(runner, monkeypatch):
-    """progressbar with update_min_steps and show_pos should show full completion pos when finished."""
+    """progressbar update_min_steps shows full pos when finished."""
 
     @click.command()
     def cli():

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -340,6 +340,22 @@ def test_progressbar_update_with_item_show_func(runner, monkeypatch):
     assert "Custom 4" in lines[2]
 
 
+def test_progressbar_update_min_steps_show_pos(runner, monkeypatch):
+    """progressbar with update_min_steps and show_pos should show full completion pos when finished."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    assert "20/20" in output
+
+
 def test_progress_bar_update_min_steps(runner):
     bar = _create_progress(update_min_steps=5)
     bar.update(3)


### PR DESCRIPTION
Fixes #3571.

### Root Cause
When `update_min_steps > 1` is used with `show_pos=True`, trailing steps that do not reach `update_min_steps` remain buffered in `_completed_intervals`. When `finish()` is called, these buffered steps were not applied to `self.pos`, causing `format_pos()` to display an incomplete position (e.g. `14/20`).

### Fix
Flushes remaining `_completed_intervals` in `ProgressBar.finish()` by calling `make_step()` before setting `self.finished = True`. Added a regression unit test `test_progressbar_update_min_steps_show_pos` in `tests/test_termui.py`.
