### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- {func}`edit` accepts :class:`os.PathLike` values, including
+  :class:`pathlib.Path`, for ``filename``. Passing a path object used to
+  raise ``TypeError`` because ``Path`` is neither a ``str`` nor an
+  iterable of strings. {issue}`2869`
 - Add built-in shell completion support for PowerShell (Windows PowerShell
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -696,13 +696,14 @@ class Editor:
                 return editor
         return "vi"
 
-    def edit_files(self, filenames: cabc.Iterable[str]) -> None:
+    def edit_files(self, filenames: cabc.Iterable[str | os.PathLike[str]]) -> None:
         """Open files in the user's editor."""
         import shlex
         import subprocess
 
         editor = self.get_editor()
         environ: dict[str, str] | None = None
+        names = [os.fspath(name) for name in filenames]
 
         if self.env:
             environ = os.environ.copy()
@@ -713,7 +714,7 @@ class Editor:
             # in pager(): strips quotes from tokens and preserves quoted
             # Windows paths.
             c = subprocess.Popen(
-                args=shlex.split(editor) + list(filenames),
+                args=shlex.split(editor) + names,
                 env=environ,
             )
             exit_code = c.wait()

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -4,6 +4,7 @@ import collections.abc as cabc
 import inspect
 import io
 import itertools
+import os
 import re
 import sys
 import typing as t
@@ -837,7 +838,7 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None = None,
 ) -> None: ...
 
 
@@ -847,7 +848,7 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | cabc.Iterable[str] | None = None,
+    filename: str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None = None,
 ) -> str | bytes | bytearray | None:
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating
@@ -884,6 +885,10 @@ def edit(
         ``filename`` now accepts any ``Iterable[str]`` in addition to a ``str``
         if the ``editor`` supports editing multiple files at once.
 
+    .. versionchanged:: 8.5.0
+        ``filename`` now accepts :class:`os.PathLike` values, including
+        :class:`pathlib.Path`, matching :func:`open_file`.
+
     """
     from ._termui_impl import Editor
 
@@ -892,10 +897,12 @@ def edit(
     if filename is None:
         return ed.edit(text)
 
-    if isinstance(filename, str):
-        filename = (filename,)
+    if isinstance(filename, (str, os.PathLike)):
+        filenames: tuple[str, ...] = (os.fspath(filename),)
+    else:
+        filenames = tuple(os.fspath(name) for name in filename)
 
-    ed.edit_files(filenames=filename)
+    ed.edit_files(filenames=filenames)
     return None
 
 

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -838,7 +838,10 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None = None,
+    filename: str
+    | os.PathLike[str]
+    | cabc.Iterable[str | os.PathLike[str]]
+    | None = None,
 ) -> None: ...
 
 
@@ -848,7 +851,10 @@ def edit(
     env: cabc.Mapping[str, str] | None = None,
     require_save: bool = True,
     extension: str = ".txt",
-    filename: str | os.PathLike[str] | cabc.Iterable[str | os.PathLike[str]] | None = None,
+    filename: str
+    | os.PathLike[str]
+    | cabc.Iterable[str | os.PathLike[str]]
+    | None = None,
 ) -> str | bytes | bytearray | None:
     r"""Edits the given text in the defined editor.  If an editor is given
     (should be the full path to the executable but the regular operating

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -2,6 +2,7 @@ import contextlib
 import gc
 import io
 import os
+import pathlib
 import platform
 import shlex
 import shutil
@@ -549,6 +550,35 @@ def test_editor_path_normalization(editor_cmd, filenames, expected_args):
         args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
         assert args == expected_args
         assert mock_popen.call_args[1].get("shell") is None
+
+
+def test_edit_accepts_pathlib_path():
+    """filename=pathlib.Path used to raise TypeError (issue 2869)."""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as named_tempfile:
+        named_tempfile.write("hello\n")
+        path = pathlib.Path(named_tempfile.name)
+
+    try:
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value.wait.return_value = 0
+            result = click.edit(filename=path, editor="true")
+
+        assert result is None
+        args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
+        assert args[-1] == os.fspath(path)
+    finally:
+        os.unlink(named_tempfile.name)
+
+
+def test_edit_accepts_iterable_of_paths():
+    paths = [pathlib.Path("a.txt"), pathlib.Path("b.txt")]
+    with patch("subprocess.Popen") as mock_popen:
+        mock_popen.return_value.wait.return_value = 0
+        result = click.edit(filename=paths, editor="true")
+
+    assert result is None
+    args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
+    assert args[-2:] == [os.fspath(p) for p in paths]
 
 
 @pytest.mark.skipif(not WIN, reason="Windows-specific editor paths")


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

``click.edit(filename=...)`` only treated a ``str`` as a single file.
``pathlib.Path`` is not a ``str``. On Python 3.12+ it is also not
iterable, so the call raises ``TypeError: 'WindowsPath' object is not
iterable``. On earlier versions it iterated path parts and opened each
segment as a separate file.

This matches ``open_file`` and the existing ``click.Path`` param type,
which already accept ``os.PathLike``.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

fixes #2869

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->

- Tests cover a single ``Path`` and an iterable of ``Path`` values.
- ``CHANGES.md`` (the changelog file in this repo) has an 8.5.0 entry.
- Docstring notes the 8.5.0 PathLike change.
