### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 8.5.1
+
+Unreleased
+
+- Shell completion no longer dumps a traceback when a custom
+  {meth}`Group.get_command` raises {exc}`UsageError` (for example via
+  {meth}`Context.fail`). The error is shown the same way as during a
+  normal invocation. {issue}`2853`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1623,7 +1623,15 @@ class Command:
 
         from .shell_completion import shell_complete
 
-        rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
+        try:
+            rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
+        except ClickException as e:
+            # Completion is dispatched before Command.main's exception
+            # handler. A custom Group.get_command that calls ctx.fail()
+            # would otherwise dump a traceback into the shell.
+            e.show()
+            sys.exit(e.exit_code)
+
         sys.exit(rv)
 
     def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -492,6 +492,54 @@ def test_context_settings(runner):
     assert result.output == "plain,a\nplain,b\n"
 
 
+class _AmbiguousPrefixGroup(Group):
+    """Matches the documented alias-group pattern that calls ``ctx.fail``
+    when a prefix is not unique.
+    """
+
+    def get_command(self, ctx, cmd_name):
+        matches = [
+            name for name in self.list_commands(ctx) if name.startswith(cmd_name)
+        ]
+        if len(matches) > 1:
+            ctx.fail(f"Too many matches: {', '.join(sorted(matches))}")
+        if len(matches) == 1:
+            return super().get_command(ctx, matches[0])
+        return super().get_command(ctx, cmd_name)
+
+
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_completion_usage_error_is_not_a_traceback(runner):
+    """Issue #2853: ``get_command`` may raise ``UsageError`` while
+    resolving completion input. That used to escape ``Command.main``
+    and print a traceback.
+    """
+    cli = _AmbiguousPrefixGroup("cli", commands=[Command("interfaces"), Command("ip")])
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli i ",
+            "COMP_CWORD": "2",
+            "_CLI_COMPLETE": "bash_complete",
+        },
+    )
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert result.output == (
+        "Usage: cli [OPTIONS] COMMAND [ARGS]...\n"
+        "Try 'cli --help' for help.\n\n"
+        "Error: Too many matches: interfaces, ip\n"
+    )
+
+
+def test_ambiguous_prefix_still_fails_on_invoke(runner):
+    cli = _AmbiguousPrefixGroup("cli", commands=[Command("interfaces"), Command("ip")])
+    result = runner.invoke(cli, ["i"])
+    assert result.exit_code == 2
+    assert "Too many matches: interfaces, ip" in result.output
+    assert "Traceback" not in result.output
+
+
 # case_sensitive=False normalizes values to lowercase, matching remains case insensitive
 @pytest.mark.parametrize(("value", "expect"), [(False, ["au", "al"]), (True, ["al"])])
 def test_choice_case_sensitive(value, expect):


### PR DESCRIPTION
## Summary

`Command.main` handles shell completion before it enters the `ClickException` handler. A custom `Group.get_command` that calls `ctx.fail()` (the documented alias/prefix pattern) therefore prints a traceback during tab completion instead of the usage error.

Normal invocation of the same prefix already shows `Error: Too many matches: ...` and exits 2. Completion should do the same.

## Related Issue

Fixes #2853

## Changes Made

- Catch `ClickException` in `Command._main_shell_completion`, call `show()`, and exit with the exception's exit code.
- Successful completion still exits early with the completer's status code.

## Testing

- `pytest tests/test_shell_completion.py tests/test_commands.py tests/test_basic.py` (265 passed)
- `pytest` (1993 passed, 24 skipped, 1 xfailed)
- `ruff check` / `ruff format` on the touched files

Tests use the documented ambiguous-prefix `get_command` pattern: completion of `cli i ` no longer traceback, and a normal `cli i` invoke still reports the usage error.

## Notes

Completion still uses `resilient_parsing` for missing commands and invalid values. This only covers exceptions that `get_command` (or similar) raises on purpose via `ctx.fail()`.
