### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Released 2026-08-24
   5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
   completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate
   the completion script. {issue}`2672` {pr}`3637`
+- Shell completion for long options written with `=` now preserves the option
+  name when completing the value, such as `--color=al` completing to
+  `--color=always` instead of `always`. {issue}`2847`
 - Supported versions of Windows enable ANSI terminal styles by default.
   Colorama is no longer a dependency and is not used. {issue}`2986` {pr}`3505`
 - {class}`Argument` accepts a `help` parameter, and help output includes

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -362,8 +362,28 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(
+            ctx, args, incomplete
+        )
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            prefixed_completions: list[CompletionItem[str]] = []
+
+            for item in completions:
+                if item.type == "plain":
+                    item = CompletionItem(
+                        f"{completion_prefix}{item.value}",
+                        item.type,
+                        item.help,
+                        **item._info,
+                    )
+
+                prefixed_completions.append(item)
+
+            completions = prefixed_completions
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the
@@ -756,9 +776,10 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str]:
     """Find the Click object that will handle the completion of the
-    incomplete value. Return the object and the incomplete value.
+    incomplete value. Return the object, incomplete value, and any
+    prefix to add back to plain completion values.
 
     :param ctx: Invocation context for the command represented by
         the parsed complete args.
@@ -767,20 +788,27 @@ def _resolve_incomplete(
     """
     # Different shells treat an "=" between a long option name and
     # value differently. Might keep the value joined, return the "="
-    # as a separate item, or return the split name and value. Always
-    # split and discard the "=" to make completion easier.
+    # as a separate item, or return the split name and value. Split and
+    # discard the "=" to make completion easier, then add it back to
+    # plain completion values so the shell replaces the whole word.
+    completion_prefix = ""
+
     if incomplete == "=":
         incomplete = ""
+
+        if args and _start_of_option(ctx, args[-1]):
+            completion_prefix = f"{args[-1]}="
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, ""
 
     params = ctx.command.get_params(ctx)
 
@@ -788,14 +816,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, ""
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, ""

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -150,6 +150,37 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+@pytest.mark.parametrize(
+    ("shell", "env", "expect"),
+    [
+        (
+            "bash",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain,--color=auto\nplain,--color=always\n",
+        ),
+        (
+            "zsh",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\n",
+        ),
+        (
+            "powershell",
+            {"COMP_WORDS": "cli --color=a", "COMP_CWORD": "1"},
+            "plain\n--color=auto\n_\nplain\n--color=always\n_\n",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_long_option_equals_value_completion(runner, shell, env, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    env["_CLI_COMPLETE"] = f"{shell}_complete"
+    result = runner.invoke(cli, env=env)
+    assert result.output == expect
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
﻿### Problem

Completing a long option value written with `=` loses the option name. For a choice option such as `--color`, shell completion for `--color=a` returns `auto` and `always`, which can replace the whole current word instead of preserving `--color=`.

Closes #2847

### Reproducer

```text
$ _CLI_COMPLETE=bash_complete COMP_WORDS="cli --color=a" COMP_CWORD=1 cli
# before: plain,auto
# before: plain,always
# expected: plain,--color=auto
# expected: plain,--color=always
```

### Fix

Track the `--option=` prefix while resolving an incomplete option value, use the value after `=` for matching, then add the prefix back to plain completion items before shell-specific formatting.

### Testing

Added `test_long_option_equals_value_completion` covering bash, zsh, and PowerShell. Ran:

```text
python -m pytest tests\test_shell_completion.py::test_long_option_equals_value_completion -q
python -m pytest tests\test_shell_completion.py -q
python -m pytest
```
