### PR TITLE
AI junk

### DIFF
--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -348,6 +348,12 @@ class ProgressBar(t.Generic[V]):
             self._completed_intervals = 0
 
     def finish(self) -> None:
+        # Apply steps held back by update_min_steps so show_pos (and
+        # other pos-based formatting) matches a completed bar.
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+
         self.eta_known = False
         self.current_item = None
         self.finished = True

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -350,6 +350,43 @@ def test_progress_bar_update_min_steps(runner):
     assert bar.pos == 5
 
 
+def test_progressbar_finish_applies_pending_intervals():
+    """finish() must apply leftover update_min_steps so pos reaches length."""
+    bar = _create_progress(length=20, update_min_steps=7)
+    bar.update(14)
+    bar.update(6)
+    assert bar.pos == 14
+    assert bar._completed_intervals == 6
+
+    bar.finish()
+
+    assert bar.pos == 20
+    assert bar._completed_intervals == 0
+    assert bar.finished
+    assert "20/20" in bar.format_pos()
+
+
+def test_progressbar_show_pos_flush_on_finish(runner, monkeypatch):
+    """End-to-end: final rendered line shows 20/20 (#3571)."""
+
+    @click.command()
+    def cli():
+        with click.progressbar(
+            range(20),
+            show_pos=True,
+            update_min_steps=7,
+        ) as progress:
+            for _ in progress:
+                pass
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    output = runner.invoke(cli, [], catch_exceptions=False).output
+    lines = [line for line in output.split("\r") if "[" in line]
+
+    assert "20/20" in lines[-1]
+    assert "14/20" not in lines[-1]
+
+
 @pytest.mark.parametrize("key_char", ("h", "H", "é", "À", " ", "字", "àH", "àR"))
 @pytest.mark.parametrize("echo", [True, False])
 @pytest.mark.skipif(not WIN, reason="Tests user-input using the msvcrt module.")


### PR DESCRIPTION
Flush leftover _completed_intervals in finish() so the final position matches a completed bar. Fixes #3571.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
