### PR TITLE
AI junk

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -31,7 +31,7 @@ Example:
 ```{eval-rst}
 .. click:example::
 
-    @click.command()
+    import click\n    \n    @click.command()
     @click.option('--name', prompt=True)
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -50,7 +50,7 @@ a different one:
 ```{eval-rst}
 .. click:example::
 
-    @click.command()
+    import click\n    \n    @click.command()
     @click.option('--name', prompt='Your name please')
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -92,7 +92,7 @@ option's flag is given, instead of if the option is not provided at all.
 ```{eval-rst}
 .. click:example::
 
-    @click.command()
+    import click\n    \n    @click.command()
     @click.option('--name', prompt=True, prompt_required=False, default="Default")
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -153,7 +153,7 @@ To describe what the default value will be, set it in ``show_default``.
 
     import os
 
-    @click.command()
+    import click\n    \n    @click.command()
     @click.option(
         "--username", prompt=True,
         default=lambda: os.environ.get("USER", ""),

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -32,7 +32,6 @@ Example:
 .. click:example::
 
     import click
-    
     @click.command()
     @click.option('--name', prompt=True)
     def hello(name):
@@ -53,7 +52,6 @@ a different one:
 .. click:example::
 
     import click
-    
     @click.command()
     @click.option('--name', prompt='Your name please')
     def hello(name):
@@ -97,7 +95,6 @@ option's flag is given, instead of if the option is not provided at all.
 .. click:example::
 
     import click
-    
     @click.command()
     @click.option('--name', prompt=True, prompt_required=False, default="Default")
     def hello(name):
@@ -143,7 +140,6 @@ environment:
 ```python
 import os
 import click
-
 @click.command()
 @click.option(
     "--username", prompt=True,
@@ -161,7 +157,6 @@ To describe what the default value will be, set it in ``show_default``.
     import os
 
     import click
-    
     @click.command()
     @click.option(
         "--username", prompt=True,

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -31,7 +31,9 @@ Example:
 ```{eval-rst}
 .. click:example::
 
-    import click\n    \n    @click.command()
+    import click
+    
+    @click.command()
     @click.option('--name', prompt=True)
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -50,7 +52,9 @@ a different one:
 ```{eval-rst}
 .. click:example::
 
-    import click\n    \n    @click.command()
+    import click
+    
+    @click.command()
     @click.option('--name', prompt='Your name please')
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -92,7 +96,9 @@ option's flag is given, instead of if the option is not provided at all.
 ```{eval-rst}
 .. click:example::
 
-    import click\n    \n    @click.command()
+    import click
+    
+    @click.command()
     @click.option('--name', prompt=True, prompt_required=False, default="Default")
     def hello(name):
         click.echo(f"Hello {name}!")
@@ -136,6 +142,7 @@ environment:
 
 ```python
 import os
+import click
 
 @click.command()
 @click.option(
@@ -153,7 +160,9 @@ To describe what the default value will be, set it in ``show_default``.
 
     import os
 
-    import click\n    \n    @click.command()
+    import click
+    
+    @click.command()
     @click.option(
         "--username", prompt=True,
         default=lambda: os.environ.get("USER", ""),


### PR DESCRIPTION
## Description

The Click documentation uses a custom Sphinx directive .. click:example:: that pre-imports click into the execution namespace when building the docs. However, the rendered source code blocks do not include import click.

This means users who copy the examples from the documentation will get NameError: name click is not defined unless they add the import themselves.

This change adds import click to each .. click:example:: and python example in docs/prompts.md so the snippets are self-contained.

## Verification

- Confirmed the click:example directive does not render import click automatically.
- Verified examples use @click decorators and click.echo/click.option without an explicit import.
- No open or merged PR was found addressing this.