### PR TITLE
AI junk

### DIFF
--- a/docs/extending-click.md
+++ b/docs/extending-click.md
@@ -109,7 +109,7 @@ command called `push`, it would accept `pus` as an alias (so long as it was uniq
         def resolve_command(self, ctx, args):
             # always return the full command name
             _, cmd, args = super().resolve_command(ctx, args)
-            return cmd.name, cmd, args
+            return cmd.name if cmd else None, cmd, args
 ```
 
 It can be used like this:

--- a/examples/aliases/aliases.py
+++ b/examples/aliases/aliases.py
@@ -70,7 +70,7 @@ class AliasedGroup(click.Group):
     def resolve_command(self, ctx, args):
         # always return the command's name, not the alias
         _, cmd, args = super().resolve_command(ctx, args)
-        return cmd.name, cmd, args
+        return cmd.name if cmd else None, cmd, args
 
 
 def read_config(ctx, param, value):


### PR DESCRIPTION
The `AliasedGroup` example overrides `resolve_command` and does `return cmd.name, cmd, args`. During shell completion (resilient parsing) of an unknown or mistyped command, the base `Group.resolve_command` returns `cmd = None`, so `cmd.name` raises `AttributeError: 'NoneType' object has no attribute 'name'`.

Click's base `Group.resolve_command` already guards this with `cmd_name if cmd else None`; this change makes the example do the same (`return cmd.name if cmd else None, cmd, args`). The identical bug is in the runnable `examples/aliases/aliases.py`, fixed here too.

Verified on click 8.4.2 (Python 3.14): the current example raises the AttributeError during completion of an unknown command; with the fix, completion returns the expected results.

Closes #2402.