### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ Unreleased
   {class}`ParamType` takes a second optional type parameter describing the
   input value it accepts (`ParamType[int, str]` for a type converting
   strings to integers), defaulting to `Any`. {pr}`3407`
+- Fix a ``TypeError`` in the Windows pager fallback 
+  that caused a ``[WinError 32]`` crash.
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -623,9 +623,9 @@ def _tempfilepager(
     # On Windows, NamedTemporaryFile cannot be opened by another process
     # while Python still has it open, so we use delete=False and clean up manually
     # rather than using a contextmanager here.
-    f = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    f = tempfile.NamedTemporaryFile(mode="w",encoding=encoding, delete=False)
     try:
-        yield t.cast(t.BinaryIO, f), encoding, color
+        yield t.cast(t.TextIO, f), encoding, color
         f.flush()
         f.close()
         subprocess.call([str(cmd_path), f.name])


### PR DESCRIPTION
On branch fix-windows-pager-typeerror
Changes to be committed:
	modified:   src/click/_termui_impl.py
	
Fixes a `TypeError` and subsequent `[WinError 32]` when using `click.echo_via_pager()` on Windows.

**The Bug:**
The `_tempfilepager` yields a binary file (`mode="wb"`), but `echo_via_pager` expects a `TextIO` stream and writes strings to it.

**The Domino Effect:**
1. Writing a string to the `"wb"` file throws a `TypeError`.
2. Because this exception happens before `f.close()`, the temporary file is left open by Python.
3. The `finally` block attempts `os.unlink()` on an open file, which Windows rejects, throwing `[WinError 32]`.

**The Fix:**
Changed the `NamedTemporaryFile` mode to `"w"` with explicit encoding, and yielded it as `TextIO` to match the expected signature in `echo_via_pager`.

**(Note: I did not open an issue prior to this PR as the type mismatch was straightforward.**

**Regarding Tests:**
I did not include an automated test because mocking the Windows Terminal and pager subprocesses in the test suite is a bit tricky, and I'm a first-time contributor. However, the problem is very apparent and easily reproducible. 

If you run the following script on Windows 11 using Click 8.4.2, it crashes immediately with a `TypeError` (and subsequently `[WinError 32]`). With my patch applied, it opens the pager and exits cleanly.

```python
import click

# Generate enough text to force the pager to actually open
large_text = "\n".join([f"This is line number {i}" for i in range(1000)])

print("Opening pager... Press 'q' to quit once it opens.")

# This triggers the TypeError on Windows in 8.4.2
click.echo_via_pager(large_text)

print("If you see this, it didn't crash!")
```