### PR TITLE
AI junk

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -58,6 +58,16 @@ default value is provided, the type is assumed to be {data}`STRING`.
    and they should not error out if the wildcard is empty.
 ```
 
+`required` is enforced while Click parses command-line input. Calling another
+command directly with {meth}`Context.invoke` does not parse a command line.
+Parameters that are not passed to `invoke` use their defaults, and a required
+argument without a default receives `None`. Pass the argument explicitly when
+invoking the command from Python:
+
+```python
+click.get_current_context().invoke(touch, filename="foo.txt")
+```
+
 ## Multiple Arguments
 
 To set the number of argument use the `nargs` kwarg. It can be set to


### PR DESCRIPTION
Document that `required` is enforced during command-line parsing, while `Context.invoke` supplies defaults directly and gives a required argument without a default the value `None`. The example demonstrates passing the argument explicitly for programmatic invocation.

Fixes #2801

Validation:

- `python -m sphinx -E -W -b dirhtml docs <output>`
- `pytest tests/test_arguments.py` (`109 passed`)
- direct verification of omitted and explicit `Context.invoke` argument values