### PR TITLE
Refactor pager stream handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,10 @@ Unreleased
   unlinked its file without closing it first, and Windows refuses to remove a
   file the process still holds open, so the cleanup failure masked the real
   exception. {issue}`3731` {pr}`3764`
+- The temporary file the pager writes to on Windows is opened with the encoding
+  {func}`get_pager_file` picked for the output stream, and with
+  `errors="replace"` to match the pipe backend. Any text stdout can encode
+  reaches the pager.
 
 ## Version 8.4.2
 

--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -506,7 +506,7 @@ def should_strip_ansi(
         if stream is None:
             stream = sys.stdin
         elif hasattr(stream, "color"):
-            # ._termui_impl.MaybeStripAnsi handles stripping ansi itself,
+            # ._termui_impl._PagerWriter handles stripping ansi itself,
             # so we don't need to strip it here
             return False
         return not isatty(stream) and not _is_jupyter_kernel_output(stream)

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import contextlib
-import io
 import math
 import os
 import shlex
@@ -28,22 +27,9 @@ from ._compat import strip_ansi
 from ._compat import term_len
 from ._compat import WIN
 from .exceptions import ClickException
-from .utils import _KeepOpenFile
 from .utils import echo
 
 V = t.TypeVar("V")
-
-
-class _BufferedTextPagerStream(t.Protocol):
-    buffer: t.BinaryIO
-
-
-def _has_binary_buffer(
-    stream: t.BinaryIO | t.TextIO,
-) -> t.TypeGuard[_BufferedTextPagerStream]:
-    # TextIO is wider than TextIOWrapper; text-only streams such as StringIO
-    # are valid TextIO values but do not expose a binary buffer to wrap.
-    return getattr(stream, "buffer", None) is not None
 
 
 if os.name == "nt":
@@ -394,20 +380,49 @@ class ProgressBar(t.Generic[V]):
             self.render_progress()
 
 
-class MaybeStripAnsi(io.TextIOWrapper):
-    def __init__(self, stream: t.IO[bytes], *, color: bool, **kwargs: t.Any):
-        super().__init__(stream, **kwargs)
+class _PagerWriter:
+    """Wrap a pager's output stream to strip ANSI styling when colors are
+    disabled.
+
+    The wrapped stream is owned by the pager strategy that produced it, so this
+    wrapper never closes it: ``_pipepager`` closes its pipe to signal EOF to the
+    pager process, ``_tempfilepager`` closes and removes its temporary file, and
+    ``_nullpager`` leaves an external stream such as ``sys.stdout`` untouched.
+
+    The ``color`` attribute lets :func:`click.echo` detect that ANSI stripping
+    is handled here, so it doesn't strip a second time (see
+    :func:`._compat.should_strip_ansi`).
+    """
+
+    def __init__(self, stream: t.TextIO, color: bool) -> None:
+        self._stream = stream
         self.color = color
 
     def write(self, text: str) -> int:
         if not self.color:
             text = strip_ansi(text)
-        return super().write(text)
+
+        return self._stream.write(text)
+
+    def writelines(self, lines: cabc.Iterable[str]) -> None:
+        for line in lines:
+            self.write(line)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def close(self) -> None:
+        # The pager strategy owns the stream's lifecycle. Flush pending output,
+        # but never close the underlying stream from here.
+        self._stream.flush()
+
+    def __getattr__(self, name: str) -> t.Any:
+        return getattr(self._stream, name)
 
 
 def _pager_contextmanager(
     color: bool | None = None,
-) -> t.ContextManager[tuple[t.BinaryIO | t.TextIO, str, bool]]:
+) -> t.ContextManager[tuple[t.TextIO, bool]]:
     """Decide what method to use for paging through text."""
     stdout = _default_text_stdout()
 
