### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ Unreleased
   {class}`ParamType` takes a second optional type parameter describing the
   input value it accepts (`ParamType[int, str]` for a type converting
   strings to integers), defaulting to `Any`. {pr}`3407`
+- `HelpFormatter.write_usage` no longer breaks long options at hyphens.
+  {issue}`3362`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,12 +53,17 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is false, words will only be broken
+                             at whitespace.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
         ``text``, ``initial_indent``, or ``subsequent_indent`` no longer
         count toward the width budget, so styled input wraps based on what
         the user sees instead of raw byte length.
+
+    .. versionchanged:: 8.5.0
+        Added the ``break_on_hyphens`` parameter.
     """
     from ._textwrap import TextWrapper
 
@@ -67,6 +73,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +193,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +203,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -603,6 +603,34 @@ def test_help_formatter_write_usage_without_args_styled_prefix():
     assert "\x1b[" in rendered
 
 
+def test_write_usage_does_not_break_options_on_hyphens():
+    formatter = click.HelpFormatter(width=65)
+    args = " ".join(
+        [
+            "--enable-verbose-logging",
+            "--output-file-path",
+            "--max-retry-count",
+            "--disable-cache-mode",
+            "--config-file-location",
+            "--user-auth-token",
+            "--auto-update-interval",
+            "--force-overwrite-existing",
+            "--network-timeout-seconds",
+            "--debug-trace-enabled",
+        ]
+    )
+
+    formatter.write_usage("program", args)
+
+    assert formatter.getvalue() == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+
 @pytest.mark.parametrize(
     ("command_kwargs", "expected_usage_line"),
     [


### PR DESCRIPTION
Fixes #3362

HelpFormatter.write_usage currently allows text wrapping to split long command-line options at their hyphens. Add a backwards-compatible break_on_hyphens parameter to wrap_text and disable hyphen breaks specifically for usage arguments, while preserving the existing wrapping behavior for other help text.

The API parameter and behavior are documented in the formatter docstring and the unreleased changelog.

Tests: PYTHONPATH=src python -m pytest tests/test_formatting.py -q (38 passed); PYTHONPATH=src python -m ruff check src/click/formatting.py tests/test_formatting.py; python -m compileall -q src/click/formatting.py tests/test_formatting.py.