### PR TITLE
AI junk

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections.abc as cabc
+import sys
 from contextlib import contextmanager
 from gettext import gettext as _
 
@@ -139,6 +140,8 @@ class HelpFormatter:
             width = FORCED_WIDTH
             if width is None:
                 width = max(min(shutil.get_terminal_size().columns, max_width) - 2, 50)
+        elif width <= 0:
+            width = sys.maxsize
         self.width = width
         self.current_indent = 0
         self.buffer = []

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -52,6 +52,25 @@ def test_basic_functionality(runner):
     ]
 
 
+@pytest.mark.parametrize("terminal_width", [0, -1])
+def test_non_positive_terminal_width_matches_large_width_help(runner, terminal_width):
+    @click.command(
+        help=(
+            "This is a very long help message that should stay on one line in"
+            " CliRunner output unless a test explicitly sets terminal_width."
+        )
+    )
+    def cli():
+        pass
+
+    expected = runner.invoke(cli, ["--help"], terminal_width=1000)
+    result = runner.invoke(cli, ["--help"], terminal_width=terminal_width)
+
+    assert not expected.exception
+    assert not result.exception
+    assert result.output == expected.output
+
+
 def test_wrapping_long_options_strings(runner):
     @click.group()
     def cli():


### PR DESCRIPTION
## Summary

- treat explicit non-positive terminal widths as effectively unbounded
- add regression coverage for zero and negative widths
- preserve existing default wrapping behavior

## Validation

- `python -m pytest tests/test_formatting.py` (37 passed, 10 skipped)
- `python -m pytest` (1872 passed, 94 skipped, 1 xfailed)
- `python -m ruff check src tests`
- `pyright --verifytypes click`

Closes #1997