### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ Unreleased
   This stripping was lost in `8.4.0` when {pr}`2969` began writing the
   prompt with `input()` directly. {issue}`3572` {pr}`3653`
 - Fix test failures when using pytest >= 9.1. {pr}`3656`
+- `progressbar()` with `show_pos=True` shows the final position when
+  `update_min_steps` does not divide the length, instead of a stale count
+  below the total. {issue}`3571` {pr}`3730`
 - {class}`Path` with `allow_dash=True` no longer triggers a `BytesWarning`,
   an error under `python -bb`, when checking a value against the `-`
   convention. {issue}`2877` {pr}`3642`

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,13 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Flush steps buffered below the ``update_min_steps`` threshold so a
+        # fully consumed iterator reports its final position (e.g. with
+        # ``show_pos``) instead of the last position that met the threshold.
+        if self._completed_intervals:
+            self.pos += self._completed_intervals
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -106,6 +106,16 @@ def test_progressbar_hidden_manual(runner, monkeypatch):
     assert runner.invoke(cli, []).output == ""
 
 
+def test_progressbar_finish_reports_full_position(runner, monkeypatch):
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+
+    with _create_progress(20, show_pos=True, update_min_steps=3) as progress:
+        for _ in progress:
+            pass
+
+    assert progress.pos == progress.length
+
+
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])
 def test_progressbar_time_per_iteration(runner, avg, expected):
     with _create_progress(2, avg=avg) as progress:


### PR DESCRIPTION
Fixes #3571

### The bug

When `update_min_steps` does not divide the length of the iterable and `show_pos=True`, the progress bar ends showing a stale count such as `18/20` even though the bar and percentage are at 100%.

`ProgressBar.update()` buffers steps in `self._completed_intervals` and only advances `self.pos` (via `make_step`) once the buffer reaches `update_min_steps`. The trailing steps that never reach the threshold stay in the buffer. When the iterator is exhausted, `generator()` calls `finish()`, which sets `self.finished = True` but never flushes that buffer. Since `pct` returns `1.0` once `finished`, the bar and percentage read 100% while `show_pos` renders the stale `self.pos` — a self-contradictory line.

Reproduced against `main` (`update_min_steps=3`, length `20`): after the loop `pos == 18` with `2` steps still buffered, and `finish()` leaves `pos == 18`.

### The fix

Flush the buffered `_completed_intervals` into `self.pos` in `finish()`, so a fully consumed iterator reports its final position. `finish()` is only called when the iterator is exhausted (end of `generator()`); early exit via the context manager goes through `render_finish()`, so this does not falsely complete a bar that was abandoned.

### Tests

Added `test_progressbar_finish_reports_full_position` in `tests/test_termui.py`: iterating a bar with `update_min_steps=3` over length `20` and `show_pos=True` now ends with `progress.pos == progress.length`. It fails on `main` (`assert 18 == 20`) and passes with the change. `tests/test_termui.py` is green (222 passed), and `ruff check` / `ruff format --check` are clean.

I'll add a `CHANGES.md` entry once this PR has a number.
