### PR TITLE
Settles progress bar on its final position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,10 @@ Unreleased
   raised `TypeError: a bytes-like object is required, not 'str'`, and the
   `color` argument was ignored on that path. Regression introduced in `8.4.0`
   by {pr}`1572`. {issue}`3731` {issue}`3732` {issue}`3740` {pr}`3739`
+- {func}`progressbar` settles on its final position when `update_min_steps`
+  does not divide the total. Steps below that threshold are applied when the
+  bar finishes, so `show_pos` renders `20/20` rather than the last multiple
+  it reached. {issue}`3571` {pr}`3769`
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -154,6 +154,14 @@ class ProgressBar(t.Generic[V]):
         return next(iter(self))
 
     def render_finish(self) -> None:
+        # Steps stay pending until they add up to update_min_steps, so a length
+        # that is not a multiple of it keeps a sub-threshold remainder that
+        # never reaches pos. Apply it so the bar settles on its true position.
+        if self._completed_intervals:
+            self.make_step(self._completed_intervals)
+            self._completed_intervals = 0
+            self.render_progress()
+
         if self.hidden or not self._is_atty:
             return
         self.file.write(AFTER_BAR)

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -106,6 +106,37 @@ def test_progressbar_hidden_manual(runner, monkeypatch):
     assert runner.invoke(cli, []).output == ""
 
 
+@pytest.mark.parametrize("update_min_steps", [1, 2, 3, 7, 20, 25])
+@pytest.mark.parametrize("drive", ["iterate", "update"])
+def test_progressbar_lands_on_final_position(monkeypatch, update_min_steps, drive):
+    """The bar reaches its total whatever the ``update_min_steps`` threshold.
+
+    Regression for issue #3571: a threshold that does not divide the length
+    left a remainder pending, so `show_pos` froze below completion, reporting
+    `14/20` for a length of 20 and a threshold of 7. Thresholds of 1 and 2 do
+    divide 20, and 25 exceeds it, so nothing is ever rendered until the end.
+    """
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    stream = io.StringIO()
+
+    if drive == "iterate":
+        with click.progressbar(
+            range(20), show_pos=True, update_min_steps=update_min_steps, file=stream
+        ) as bar:
+            for _ in bar:
+                pass
+    else:
+        with click.progressbar(
+            length=20, show_pos=True, update_min_steps=update_min_steps, file=stream
+        ) as bar:
+            for _ in range(20):
+                bar.update(1)
+
+    assert bar.pos == 20
+    assert bar.finished
+    assert "20/20" in stream.getvalue()
+
+
 @pytest.mark.parametrize("avg, expected", [([], 0.0), ([1, 4], 2.5)])
 def test_progressbar_time_per_iteration(runner, avg, expected):
     with _create_progress(2, avg=avg) as progress:


### PR DESCRIPTION
This fix has been shipped in Click Extra for a couple of weeks and has been tested on a couple of production ready CLIs.

Closes #3571.

This PR unfortunately close the honeypot of lazy LLMs contributions. 😁