### PR TITLE
AI junk

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,8 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if false, words are never split at a hyphen.
+        Useful for text made of option names, which must stay copyable.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +70,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +190,9 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    # An option name is a single token. Splitting it at a
+                    # hyphen produces something the user cannot copy or type.
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +202,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -503,6 +503,59 @@ def test_wrap_text_visible_width(body, width, initial_indent):
     assert styled_visible == plain.splitlines()
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    """An option name is a single token. Wrapping must not split it at a
+    hyphen, which would leave a fragment the user cannot copy or type.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    rendered = formatter.getvalue()
+
+    assert rendered == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+    # Every option survives intact rather than being split across lines.
+    for option in options:
+        assert option in rendered
+
+
+def test_write_usage_long_prefix_does_not_break_options_at_hyphens():
+    """The same holds on the branch where the prefix is too long and the
+    arguments move to their own line.
+
+    The width is chosen so the options still fit once wrapped; a word wider
+    than the line is broken by ``break_long_words``, which is a separate
+    mechanism and not what this test is about.
+    """
+    formatter = click.HelpFormatter(width=40)
+    formatter.write_usage(
+        "program-with-a-long-name",
+        "--a-very-long-option-name --second-long-option",
+    )
+    rendered = formatter.getvalue()
+
+    assert "--a-very-long-option-name" in rendered
+    assert "--second-long-option" in rendered
+
+
 def test_write_usage_styled_prefix_keeps_options_on_one_line():
     """End-to-end: a downstream-styled ``Usage:`` prefix should not split
     ``[OPTIONS]`` across two lines.


### PR DESCRIPTION
Fixes #3362.

## The problem

`wrap_text` builds its `TextWrapper` without setting `break_on_hyphens`, so it keeps `textwrap`'s default of `True`. That is the right default for prose — splitting a hyphenated word across lines is normal typesetting — but wrong for a usage line, which is a list of option names.

Reproducing the report on `main`:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location --user-auth-token --auto-update-interval
               --force-overwrite-existing --network-timeout-
               seconds --debug-trace-enabled
```

Three options are split. `--max-` on its own is not something a reader can copy or type, and it is not obvious from the fragment whether the newline is part of the name.

## After

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

Byte-identical to the expected output in the issue.

## The change

`wrap_text` gains a `break_on_hyphens` parameter **defaulting to `True`**, so no existing caller changes behaviour. `write_usage` passes `False` from both of its branches — the one where arguments sit beside the prefix, and the one where a long prefix pushes them onto their own line.

I kept it scoped to `write_usage` rather than flipping the default globally, since prose help text is a different case and that would be a wider behavioural change than the issue calls for.

## Tests

Two regression tests: one reproducing the report exactly and asserting the full expected output, one covering the long-prefix branch. The first fails on `main`.

Note the second test uses `width=40` deliberately — at narrower widths the option is wider than the line and `break_long_words` splits it, which is a separate mechanism and not what this fixes.

Full suite: **1993 passed, 24 skipped, 1 xfailed**.