### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -351,6 +351,11 @@ class ProgressBar(t.Generic[V]):
         self.eta_known = False
         self.current_item = None
         self.finished = True
+        # When update_min_steps > 1, the tail of accumulated steps may
+        # not reach the threshold, leaving pos below length. Clamp it so
+        # that format_pos() shows the correct final count (e.g. "20/20").
+        if self.length is not None and self.pos < self.length:
+            self.pos = self.length
 
     def generator(self) -> cabc.Iterator[V]:
         """Return a generator which yields the items added to the bar


### PR DESCRIPTION
## Problem

Fixes #3571.

When `update_min_steps > 1` and `length` is not a multiple of `update_min_steps`,
progressbar shows a stale position in `show_pos` mode at end of iteration.

Example with `length=20`, `update_min_steps=7` — final output:

```
[####################################]  14/20
```

Expected: `20/20`.

## Root cause

`update()` only calls `make_step()` when `_completed_intervals >= update_min_steps`.
When the loop finishes, the tail of accumulated steps (items 14-19, i.e. 6 steps)
never reaches the threshold of 7, so `make_step` is never called and `self.pos`
stays at 14. `finish()` sets `self.finished = True` but does NOT update `self.pos`.
The final `render_progress()` then reads `self.pos == 14` and `format_pos()`
returns `"14/20"` instead of `"20/20"`.

`pct` and `format_bar()` are unaffected because they short-circuit to 1.0 / a
full bar when `self.finished is True`. Only `format_pos()` uses the raw `self.pos`,
which is why the visual bar is correct but the count is wrong.

## Fix

One-line addition to `finish()`: clamp `self.pos` to `self.length` when
`self.pos < self.length`. Safe because:

- `pct` already returns 1.0 when finished — unaffected.
- `eta` returns 0.0 when finished — unaffected.
- Guard `self.pos < self.length` prevents reducing pos in edge cases.

## Reproduction

```python
import click

with click.progressbar(range(20), show_pos=True, update_min_steps=7) as bar:
    for _ in bar:
        pass
# Before fix: [####################################]  14/20
# After fix:  [####################################]  20/20
```

Closes #3571.
