### PR TITLE
AI junk

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -138,6 +138,59 @@ And from the command line:
     invoke(touch, ['-foo.txt', 'bar.txt'])
 ```
 
+## Negative Number Arguments
+
+Negative numbers hit the same rule: the parser decides what is an
+option before a parameter's type is consulted, so a value like `-6`
+is rejected as an unknown option even on a `FLOAT` argument:
+
+```{eval-rst}
+.. click:example::
+
+    @click.command()
+    @click.argument('volume', type=float)
+    def gain(volume):
+        """Set the output gain in dB."""
+        click.echo(f"gain set to {volume}")
+
+And from the command line:
+
+.. click:run::
+
+    invoke(gain, ['-6'])
+```
+
+The `--` separator from the previous section works here too
+(`gain -- -6`). For a command whose arguments are routinely negative
+numbers, requiring `--` on every call is impractical, and
+`ignore_unknown_options` lets the values through instead:
+
+```{eval-rst}
+.. click:example::
+
+    @click.command(context_settings={"ignore_unknown_options": True})
+    @click.argument('volume', type=float)
+    def gain(volume):
+        """Set the output gain in dB."""
+        click.echo(f"gain set to {volume}")
+
+And from the command line:
+
+.. click:run::
+
+    invoke(gain, ['-6'])
+```
+
+This trades away some error checking: unknown options are now
+arguments, so a mistyped or misplaced flag arrives as a value. A
+`FLOAT` argument still rejects `--verbose` with a usage error during
+type conversion, but a `STRING` argument accepts it silently, and a
+command that accepts both numbers and free-form strings cannot tell a
+flag-like value from a typo. When a command combines
+`ignore_unknown_options` with loosely typed arguments, validate the
+values yourself: decide what a legitimate value looks like for that
+command and reject dash-prefixed tokens that do not match.
+
 (environment-variables)=
 
 ## Environment Variables


### PR DESCRIPTION
Addresses the docs discussion in #2676.

Adds a "Negative Number Arguments" section to the arguments docs, directly after the existing `ignore_unknown_options` example it builds on. It covers:

- why `-6` is rejected before the parameter's type is consulted, shown with a runnable example
- the `--` separator, connected back to the section above it
- the `ignore_unknown_options` recipe for commands whose arguments are routinely negative numbers
- the caveat that comes with it: unknown options become arguments, so mistyped or misplaced flags arrive as values, and string-typed arguments accept them silently. The section closes with the practical guidance to validate values when using this pattern.

I hit this exact problem building a mixer-control CLI (fader values like `-6`) and shipped the `ignore_unknown_options`-plus-validation pattern there, including learning the caveat the hard way: a misplaced `--json` was silently accepted as a string value until validation was added. This section is the write-up I wish the docs had had.

No parser changes, per the maintainer discussion in #2676 (the feature itself is deferred to the parser rewrite). The examples are `click:run` blocks, so their output is generated by executing the code at docs build time; `sphinx-build -E -W -b dirhtml docs docs/_build/dirhtml` passes locally with no warnings. Lines are wrapped at 80 characters. No CHANGES entry since this is docs-only; happy to add one if wanted.