### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,9 @@ Unreleased
   {class}`ParamType` takes a second optional type parameter describing the
   input value it accepts (`ParamType[int, str]` for a type converting
   strings to integers), defaulting to `Any`. {pr}`3407`
+- The command-alias examples now preserve `None` from
+  {meth}`Group.resolve_command`, avoiding tracebacks during shell completion
+  for unknown subcommands. {issue}`2402`
 
 ## Version 8.4.2
 

--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:

--- a/examples/aliases/aliases.py
+++ b/examples/aliases/aliases.py
@@ -70,7 +70,7 @@ class AliasedGroup(click.Group):
     def resolve_command(self, ctx, args):
         # always return the command's name, not the alias
         _, cmd, args = super().resolve_command(ctx, args)
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 def read_config(ctx, param, value):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+ALIASED_GROUP_FILES = [
+    ROOT / "docs" / "extending-click.md",
+    ROOT / "examples" / "aliases" / "aliases.py",
+    ROOT / "tests" / "typing" / "typing_aliased_group.py",
+]
+
+
+def test_aliased_group_examples_handle_unknown_commands():
+    for path in ALIASED_GROUP_FILES:
+        text = path.read_text()
+
+        assert "return cmd.name, cmd, args" not in text, path
+        assert "return cmd.name if cmd else None, cmd, args" in text, path

--- a/tests/typing/typing_aliased_group.py
+++ b/tests/typing/typing_aliased_group.py
@@ -21,11 +21,10 @@ class AliasedGroup(click.Group):
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
-    ) -> tuple[str | None, click.Command, list[str]]:
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         # always return the full command name
         _, cmd, args = super().resolve_command(ctx, args)
-        assert cmd is not None
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 @click.command(cls=AliasedGroup)


### PR DESCRIPTION
Fixes #2402

## Summary
- Update the command-alias docs and example app to preserve `None` from `Group.resolve_command` when an unknown command is being resolved.
- Update the typing fixture return type to match that `cmd` may be `None`.
- Add a regression check so the docs/example/typing copies do not drift back to the tracebacking form.

## Test plan
- RED: `python3 -m pytest tests/test_docs.py -q` → failed because `docs/extending-click.md` still contained `return cmd.name, cmd, args`.
- GREEN: `uv run --frozen pytest tests/test_docs.py -q` → 1 passed.
- GREEN: `uv run --frozen pytest tests/test_docs.py tests/test_shell_completion.py tests/test_commands.py::test_aliased_command_canonical_name -q` → 60 passed.
- GREEN: `uv run --frozen pytest tests -q` → 1941 passed, 24 skipped, 31000 deselected, 1 xfailed.
- GREEN: `uv run --frozen ruff check CHANGES.md docs/extending-click.md examples/aliases/aliases.py tests/test_docs.py tests/typing/typing_aliased_group.py` → All checks passed.
- GREEN: `uv run --frozen ruff format --check examples/aliases/aliases.py tests/test_docs.py tests/typing/typing_aliased_group.py` → 3 files already formatted.
- GREEN: `python3 -m py_compile examples/aliases/aliases.py tests/typing/typing_aliased_group.py tests/test_docs.py`.
- GREEN: `git diff --check`.
