### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -156,6 +156,9 @@ class ProgressBar(t.Generic[V]):
     def render_finish(self) -> None:
         if self.hidden or not self._is_atty:
             return
+        if not self.finished:
+            self.finish()
+            self.render_progress()
         self.file.write(AFTER_BAR)
         self.file.flush()
 
@@ -348,6 +351,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,23 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_finish_show_pos(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+        ) as bar:
+            for _ in bar:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, []).output
+    lines = [line for line in output.split("\n") if "[" in line]
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571

When `click.progressbar` is used with `update_min_steps` that does not evenly divide `length` (combined with `show_pos=True`), leftover steps in `_completed_intervals` were not flushed upon completion. Consequently, `pos` remained at the last interval boundary (e.g., showing `14/20` instead of `20/20`).

### Changes
- Flush any remaining `_completed_intervals` in `ProgressBar.finish()`.
- Ensure unfinished progress bar finishes and updates rendering in `ProgressBar.render_finish()`.
- Added unit test in `tests/test_termui.py`.