### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,11 @@ Unreleased
   `DeprecationWarning` until Click 9.0: `LazyFile`, `KeepOpenFile`,
   `make_default_short_help`, `PacifyFlushWrapper`, and `safecall`.
   {issue}`3099` {pr}`3695`
+- {meth}`HelpFormatter.write_usage` no longer splits an option name at a
+  hyphen when it reaches the wrap column, so `--max-retry-count` is not
+  broken into `--max-` and `retry-count`. {func}`wrap_text` accepts a
+  `break_on_hyphens` parameter to control this; it defaults to `True`, so
+  help text wrapping is unchanged. {issue}`3362`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,12 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: whether a word may be split after a hyphen.
+                             Disable it for text made of tokens that must
+                             stay intact, such as option names.
+
+    .. versionchanged:: 8.5.0
+        Added the ``break_on_hyphens`` parameter.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +74,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +194,10 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    # An option name is a single token; breaking
+                    # "--output-file-path" after a hyphen would read as two
+                    # separate options.
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +207,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -603,6 +603,61 @@ def test_help_formatter_write_usage_without_args_styled_prefix():
     assert "\x1b[" in rendered
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    """An option name reaching the wrap column stays whole. Regression for
+    #3362, where ``--max-retry-count`` was split into ``--max-`` and
+    ``retry-count``, reading as two separate options.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    f = click.HelpFormatter(width=65)
+    f.write_usage("program", " ".join(options))
+
+    assert f.getvalue() == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+
+def test_write_usage_long_prefix_does_not_break_options_at_hyphens():
+    """The same holds on the branch that moves args to their own line."""
+    f = click.HelpFormatter(width=40)
+    f.write_usage("a-long-program-name", "--output-file-path --max-retry-count")
+
+    for line in f.getvalue().splitlines():
+        assert not line.endswith("-")
+
+
+def test_wrap_text_breaks_on_hyphens_by_default():
+    """Prose is unaffected: ``wrap_text`` still breaks at hyphens unless
+    asked not to.
+    """
+    text = "a well-known and much-discussed topic"
+
+    assert click.formatting.wrap_text(text, width=20) == (
+        "a well-known and\nmuch-discussed topic"
+    )
+    assert click.formatting.wrap_text(text, width=14, break_on_hyphens=True) == (
+        "a well-known\nand much-\ndiscussed\ntopic"
+    )
+    assert click.formatting.wrap_text(text, width=14, break_on_hyphens=False) == (
+        "a well-known\nand\nmuch-discussed\ntopic"
+    )
+
+
 @pytest.mark.parametrize(
     ("command_kwargs", "expected_usage_line"),
     [


### PR DESCRIPTION
Fixes #3362.

## Problem

`textwrap` breaks words at hyphens by default, so an option name that reaches the wrap column is split across two lines:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
               --force-overwrite-existing --network-timeout-
               seconds --debug-trace-enabled
```

`--max-` and `retry-count` read as two separate options rather than one.

## Fix

`wrap_text` gains a `break_on_hyphens` parameter, forwarded to the `TextWrapper` it already builds, and `write_usage` passes `False` from both of its branches (args beside the prefix, and args moved to their own line).

The parameter defaults to `True`, so nothing else changes. That matters: help text is prose, where breaking `much-discussed` across lines is the desired behaviour. Only the usage line, which is a list of tokens that must stay intact, opts out.

Output for the issue's reproduction now matches the expected output exactly:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

## Tests

- `test_write_usage_does_not_break_options_at_hyphens` — the issue's exact case, asserting the full expected output.
- `test_write_usage_long_prefix_does_not_break_options_at_hyphens` — covers the other `write_usage` branch, asserting no line ends in a hyphen.
- `test_wrap_text_breaks_on_hyphens_by_default` — pins that prose wrapping is unchanged, with both settings shown side by side at a width that forces the difference.

Full suite passes (1847 passed, 95 skipped, 1 xfailed).

## Note

An option longer than the available width is still broken mid-token by `break_long_words`, now at an arbitrary character rather than at a hyphen. That only arises at widths too narrow to fit the option at all. I left it alone to keep this change to the reported behaviour — happy to pass `break_long_words=False` for the usage line as well if you would rather it overflow than split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)