### PR TITLE
AI junk

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1536,11 +1536,11 @@ class Command:
         if prog_name is None:
             prog_name = _detect_program_name()
 
-        # Process shell completion requests and exit early.
-        self._main_shell_completion(extra, prog_name, complete_var)
-
         try:
             try:
+                # Process shell completion requests and exit early.
+                self._main_shell_completion(extra, prog_name, complete_var)
+
                 with self.make_context(prog_name, args, **extra) as ctx:
                     rv = self.invoke(ctx)
                     if not standalone_mode:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -492,6 +492,37 @@ def test_context_settings(runner):
     assert result.output == "plain,a\nplain,b\n"
 
 
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_completion_usage_error(runner):
+    class AmbiguousGroup(Group):
+        def get_command(self, ctx, cmd_name):
+            matches = [
+                name for name in self.list_commands(ctx) if name.startswith(cmd_name)
+            ]
+
+            if len(matches) > 1:
+                ctx.fail(f"Too many matches: {', '.join(matches)}")
+
+            return super().get_command(ctx, cmd_name)
+
+    cli = AmbiguousGroup("cli", commands=[Command("interfaces"), Command("ip")])
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli i ",
+            "COMP_CWORD": "2",
+            "_CLI_COMPLETE": "bash_complete",
+        },
+    )
+
+    assert result.exit_code == 2
+    assert result.output == (
+        "Usage: cli [OPTIONS] COMMAND [ARGS]...\n"
+        "Try 'cli --help' for help.\n\n"
+        "Error: Too many matches: interfaces, ip\n"
+    )
+
+
 # case_sensitive=False normalizes values to lowercase, matching remains case insensitive
 @pytest.mark.parametrize(("value", "expect"), [(False, ["au", "al"]), (True, ["al"])])
 def test_choice_case_sensitive(value, expect):


### PR DESCRIPTION
Fixes #2853

Shell completion is currently dispatched before `Command.main()` enters its normal `ClickException` handling boundary. If a custom `Group.get_command()` calls `ctx.fail()` while resolving completion input, the resulting `UsageError` escapes and the shell displays a traceback.

This moves completion dispatch inside the existing exception boundary. Successful completion still exits early as before, while Click usage errors now use the standard concise error presentation. The regression test models an ambiguous prefix in a custom group and verifies the formatted message and exit code.

Tests:

- `python -m pytest tests/test_shell_completion.py -q` (59 passed)
- `python -m pytest -q` (1845 passed, 95 skipped, 31000 deselected, 1 xfailed)
- `ruff format --check src/click/core.py tests/test_shell_completion.py`
- `ruff check src/click/core.py tests/test_shell_completion.py`

AI assistance: Codex was used for issue discovery, implementation support, and test execution. I reviewed the resulting change and test coverage.