### PR TITLE
AI junk

### DIFF
--- a/src/click/types.py
+++ b/src/click/types.py
@@ -468,6 +468,7 @@ class Choice(ParamType[_ValueT_co], t.Generic[_ValueT_co]):
         """Get the error message when the given choice is invalid.
 
         :param value: The invalid value.
+        :param ctx: The current context, used to normalize the choices.
 
         .. versionadded:: 8.2
         """


### PR DESCRIPTION
Small docs fix. `Choice.get_invalid_choice_message` takes `value` and `ctx`, but the docstring only documents `value`. Added a `:param ctx:` line describing it (it's used to normalize the choices for the message), matching how `ctx` is documented elsewhere in click.

No code changes.