### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,9 @@ Unreleased
   does not divide the total. Steps below that threshold are applied when the
   bar finishes, so `show_pos` renders `20/20` rather than the last multiple
   it reached. {issue}`3571` {pr}`3769`
+- `HelpFormatter.write_usage()` no longer splits option names containing
+  hyphens across lines; e.g. `--max-retry-count` stays intact. `wrap_text()`
+  gained a `break_on_hyphens` parameter. {issue}`3362` {pr}`3772`
 
 ## Version 8.4.2
 

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -67,6 +68,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +188,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +198,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,3 +630,29 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_write_usage_does_not_break_options_on_hyphens():
+    # Regression test for issue #3362: option names containing hyphens must not
+    # be split across lines at a hyphen in the usage line.
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    result = formatter.getvalue()
+
+    for option in options:
+        assert option in result, f"{option!r} was split across lines"
+
+    for line in result.splitlines():
+        assert not line.rstrip().endswith("-"), f"line broken at hyphen: {line!r}"


### PR DESCRIPTION
Fixes #3362.

## The problem

`HelpFormatter.write_usage` wraps the argument list with `textwrap`, whose default `break_on_hyphens=True` splits words at hyphens. When an option name falls at the wrap boundary it is broken mid-name:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
```

## The change

- Add a `break_on_hyphens` parameter to `wrap_text` (default `True`, so existing behavior — including help-text wrapping — is unchanged).
- Pass `break_on_hyphens=False` from `HelpFormatter.write_usage`, so option names stay intact on the usage line.

The reproduction from the issue now produces the expected output, with option names kept whole:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

## Tests

- Added a regression test in `tests/test_formatting.py`.
- Full local test suite passes (`1899 passed, 95 skipped`).

---

*Disclosure: this contribution was prepared with AI assistance; I reviewed the change and verified the full test run before submitting.*
