### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,9 @@ Unreleased
   does not divide the total. Steps below that threshold are applied when the
   bar finishes, so `show_pos` renders `20/20` rather than the last multiple
   it reached. {issue}`3571` {pr}`3769`
+- {meth}`HelpFormatter.write_usage` keeps hyphenated usage tokens such as
+  option names on one line instead of wrapping at the hyphen.
+  {issue}`3362`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,12 +53,19 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then wrapping may split a
+                             token after a hyphen. Pass ``False`` to keep
+                             hyphenated tokens such as option names intact.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
         ``text``, ``initial_indent``, or ``subsequent_indent`` no longer
         count toward the width budget, so styled input wraps based on what
         the user sees instead of raw byte length.
+
+    .. versionchanged:: 8.5.0
+        Added ``break_on_hyphens``. ``HelpFormatter.write_usage``
+        passes ``False`` so hyphenated usage tokens stay on one line.
     """
     from ._textwrap import TextWrapper
 
@@ -67,6 +75,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -162,6 +171,10 @@ class HelpFormatter:
         :param args: whitespace separated list of arguments.
         :param prefix: The prefix for the first line. Defaults to
             ``"Usage: "``.
+
+        .. versionchanged:: 8.5.0
+            Hyphenated usage tokens such as option names are not wrapped
+            in the middle of the token.
         """
         if prefix is None:
             prefix = "{usage} ".format(usage=_("Usage:"))
@@ -186,6 +199,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +209,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -503,6 +503,37 @@ def test_wrap_text_visible_width(body, width, initial_indent):
     assert styled_visible == plain.splitlines()
 
 
+def test_write_usage_does_not_wrap_hyphenated_option_tokens():
+    """Usage tokens such as ``--max-retry-count`` must wrap on spaces, not
+    on internal hyphens. Regression for issue 3362.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    actual = formatter.getvalue()
+    expected = (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+    assert actual == expected
+    for token in options:
+        assert token in actual
+
+
 def test_write_usage_styled_prefix_keeps_options_on_one_line():
     """End-to-end: a downstream-styled ``Usage:`` prefix should not split
     ``[OPTIONS]`` across two lines.


### PR DESCRIPTION
write_usage wraps args with wrap_text. The wrapper inherited textwrap hyphen breaks, so tokens such as option names were split across lines.

Disable hyphen breaks for usage args so each whitespace separated token stays together.

Fixes #3362