@@ -447,37 +462,21 @@ def get_pager_file(color: bool | None = None) -> t.Generator[t.TextIO, None, Non
     :param color: controls if the pager supports ANSI colors or not.  The
                   default is autodetection.
     """
-    with _pager_contextmanager(color=color) as (stream, encoding, color):
-        # Split streams by capabilities rather than the abstract TextIO /
-        # BinaryIO annotations: buffered text streams can be unwrapped to bytes,
-        # while other streams are yielded as-is.
-        wrapper: MaybeStripAnsi | None = None
-        if _has_binary_buffer(stream):
-            # Text stream backed by a binary buffer.
-            wrapper = MaybeStripAnsi(stream.buffer, color=color, encoding=encoding)
-            stream = wrapper
+    with _pager_contextmanager(color=color) as (stream, color):
+        # Every pager strategy yields a text stream, so the only thing left to
+        # do is strip ANSI styling when colors are disabled. The wrapper does
+        # not close the stream: each strategy owns its stream's lifecycle.
+        writer = _PagerWriter(stream, color=color)
         try:
-            # Narrow the BinaryIO | TextIO union that _pager_contextmanager
-            # yields; the caller writes text to the pager.
-            yield t.cast(t.TextIO, stream)
+            yield t.cast(t.TextIO, writer)
         finally:
-            try:
-                stream.flush()
-            finally:
-                # Hand the binary buffer back to the pager that produced it
-                # rather than letting this TextIOWrapper close it on garbage
-                # collection. The pager owns the buffer's lifecycle: subprocess
-                # pipes and temp files are closed by their own helpers, while a
-                # borrowed stdout must stay open for the caller. detach() runs
-                # even if flush() raised, so the buffer is never closed here.
-                if wrapper is not None:
-                    wrapper.detach()
+            writer.flush()
 
 
 @contextlib.contextmanager
 def _pipepager(
     cmd_parts: list[str], color: bool | None = None
-) -> t.Iterator[tuple[t.BinaryIO | t.TextIO, str, bool]]:
+) -> t.Iterator[tuple[t.TextIO, bool]]:
     """Page through text by feeding it to another program.
 
     Invokes the pager via :class:`subprocess.Popen` with an ``argv`` list
@@ -544,10 +543,11 @@ def _pipepager(
         errors="replace",
         text=True,
     )
-    stdin = t.cast(t.BinaryIO, c.stdin)
-    encoding = get_best_encoding(stdin)
+    # With ``text=True``, ``c.stdin`` is already a text stream that encodes
+    # writes for the pager process (honoring ``errors="replace"``).
+    stdin = t.cast(t.TextIO, c.stdin)
     try:
-        yield stdin, encoding, color
+        yield stdin, color
     except BrokenPipeError:
         # In case the pager exited unexpectedly, ignore the broken pipe error.
         pass
@@ -587,7 +587,7 @@ def _pipepager(
 @contextlib.contextmanager
 def _tempfilepager(
     cmd_parts: list[str], color: bool | None = None
-) -> t.Iterator[tuple[t.BinaryIO | t.TextIO, str, bool]]:
+) -> t.Iterator[tuple[t.TextIO, bool]]:
     """Page through text by invoking a program on a temporary file.
 
     Used as the primary pager strategy on Windows (where piping to
@@ -631,9 +631,11 @@ def _tempfilepager(
     # On Windows, NamedTemporaryFile cannot be opened by another process
     # while Python still has it open, so we use delete=False and clean up manually
     # rather than using a contextmanager here.
-    f = tempfile.NamedTemporaryFile(mode="w", delete=False)
+    f = tempfile.NamedTemporaryFile(
+        mode="w", encoding=encoding, errors="replace", delete=False
+    )
     try:
-        yield t.cast(t.BinaryIO, f), encoding, color
+        yield t.cast(t.TextIO, f), color
         f.flush()
         f.close()
         subprocess.call([str(cmd_path), f.name])
@@ -649,21 +651,17 @@ def _tempfilepager(
 @contextlib.contextmanager
 def _nullpager(
     stream: t.TextIO, color: bool | None = None
-) -> t.Iterator[tuple[t.TextIO, str, bool]]:
-    """Simply print unformatted text. This is the ultimate fallback. Don't close the
-    output stream in this case, since it's coming from elsewhere rather than our
-    internal helpers.
+) -> t.Iterator[tuple[t.TextIO, bool]]:
+    """Simply print unformatted text. This is the ultimate fallback.
 
-    The stream is wrapped in :class:`~click.utils._KeepOpenFile` so that, as a
-    borrowed stream, it is not closed by a ``with`` block. The wrapper that
-    :func:`get_pager_file` builds around it is detached rather than closed.
+    The stream comes from elsewhere (typically ``sys.stdout``), so its lifecycle
+    is left untouched: :class:`_PagerWriter` never closes what it wraps, and it
+    is the only thing :func:`get_pager_file` hands to the caller.
     """
