### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- `HelpFormatter.write_usage` no longer breaks a hyphenated option or
+  argument name (e.g. `--max-retry-count`) across two lines when wrapping
+  the usage line. `wrap_text` gained a `break_on_hyphens` parameter
+  (default `True`, matching prior behavior for other callers) to control
+  this. {issue}`3362`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,12 +53,20 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is unset, words are only split at
+                             whitespace instead of also at hyphens, so a
+                             single hyphenated token (like an
+                             ``--option-name``) is never broken across
+                             lines.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
         ``text``, ``initial_indent``, or ``subsequent_indent`` no longer
         count toward the width budget, so styled input wraps based on what
         the user sees instead of raw byte length.
+
+    .. versionadded:: 8.6.0
+        Added the ``break_on_hyphens`` parameter.
     """
     from ._textwrap import TextWrapper
 
@@ -67,6 +76,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +196,10 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    # Args are option/argument names, e.g. "--max-retry-count".
+                    # Breaking one at an internal hyphen (the textwrap
+                    # default) makes it unrecognizable as a single token.
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +209,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -517,6 +517,56 @@ def test_write_usage_styled_prefix_keeps_options_on_one_line():
     assert visible == "Usage: cli [OPTIONS]\n"
 
 
+def test_write_usage_does_not_break_hyphenated_option_names():
+    """Issue #3362: wrapping the usage line must never split a single
+    hyphenated option name (like ``--max-retry-count``) at one of its
+    internal hyphens -- only at whitespace between tokens.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+
+    assert formatter.getvalue().splitlines() == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location --user-auth-token",
+        "               --auto-update-interval --force-overwrite-existing",
+        "               --network-timeout-seconds --debug-trace-enabled",
+    ]
+
+
+def test_wrap_text_break_on_hyphens_default_still_breaks_prose():
+    """``break_on_hyphens`` defaults to the pre-existing behaviour (``True``)
+    so callers other than ``write_usage`` -- prose help text, option
+    descriptions -- keep wrapping hyphenated compound words the way
+    ``textwrap`` always has.
+    """
+    text = "a state-of-the-art description"
+
+    assert (
+        click.formatting.wrap_text(text, width=16) == "a state-of-the-\nart description"
+    )
+    # With break_on_hyphens=False, "state-of-the-art" doesn't fit after "a "
+    # at this width, so the whole word moves to its own line instead of
+    # being split at one of its internal hyphens.
+    assert (
+        click.formatting.wrap_text(text, width=16, break_on_hyphens=False)
+        == "a\nstate-of-the-art\ndescription"
+    )
+
+
 @pytest.mark.parametrize(
     ("formatter_kwargs", "current_indent", "prog", "args", "prefix", "expected"),
     [


### PR DESCRIPTION
Fixes #3362.

## What

`HelpFormatter.write_usage` wraps the "Usage: ..." line via `wrap_text`, which builds a stdlib `textwrap.TextWrapper` without overriding `break_on_hyphens` (default `True`). `textwrap` treats each internal hyphen in a word as a valid break point, so a long option name like `--max-retry-count` could get split mid-token across two lines (`"--max-\nretry-count"`), making it unrecognizable as a single flag.

## Fix

Added a `break_on_hyphens` parameter to `wrap_text` (default `True`, so every other current caller -- `write_text`'s prose help descriptions, `write_dl`'s option-description column -- keeps wrapping hyphenated compound words exactly as before) and pass `break_on_hyphens=False` from `write_usage`'s two `wrap_text` call sites, since usage-line tokens are option/argument names, not prose that should hyphenate like normal English text.

## Testing

- `test_write_usage_does_not_break_hyphenated_option_names` uses the exact reproduction and width from #3362 -- asserts the precise expected output from the issue, line for line.
- `test_wrap_text_break_on_hyphens_default_still_breaks_prose` confirms `write_text`/`write_dl`'s hyphen-breaking for prose is unaffected by the new parameter's default.
- Verified as a negative control: both new tests fail on unfixed source with the exact reported symptom (mid-hyphen break / missing parameter -- see commit message for the exact diff), and the whole test suite (1915 tests) plus `ruff check`/`ruff format --diff` and `mypy` are clean with the fix applied.

## Notes for review

- Added a `CHANGES.md` entry under a new `## Unreleased` section, but left the `{pr}` role off since the PR number wasn't assigned yet -- happy to fill it in, or you're welcome to during merge.
- The `.. versionadded:: 8.6.0` docstring directive is my best guess at the next release version; please adjust if this lands as a different version number.
