### PR TITLE
AI junk

### DIFF
--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -362,8 +362,26 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+
+        # Detect if the incomplete value uses "=" to separate option
+        # and value (e.g. "--color=al"). If so, track the option prefix
+        # so completions can be prepended with it. Shells replace the
+        # entire current word with the completion, so without the prefix
+        # the option name would be lost.
+        option_prefix = ""
+        if "=" in incomplete and _start_of_option(ctx, incomplete):
+            option_prefix = incomplete.partition("=")[0] + "="
+
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if option_prefix:
+            completions = [
+                CompletionItem(option_prefix + c.value, type=c.type, help=c.help)
+                for c in completions
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the


### PR DESCRIPTION
Fixes #2847.

When a long option uses = to separate option from value (e.g. --color=value), shells replace the entire current word with the completion. Without tracking the option prefix, the completion replaces --color= with just auto, losing the option name.

This detects the = separator in get_completions(), saves the prefix (--color=), and prepends it to each completion item so the shell replaces --color= with --color=auto as expected.

Tested with bash and zsh completion scenarios. All existing tests pass.