### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@ Unreleased
   {pr}`3777`
 - {func}`edit` accepts `os.PathLike` values for `filename`, in addition to
   strings. {issue}`2869` {pr}`3781`
+- {meth}`Context.invoke` and {meth}`Context.forward` record parameter
+  sources on the child context so {meth}`Context.get_parameter_source`
+  no longer returns `None`. {issue}`2753`
 
 ## Version 8.4.2
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -867,6 +867,11 @@ class Context:
             (options and click arguments) must be keyword arguments and Click
             will fill in defaults.
 
+        .. versionchanged:: 8.5
+            Parameter sources are recorded on the child context, so
+            :meth:`get_parameter_source` no longer returns ``None`` after
+            :meth:`invoke` or :meth:`forward`.
+
         .. versionchanged:: 8.0
             All ``kwargs`` are tracked in :attr:`params` so they will be
             passed if :meth:`forward` is called at multiple levels.
@@ -899,6 +904,14 @@ class Context:
                     if default_value is UNSET:
                         default_value = None
                     kwargs[param.name] = param.type_cast_value(ctx, default_value)
+                    ctx.set_parameter_source(param.name, ParameterSource.DEFAULT)
+                elif param.expose_value:
+                    # Forwarded values keep the parent's source. Explicit
+                    # invoke kwargs without one are treated as DEFAULT.
+                    source = self.get_parameter_source(param.name)
+                    if source is None:
+                        source = ParameterSource.DEFAULT
+                    ctx.set_parameter_source(param.name, source)
 
             # Track all kwargs as params, so that forward() will pass
             # them on in subsequent calls.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 import click
+from click.core import ParameterSource
 
 
 def test_other_command_invoke(runner):
@@ -39,6 +40,45 @@ def test_other_command_forward(runner):
     result = runner.invoke(cli, ["dist"])
     assert not result.exception
     assert result.output == "Count: 1\nCount: 42\n"
+
+
+def test_invoke_forward_parameter_source(runner):
+    # Repro from https://github.com/pallets/click/issues/2753
+    cli = click.Group()
+    sources = []
+
+    @cli.command()
+    @click.option("--count", default=1)
+    @click.pass_context
+    def test(ctx, count):
+        sources.append((count, ctx.get_parameter_source("count")))
+
+    @cli.command()
+    @click.option("--count", default=1)
+    @click.pass_context
+    def dist(ctx, count):
+        ctx.forward(test)
+        ctx.invoke(test, count=42)
+
+    result = runner.invoke(cli, ["test"])
+    assert not result.exception
+    assert sources == [(1, ParameterSource.DEFAULT)]
+
+    sources.clear()
+    result = runner.invoke(cli, ["dist"])
+    assert not result.exception
+    assert sources == [
+        (1, ParameterSource.DEFAULT),
+        (42, ParameterSource.DEFAULT),
+    ]
+
+    sources.clear()
+    result = runner.invoke(cli, ["dist", "--count", "5"])
+    assert not result.exception
+    assert sources == [
+        (5, ParameterSource.COMMANDLINE),
+        (42, ParameterSource.COMMANDLINE),
+    ]
 
 
 def test_forwarded_params_consistency(runner):


### PR DESCRIPTION
`Context.invoke()` and `Context.forward()` create a child context and fill in parameter values, but they never recorded `_parameter_source`. After those calls, `get_parameter_source()` returned `None` even though a direct CLI invocation of the same command reports `ParameterSource.DEFAULT`.

Defaults filled by invoke are recorded as `DEFAULT`. Values taken from the caller (including `forward`) keep the parent source when it is known.

Fixes #2753