### PR TITLE
Forward all user's parameters set in `PAGER` and improve flag detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,12 @@ Unreleased
   {func}`get_pager_file` picked for the output stream, and with
   `errors="replace"` to match the pipe backend. Any text stdout can encode
   reaches the pager.
+- The temporary file pager backend forwards any parameters the user set in
+  `PAGER` to the pager command instead of silently dropping them. On Windows,
+  `PAGER="less -R"` now invokes `less -R` on the temporary file rather than
+  bare `less`. {pr}`3777`
+- Improve raw mode detection by parsing the option tokens. {issue}`3416`
+  {pr}`3777`
 
 ## Version 8.4.2
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -488,7 +488,7 @@ def _pager_contextmanager(
     cmd_path, cmd_params = resolved
 
     if use_tempfile:
-        return _tempfilepager(cmd_path, color)
+        return _tempfilepager(cmd_path, cmd_params, color)
 
     return _pipepager(cmd_path, cmd_params, color)
 
@@ -517,6 +517,34 @@ def get_pager_file(color: bool | None = None) -> t.Generator[t.TextIO, None, Non
             writer.flush()
 
 
+def _less_uses_raw_mode(less_env: str, cmd_params: list[str]) -> bool:
+    """Detect a raw-control-characters request in a ``less`` invocation.
+
+    Parses the tokens of the ``LESS`` environment variable and the command
+    line: only short-option clusters (``-R``, ``-rX``, ``-XrY``) and the
+    ``--raw-control-chars`` long option request raw mode. Filenames and
+    long-option values may carry the letter ``r`` without being such a
+    request.
+    """
+    try:
+        env_tokens = shlex.split(less_env)
+    except ValueError:
+        # Unbalanced quotes make ``LESS`` unparsable: fall back to whitespace
+        # splitting rather than failing the pager over it.
+        env_tokens = less_env.split()
+    tokens = env_tokens + cmd_params
+
+    for token in tokens:
+        if token.startswith("--"):
+            if token.casefold() == "--raw-control-chars":
+                return True
+        elif token.startswith("-") and len(token) > 1:
+            if "r" in token[1:].casefold():
+                return True
+
+    return False
+
+
 @contextlib.contextmanager
 def _pipepager(
     cmd_path: Path, cmd_params: list[str], color: bool | None = None
@@ -535,13 +563,24 @@ def _pipepager(
     env = dict(os.environ)
 
     # If we're piping to less and the user hasn't decided on colors, we enable
-    # them by default we find the -R flag in the command line arguments.
-    if color is None and cmd_path.name == "less":
-        less_flags = f"{os.environ.get('LESS', '')}{' '.join(cmd_params)}"
-        if not less_flags:
-            env["LESS"] = "-R"
+    # them: either the invocation already requests raw control characters, or
+    # ``LESS=-R`` is injected. Match on the stem so a resolved ``less.exe`` is
+    # recognized like bare ``less``, case-insensitively on Windows since its
+    # filesystems are. POSIX keeps an exact match.
+    cmd_name = cmd_path.stem
+    if WIN:
+        # ``_pager_contextmanager`` currently routes every Windows invocation
+        # to ``_tempfilepager``, so this branch is not reachable on Windows
+        # today: it keeps the detection correct should that routing ever
+        # change.
+        cmd_name = cmd_name.casefold()
+
+    if color is None and cmd_name == "less":
+        less_env = os.environ.get("LESS", "")
+        if _less_uses_raw_mode(less_env, cmd_params):
             color = True
-        elif "r" in less_flags or "R" in less_flags:
+        elif not less_env and not cmd_params:
+            env["LESS"] = "-R"
             color = True
 
     c = subprocess.Popen(
@@ -595,14 +634,14 @@ def _pipepager(
 
 @contextlib.contextmanager
 def _tempfilepager(
-    cmd_path: Path, color: bool | None = None
+    cmd_path: Path, cmd_params: list[str], color: bool | None = None
 ) -> t.Iterator[tuple[t.TextIO, bool | None]]:
     """Page through text by invoking a program on a temporary file.
 
     Used as the primary pager strategy on Windows (where piping to
     ``more`` adds spurious ``\\r\\n``), and as a fallback on other
-    platforms. The command is invoked with the temporary file as its only
-    argument: any parameters the user set in ``PAGER`` are not passed on.
+    platforms. The command is invoked with any parameters from ``PAGER``
+    followed by the temporary file name.
     """
     import subprocess
     import tempfile
@@ -618,7 +657,7 @@ def _tempfilepager(
         yield t.cast(t.TextIO, f), color
         f.flush()
         f.close()
-        subprocess.call([str(cmd_path), f.name])
+        subprocess.call([str(cmd_path), *cmd_params, f.name])
     finally:
         # An error raised while paging skips the close() above, and Windows
         # refuses to unlink a file the process still holds open. Closing here

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -2,9 +2,11 @@ import contextlib
 import gc
 import io
 import os
+import pathlib
 import platform
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -759,6 +761,157 @@ def test_echo_via_pager_real_pager_handles_ansi(monkeypatch, capfd, color, expec
     assert out == expected
 
 
+@pytest.mark.skipif(WIN, reason="The fake pager is a shell script.")
+@pytest.mark.parametrize(
+    ("pager_name", "expected_color"),
+    [
+        pytest.param("less", True, id="less"),
+        pytest.param("less.exe", True, id="less.exe"),
+        pytest.param("LESS.EXE", False, id="upper case stays unmatched on POSIX"),
+        pytest.param("cat", False, id="not less"),
+    ],
+)
+def test_pipepager_less_detection_matches_stem(
+    monkeypatch, tmp_path, pager_name, expected_color
+):
+    """The ``less`` detection behind the ``LESS=-R`` auto-enable matches the
+    command stem, so a ``less.exe`` resolved on Windows is recognized the same
+    as a bare ``less``. POSIX keeps an exact, case-sensitive match.
+    """
+    fake_pager = tmp_path / pager_name
+    fake_pager.write_text("#!/bin/sh\ncat\n", encoding="UTF-8")
+    fake_pager.chmod(0o755)
+
+    monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
+    monkeypatch.setitem(click._termui_impl.os.environ, "PAGER", str(fake_pager))
+    monkeypatch.delitem(click._termui_impl.os.environ, "LESS", raising=False)
+
+    with click.get_pager_file() as pager:
+        assert pager.color is expected_color
+
+
+@pytest.mark.skipif(WIN, reason="The fake pager is a shell script.")
+def test_pipepager_less_detection_case_insensitive_on_windows(monkeypatch, tmp_path):
+    """Windows filesystems are case-insensitive, so ``which`` resolves
+    whatever case the file carries: the ``less`` match casefolds there.
+
+    Runs ``_pipepager`` directly: faking ``WIN`` makes
+    ``_pager_contextmanager`` route to the temp file strategy instead.
+    """
+    fake_pager = tmp_path / "LESS.EXE"
+    fake_pager.write_text("#!/bin/sh\ncat\n", encoding="UTF-8")
+    fake_pager.chmod(0o755)
+
+    monkeypatch.setattr(click._termui_impl, "WIN", True)
+    monkeypatch.delitem(click._termui_impl.os.environ, "LESS", raising=False)
+
+    with click._termui_impl._pipepager(fake_pager, []) as (_, color):
+        assert color is True
+
+
+class _FakePagerProcess:
+    """Stand-in for :class:`subprocess.Popen` recording argv and env without
+    launching a process."""
+
+    def __init__(self, argv, *, env=None, **kwargs):
+        self.argv = argv
+        self.env = env
+        self.returncode = 0
+        self.stdin = io.StringIO()
+
+    def terminate(self):
+        pass
+
+    def wait(self):
+        return 0
+
+
+@pytest.mark.parametrize(
+    ("cmd_parts", "less_env", "expected_color", "expected_less"),
+    [
+        pytest.param(["less"], None, True, "-R", id="no flags: inject LESS=-R"),
+        pytest.param(["less", "-R"], None, True, None, id="explicit -R"),
+        pytest.param(["less", "-rX"], None, True, None, id="bundled short flags"),
+        pytest.param(["less"], "-R", True, "-R", id="LESS env var"),
+        pytest.param(
+            ["less", "--RAW-CONTROL-CHARS"], None, True, None, id="long option"
+        ),
+        pytest.param(["less", "-X"], None, None, None, id="unrelated flag"),
+        pytest.param(
+            ["less"],
+            "--prompt=resume",
+            None,
+            "--prompt=resume",
+            id="long option with r substring",
+        ),
+        pytest.param(["less", "README.md"], None, None, None, id="filename with R"),
+        pytest.param(
+            ["less", "requirements.txt"], None, None, None, id="filename with r"
+        ),
+        pytest.param(
+            ["less", "--", "README.md"],
+            None,
+            None,
+            None,
+            id="option terminator shields filenames",
+        ),
+        pytest.param(
+            # The detection matches the bare long option: an ``r`` inside an
+            # option value does not request raw mode.
+            ["less", "--raw-control-chars=x"],
+            None,
+            None,
+            None,
+            id="long option with value",
+        ),
+        pytest.param(
+            # Unbalanced quotes make shlex.split raise: the detection falls
+            # back to whitespace splitting, which still finds the -R.
+            ["less"],
+            '-R "',
+            True,
+            '-R "',
+            id="unparsable LESS",
+        ),
+    ],
+)
+def test_pipepager_less_raw_mode_detection(
+    monkeypatch, cmd_parts, less_env, expected_color, expected_less
+):
+    """Raw-mode detection parses the option tokens from ``LESS`` and the
+    command line. Filenames and unrelated options carrying the letter ``r``
+    or ``R`` do not request raw mode, and ``_pipepager`` then reports no
+    opinion (``None``) that :func:`get_pager_file` settles to off.
+    {issue}`3416`
+    """
+    if less_env is None:
+        monkeypatch.delitem(click._termui_impl.os.environ, "LESS", raising=False)
+    else:
+        monkeypatch.setitem(click._termui_impl.os.environ, "LESS", less_env)
+
+    processes: list[_FakePagerProcess] = []
+
+    def fake_popen(*args, **kwargs):
+        process = _FakePagerProcess(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    # Popen is faked, so no real binary needs to exist behind the resolved
+    # path: the stem is all the less detection reads from it.
+    cmd_path = pathlib.Path("/tests/less")
+
+    with click._termui_impl._pipepager(cmd_path, cmd_parts[1:]) as (_, color):
+        pass
+
+    assert color is expected_color
+    (process,) = processes
+    if expected_less is None:
+        assert "LESS" not in process.env
+    else:
+        assert process.env["LESS"] == expected_less
+
+
 def test_echo_via_pager_streams_each_write(monkeypatch):
     """Each write is flushed so a slow generator streams to the pager
     incrementally instead of buffering until the end (issues #3242, #2542).
@@ -1013,7 +1166,8 @@ def _force_tempfile_pager(monkeypatch, pager_cmd="cat"):
     backslashes and splits on the space in ``C:\\Program Files``, leaving a
     command that resolves to nothing. Click resolves the bare name itself.
     """
-    assert shutil.which(pager_cmd) is not None, f"{pager_cmd} not available"
+    cmd = shlex.split(pager_cmd)[0]
+    assert shutil.which(cmd) is not None, f"{cmd} not available"
     monkeypatch.setattr(click._termui_impl, "isatty", lambda _: True)
     monkeypatch.setattr(click._termui_impl, "WIN", True)
     monkeypatch.setitem(click._termui_impl.os.environ, "PAGER", pager_cmd)
@@ -1073,6 +1227,22 @@ def test_tempfile_pager_handles_ansi(monkeypatch, capfd, color, expected):
     out, err = capfd.readouterr()
     assert err == ""
     assert out.replace("\r\n", "\n") == expected
+
+
+@pytest.mark.skipif(shutil.which("head") is None, reason="head not available")
+def test_tempfile_pager_passes_pager_params(monkeypatch, capfd):
+    """The temp file backend forwards ``PAGER`` parameters to the command.
+
+    ``head -n 1`` renders one line out of two when the ``-n 1`` reaches the
+    command.
+    """
+    _force_tempfile_pager(monkeypatch, pager_cmd="head -n 1")
+
+    click.echo_via_pager("line one\nline two\n")
+
+    out, err = capfd.readouterr()
+    assert err == ""
+    assert out.replace("\r\n", "\n") == "line one\n"
 
 
 @pytest.mark.skipif(shutil.which("cat") is None, reason="cat not available")


### PR DESCRIPTION
Another PR following up on pager refactors that:
- Forwards all user's parameters set in `PAGER`
- Improve detection of raw mode by extending flag and option parsing
- Fix detection of `less.exe` on Windows (even if not currently exercised, this make the method future-proof)

But more importantly: adds dozen of testing with weird edge-cases around pager's internal methods.

Follows up on:
- https://github.com/pallets/click/pull/3767
- https://github.com/pallets/click/pull/3776