### PR TITLE
AI junk

### DIFF
--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:


### PR DESCRIPTION
## Summary

- make the `AliasedGroup.resolve_command` documentation example handle unknown commands
- avoid accessing `.name` on a `None` command

Issue: #2402

This updates the example only; Click runtime behavior is unchanged.