### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,10 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,19 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progress_bar_update_min_steps_flushes_at_completion(runner, monkeypatch):
+    @click.command()
+    def cli():
+        with click.progressbar(range(20), show_pos=True, update_min_steps=7) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    result = runner.invoke(cli, [], catch_exceptions=False)
+
+    assert "20/20" in result.output
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Flushes pending throttled progress updates when a progress bar finishes.

When update_min_steps holds increments below the next refresh boundary, the final render can retain the previous position even after iteration is exhausted. finish() now flushes those pending increments before the bar is marked finished.

The regression test exercises a real command with show_pos=True and verifies that the final output reaches 20/20.

Fixes #3571