### PR TITLE
AI junk

### DIFF
--- a/src/click/parser.py
+++ b/src/click/parser.py
@@ -307,10 +307,16 @@ class _OptionParser:
         state = _ParsingState(args)
         try:
             self._process_args_for_options(state)
+        except UsageError:
+            if self.ctx is None or not self.ctx.resilient_parsing:
+                raise
+
+        try:
             self._process_args_for_args(state)
         except UsageError:
             if self.ctx is None or not self.ctx.resilient_parsing:
                 raise
+
         return state.opts, state.largs, state.order
 
     def _process_args_for_args(self, state: _ParsingState) -> None:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -253,6 +253,26 @@ def test_option_custom():
     assert _get_words(cli, ["a", "b"], "c") == ["C"]
 
 
+def test_option_custom_sees_parsed_arguments():
+    seen = {}
+
+    def custom(ctx, param, incomplete):
+        seen.update(ctx.params)
+        return []
+
+    cli = Command(
+        "cli",
+        params=[
+            Argument(["type"]),
+            Option(["--test"], shell_complete=custom),
+        ],
+    )
+
+    _get_completions(cli, ["foo", "--test"], "")
+
+    assert seen["type"] == "foo"
+
+
 def test_option_multiple():
     cli = Command(
         "type",


### PR DESCRIPTION
Fixes #2184

## Summary

In resilient parsing mode, `_OptionParser.parse_args` stopped after `_process_args_for_options` raised a `UsageError`. As a result, positional arguments that had already been identified were not processed before shell completion callbacks inspected `ctx.params`.

This change continues with positional-argument processing when resilient parsing is enabled, while preserving the existing error behavior for normal parsing. The regression test verifies that a shell-completion callback sees the parsed positional argument.

## Validation

- `PYTHONPATH=src python3 -m pytest -q` — 1954 passed, 24 skipped, 1 xfailed
- Ruff check passed
- `git diff --check` passed