### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,9 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,21 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_update_min_steps_full_completion(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=7
+        ) as bar:
+            for _ in bar:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli).output
+    lines = [line for line in output.split("\n") if "[" in line]
+    assert "20/20" in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Fixes #3571.

### Description
When using \click.progressbar\ with \show_pos=True\ and \update_min_steps > 1\, the final position displayed on completion could lag behind \length\ (e.g. \14/20\ instead of \20/20\) because leftover intervals in \_completed_intervals\ were not flushed in \inish()\.

This PR updates \ProgressBar.finish()\ to advance remaining steps via \make_step()\ so \pos\ reaches \length\ upon completion.

### Verification
Added \	est_progressbar_update_min_steps_full_completion\ in \	ests/test_termui.py\.
Ran \pytest\ — all tests passed cleanly.