### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,11 @@ Unreleased
   strings to integers), defaulting to `Any`. {pr}`3407`
 - {meth}`Command.get_help_option_names` returns the help option names in the
   order they were declared. {pr}`3728`
+- {meth}`HelpFormatter.write_usage` no longer splits an option name at one of
+  its own hyphens when it reaches the wrap column, so `--max-retry-count` is
+  moved to the next line intact instead of rendering as `--max-` /
+  `retry-count`. {func}`wrap_text` accepts a `break_on_hyphens` parameter to
+  control this. {issue}`3362` {pr}`3757`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,13 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is cleared, compound words are never
+                             split at a hyphen. Useful when the text is a list
+                             of option names, where ``--max-retry-count``
+                             should stay on one line.
+
+    .. versionchanged:: 8.5.0
+        Added the ``break_on_hyphens`` parameter.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +75,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +195,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +205,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -603,6 +603,79 @@ def test_help_formatter_write_usage_without_args_styled_prefix():
     assert "\x1b[" in rendered
 
 
+def test_write_usage_does_not_break_option_names_at_hyphens():
+    """Issue #3362: an option name reaching the wrap column was split at one
+    of its own hyphens, rendering ``--max-`` / ``retry-count``. A usage line
+    holds option and metavar tokens rather than prose, so it is wrapped with
+    hyphen breaking disabled.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+    ]
+    f = click.HelpFormatter(width=65)
+    f.write_usage("program", " ".join(options))
+
+    assert f.getvalue() == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location\n"
+    )
+
+
+def test_write_usage_long_prefix_does_not_break_option_names_at_hyphens():
+    """The branch that moves the arguments onto their own line keeps option
+    names intact as well.
+    """
+    f = click.HelpFormatter(width=38)
+    f.write_usage("very-long-program-name", "--max-retry-count --output-file-path")
+
+    assert f.getvalue().splitlines()[1:] == [
+        "           --max-retry-count",
+        "           --output-file-path",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("text", "width", "break_on_hyphens", "expected"),
+    [
+        # A hyphenated token that does not fit in the remaining space is
+        # split at a hyphen by default, ...
+        pytest.param(
+            "ab --max-retry-count",
+            18,
+            True,
+            "ab --max-retry-\ncount",
+            id="split-at-hyphen",
+        ),
+        # ... and moved to the next line intact when disabled.
+        pytest.param(
+            "ab --max-retry-count",
+            18,
+            False,
+            "ab\n--max-retry-count",
+            id="keep-token-intact",
+        ),
+        # Prose keeps breaking at hyphens: the default is unchanged.
+        pytest.param(
+            "a well-documented feature",
+            12,
+            True,
+            "a well-\ndocumented\nfeature",
+            id="prose-default-unchanged",
+        ),
+    ],
+)
+def test_wrap_text_break_on_hyphens(text, width, break_on_hyphens, expected):
+    """``wrap_text`` exposes ``break_on_hyphens`` so callers can keep
+    hyphenated tokens such as option names on a single line.
+    """
+    assert click.wrap_text(text, width, break_on_hyphens=break_on_hyphens) == expected
+
+
 @pytest.mark.parametrize(
     ("command_kwargs", "expected_usage_line"),
     [


### PR DESCRIPTION
`textwrap` breaks on hyphens by default, so an option name that happens to
reach the wrap column gets split in the middle of itself:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
               --force-overwrite-existing --network-timeout-
               seconds --debug-trace-enabled
```

A usage line is a list of option and metavar tokens rather than prose, so
there is never a useful place to break inside one. Wrapping it with
`break_on_hyphens=False` moves the whole token to the next line instead:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

Both branches of `write_usage` are covered: arguments placed beside the
prefix, and arguments wrapped onto their own line when the prefix is too
long to share.

The ticket also notes there is currently no way to influence this short of
reimplementing `wrap_text` and `write_usage` in a subclass, so `wrap_text`
takes a `break_on_hyphens` argument. It defaults to `True`, leaving prose
wrapping in help text and epilogs unchanged; there is a test covering that
so the default does not drift.

fixes #3362