-    encoding = get_best_encoding(stream)
-
     if color is None:
         color = False
 
-    yield _KeepOpenFile(stream), encoding, color  # type: ignore[misc]
+    yield stream, color
 
 
 class Editor:

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -904,7 +904,8 @@ def test_echo_via_pager_tty_pager_missing(runner, monkeypatch):
 def test_get_pager_file_nullpager_wraps_textio_stream(
     monkeypatch, tmp_path, color, expected
 ):
-    """When paging falls back to a real TextIO stream, ``.buffer`` is wrapped."""
+    """When paging falls back to a real text stream, ANSI styling is stripped or
+    preserved according to ``color``."""
     pager_out = tmp_path / "pager_out.txt"
 
     with pager_out.open("w", encoding="utf-8") as text_stream:
@@ -922,20 +923,20 @@ def test_get_pager_file_nullpager_wraps_textio_stream(
 
 
 def test_get_pager_file_nullpager_keeps_stringio_stream(monkeypatch):
-    """The no-stdout fallback should keep a text-only stream and set ``.color``."""
+    """The no-stdout fallback keeps the text stream open and strips ANSI."""
 
     stream = io.StringIO()
     monkeypatch.setattr(sys, "stdout", None)
     monkeypatch.setattr(click._termui_impl, "StringIO", lambda: stream)
     monkeypatch.setattr(click._termui_impl, "isatty", lambda _: False)
 
-    styled_text = click.style("hello", fg="red")
-
     with click.get_pager_file(color=False) as pager:
-        pager.write(styled_text)
+        pager.write(click.style("hello", fg="red"))
 
+    # The wrapper must not close a stream it does not own.
     assert not stream.closed
-    assert stream.getvalue() == styled_text
+    # With colors disabled, ANSI styling is stripped.
+    assert stream.getvalue() == "hello"
 
 
 def test_get_pager_file_flushes_stream_on_exception(monkeypatch):
@@ -944,7 +945,6 @@ def test_get_pager_file_flushes_stream_on_exception(monkeypatch):
     class FlushableTextStream(io.StringIO):
         def __init__(self):
             super().__init__()
-            self.color = None
             self.flush_calls = 0
 
         def flush(self):
@@ -954,7 +954,7 @@ def test_get_pager_file_flushes_stream_on_exception(monkeypatch):
 
     @contextlib.contextmanager
     def pager_contextmanager(color=None):
-        yield stream, "utf-8", color
+        yield stream, False
 
     monkeypatch.setattr(
         click._termui_impl, "_pager_contextmanager", pager_contextmanager
@@ -962,10 +962,43 @@ def test_get_pager_file_flushes_stream_on_exception(monkeypatch):
 
     with pytest.raises(RuntimeError, match="boom"):
         with click.get_pager_file() as pager:
-            assert pager is stream
+            pager.write("partial")
             raise RuntimeError("boom")
 
     assert stream.flush_calls == 1
+    assert stream.getvalue() == "partial"
+
+
+def test_get_pager_file_close_does_not_close_borrowed_stream(monkeypatch):
+    """Closing the yielded pager must not close a stream the caller owns.
+
+    ``_PagerWriter.close()`` flushes but deliberately stops there: each pager
+    strategy owns its stream's lifecycle. This is the caller-driven half of
+    ``test_get_pager_file_missing_pager_keeps_borrowed_stream_open``, which
+    covers the same fallback but never calls ``close`` itself.
+
+    Wrapping the borrowed stream in :class:`~click.utils._KeepOpenFile` does not
+    satisfy this: that proxy only covers a ``with`` block and passes an explicit
+    ``close`` straight through. Only the writer's own ``close`` stops it.
+    """
+    stream = io.StringIO()
+    monkeypatch.setattr(click._termui_impl, "_default_text_stdout", lambda: stream)
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    # A tty plus a ``PAGER`` that doesn't resolve sends us through the
+    # ``_pipepager`` (or ``_tempfilepager``) missing-binary fallback branch.
+    monkeypatch.setitem(
+        click._termui_impl.os.environ,
+        "PAGER",
+        "click-tests-nonexistent-pager-9b3f2",
+    )
+
+    with click.get_pager_file() as pager:
+        pager.write("hello\n")
+        pager.close()
+        assert not stream.closed
+
+    assert not stream.closed
+    assert stream.getvalue() == "hello\n"
 
 
 def _force_tempfile_pager(monkeypatch, pager_cmd="cat"):
@@ -1006,11 +1039,9 @@ def _page_with_echo_via_pager():
 def test_tempfile_pager_accepts_text(monkeypatch, capfd, page):
     """The temp file backend must yield a text stream (issues #3731, #3740).
 
-    ``_tempfilepager`` opens its temp file in binary mode and yields the
-    ``_TemporaryFileWrapper`` straight to ``get_pager_file``. That wrapper
-    exposes no ``.buffer``, so the ``_has_binary_buffer`` probe is False and no
-    ``MaybeStripAnsi`` wrapper is installed. The caller then writes ``str`` to a
-    binary handle and gets ``TypeError: a bytes-like object is required``.
+    Regression: a binary-mode temp file handed straight to ``get_pager_file``
+    left the caller writing ``str`` to a binary handle, which raises
+    ``TypeError: a bytes-like object is required``.
     """
     _force_tempfile_pager(monkeypatch)
 
@@ -1032,8 +1063,8 @@ def test_tempfile_pager_accepts_text(monkeypatch, capfd, page):
 def test_tempfile_pager_handles_ansi(monkeypatch, capfd, color, expected):
     """The temp file backend honors ``color`` like the pipe backend does.
 
-    ANSI stripping lives in ``MaybeStripAnsi``, which the binary temp file
-    never gets wrapped in, so ``color`` is silently ignored on this path.
+    Regression: a binary temp file got no ANSI-stripping wrapper, so ``color``
+    was silently ignored on this path.
     """
     _force_tempfile_pager(monkeypatch)
 

--- a/tests/test_utils/test_echo_via_pager.py
+++ b/tests/test_utils/test_echo_via_pager.py
@@ -197,20 +197,20 @@ def test_echo_via_pager_yields_before_exception(monkeypatch, tmp_path):
 
     The pager file content is intentionally NOT asserted: pipe-drain timing
     between click and the pager subprocess is outside click's control
-    (#2899, #3470). Spying on ``MaybeStripAnsi.write`` records what click sent
+    (#2899, #3470). Spying on ``_PagerWriter.write`` records what click sent
     to the pager, which is deterministic regardless of scheduling.
     """
     monkeypatch.setitem(os.environ, "PAGER", "cat")
     monkeypatch.setattr(click._termui_impl, "isatty", lambda x: True)
 
     writes: list[str] = []
-    real_write = click._termui_impl.MaybeStripAnsi.write
+    real_write = click._termui_impl._PagerWriter.write
 
     def spy(self, text):
         writes.append(text)
         return real_write(self, text)
 
-    monkeypatch.setattr(click._termui_impl.MaybeStripAnsi, "write", spy)
+    monkeypatch.setattr(click._termui_impl._PagerWriter, "write", spy)
 
     pager_out_tmp = tmp_path / "pager_out.txt"
     with (


### PR DESCRIPTION
This streamline the pager handling and removes the distinction between text and binary streams.

It is a follow up on:
- #1572 
- #3405