### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 8.5.1
+
+Unreleased
+
+- {meth}`HelpFormatter.write_usage` no longer splits a hyphenated argument
+  across lines. {func}`wrap_text` accepts a `break_on_hyphens` argument to
+  control this. {issue}`3362`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,12 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then wrapping may break a
+                             word after a hyphen. Disable this for text made
+                             of hyphenated tokens such as option names.
+
+    .. versionchanged:: 8.5.1
+        Added the ``break_on_hyphens`` parameter.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +74,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -162,6 +170,9 @@ class HelpFormatter:
         :param args: whitespace separated list of arguments.
         :param prefix: The prefix for the first line. Defaults to
             ``"Usage: "``.
+
+        .. versionchanged:: 8.5.1
+            Wrapping no longer breaks an argument at a hyphen it contains.
         """
         if prefix is None:
             prefix = "{usage} ".format(usage=_("Usage:"))
@@ -186,6 +197,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +207,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,3 +630,61 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_wrap_text_break_on_hyphens():
+    """``wrap_text`` may break after a hyphen by default. That is disabled
+    when ``break_on_hyphens`` is false so a hyphenated token stays whole.
+    """
+    text = "alpha --max-retry-count"
+    assert click.wrap_text(text, width=20) == "alpha --max-retry-\ncount"
+    assert (
+        click.wrap_text(text, width=20, break_on_hyphens=False)
+        == "alpha\n--max-retry-count"
+    )
+
+
+def test_write_usage_keeps_hyphenated_options_whole():
+    """Issue #3362: an option reaching the wrap width used to be split at
+    an internal hyphen, so ``--max-retry-count`` became ``--max-`` /
+    ``retry-count``.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    text = formatter.getvalue()
+
+    for option in options:
+        assert option in text
+
+    assert text == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+
+def test_write_usage_keeps_hyphenated_options_whole_when_prefix_wraps():
+    """The write_usage branch that puts arguments on their own line wraps
+    hyphenated tokens the same way.
+    """
+    formatter = click.HelpFormatter(width=31)
+    formatter.write_usage(
+        "a-program-with-a-very-long-name", "[OPTIONS] --max-retry-count"
+    )
+    text = formatter.getvalue()
+    assert "--max-retry-count" in text
+    assert "--max-\n" not in text


### PR DESCRIPTION
## Summary

`HelpFormatter.write_usage` wraps its argument string with `wrap_text`, which uses `textwrap.TextWrapper`'s default `break_on_hyphens=True`. When a hyphenated option sits at the wrap width it is split mid-token, for example `--max-retry-count` becomes `--max-` on one line and `retry-count` on the next.

## Related Issue

Fixes #3362

## Changes Made

- Add a `break_on_hyphens` argument to `wrap_text` (default `True`, so help body text is unchanged).
- Pass `break_on_hyphens=False` from both wrapping branches of `HelpFormatter.write_usage`.
- Changelog entry under 8.5.1.

## Testing

- `pytest tests/test_formatting.py` (40 passed)
- `pytest` (1994 passed, 24 skipped, 1 xfailed)
- `ruff check` / `ruff format` on the touched files

The new tests cover `wrap_text` itself, the issue's usage-line reproduction at width 65, and the long-prefix branch of `write_usage`.

## Notes

Help text wrapping is unchanged. A token that is itself wider than the line can still be broken by `break_long_words`.