### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 Unreleased
 
+- `HelpFormatter.write_usage` no longer splits an argument after a hyphen
+  when the usage line wraps, so `--enable-verbose-logging` stays whole
+  instead of becoming `--enable-verbose-` / `logging`. `wrap_text()` takes a
+  new `break_on_hyphens` parameter, defaulting to `True`, for callers that
+  need the same control. {issue}`3362`
 - Add built-in shell completion support for PowerShell (Windows PowerShell
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,12 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: whether a long word may be split after a hyphen.
+                             Disable this for text made of tokens that must
+                             stay whole, such as option names on a usage line.
+
+    .. versionchanged:: 8.4.0
+        Added the ``break_on_hyphens`` parameter.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +74,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -162,6 +170,10 @@ class HelpFormatter:
         :param args: whitespace separated list of arguments.
         :param prefix: The prefix for the first line. Defaults to
             ``"Usage: "``.
+
+        .. versionchanged:: 8.4.0
+            Arguments are no longer split after a hyphen when they wrap, so
+            ``--enable-verbose-logging`` stays on one line.
         """
         if prefix is None:
             prefix = "{usage} ".format(usage=_("Usage:"))
@@ -186,6 +198,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +208,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,3 +630,62 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_write_usage_does_not_break_options_at_hyphens():
+    """A wrapped usage line must not split an option name after a hyphen.
+
+    ``--max-retry-count`` broken as ``--max-`` / ``retry-count`` is not a
+    thing the reader can copy, and on a narrow terminal it reads as two
+    separate options.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+    ]
+    formatter = click.HelpFormatter(width=65)
+
+    formatter.write_usage("program", " ".join(options))
+
+    lines = formatter.getvalue().splitlines()
+    assert lines == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location",
+    ]
+
+
+def test_write_usage_does_not_break_hyphens_on_the_wrapped_prefix_path():
+    """The long-prefix branch puts args on their own line; same rule there.
+
+    ``write_usage`` has two ``wrap_text`` calls and only one is reached when
+    the prefix fits, so a fix applied to one of them looks correct until the
+    program name is long.
+    """
+    formatter = click.HelpFormatter(width=40)
+
+    # Long enough that the args must wrap *within* that branch; a single short
+    # option would fit on one line and never reach the wrapping code at all.
+    formatter.write_usage(
+        "a-very-long-program-name-indeed",
+        "--max-retry-count --disable-cache-mode --user-auth-token",
+    )
+
+    value = formatter.getvalue()
+    assert "--max-\n" not in value
+    assert "--disable-cache-\n" not in value
+    for option in ("--max-retry-count", "--disable-cache-mode", "--user-auth-token"):
+        assert option in value
+
+
+def test_wrap_text_still_breaks_hyphens_by_default():
+    """Prose keeps the old behaviour; only usage lines opt out."""
+    text = "a well-considered and thoroughly-documented approach"
+
+    assert "well-\n" in click.formatting.wrap_text(text, width=12)
+    assert "well-\n" not in click.formatting.wrap_text(
+        text, width=12, break_on_hyphens=False
+    )


### PR DESCRIPTION
fixes #3362

`write_usage` wraps through `wrap_text`, which builds a `TextWrapper` with textwrap's default `break_on_hyphens=True`. On a narrow line that splits an option after any internal hyphen:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
```

Neither half of `--max-` / `retry-count` is copyable, and at a glance it reads as two separate options. After:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval
```

## Approach

Hyphen breaking is right for prose and wrong for a line made of tokens that must stay whole. Rather than hardcode that inside `write_usage`, `wrap_text()` gains a `break_on_hyphens` parameter defaulting to `True` — help text and every other caller are unchanged — and `write_usage` passes `False`.

Exposing it also answers the issue's second point: someone hitting this had no way to influence the wrapper short of reimplementing `write_usage` in a subclass.

## Both call sites

`write_usage` has two `wrap_text` calls and only one runs per invocation. The second is reached when the prefix is too long for the args to sit beside it:

```python
if text_width >= (term_len(usage_prefix) + 20):
    ...   # args to the right of the prefix
else:
    ...   # args on the next line
```

Fixing only the first leaves the bug live behind a long program name, so both pass `break_on_hyphens=False`.

## Tests

Three, each failing on `main`:

| Test | Pins |
| --- | --- |
| `test_write_usage_does_not_break_options_at_hyphens` | the reported case, asserting the exact three output lines |
| `test_write_usage_does_not_break_hyphens_on_the_wrapped_prefix_path` | the long-prefix branch |
| `test_wrap_text_still_breaks_hyphens_by_default` | prose is unaffected; only usage lines opt out |

The second one is worth a note. My first version passed on `main`, because a single short option fits on one line and never reaches the wrapping code in that branch at all — it looked like coverage while testing nothing. It now passes three options so the args genuinely have to wrap inside that branch, and it fails on `main` like the others.

The third exists because the obvious wrong fix is to set `break_on_hyphens=False` inside `wrap_text` itself, which would silently change every help paragraph in every Click app.

```
$ pytest -q
1955 passed, 25 skipped, 1 xfailed

$ ruff check src tests    All checks passed!
$ ruff format --check     63 files already formatted
```

`CHANGES.md` entry under 8.5.0, plus `.. versionchanged:: 8.4.0` notes on `wrap_text` and `write_usage`. Say the word if those should read 8.5.0 instead — the file's existing `versionchanged` markers point at 8.4.0 while the changelog is on 8.5.0, and I was not sure which is current.