### PR TITLE
AI junk

### DIFF
--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,9 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then words longer than the
+                             width will be broken on hyphens (defaults to
+                             True, matching :func:`textwrap.wrap`).
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +71,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +191,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +201,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -590,6 +590,24 @@ def test_help_formatter_write_usage(
     assert f.getvalue() == expected
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    """Usage lines wrap on spaces, not mid-option at hyphens (#3362)."""
+    f = click.HelpFormatter(width=65)
+    f.write_usage(
+        "program",
+        "--output-file-path --max-retry-count --disable-cache-mode "
+        "--config-file-location --verbose-logging-mode --input-source-format "
+        "--parallel-worker-count --request-timeout-secs --retry-backoff-factor "
+        "--stream-chunk-size",
+    )
+    rendered = f.getvalue()
+    assert "--max-retry-count" in rendered
+    assert "--disable-cache-mode" in rendered
+    assert not any(
+        line.rstrip().endswith("-") for line in rendered.splitlines()
+    ), "options must not be split at hyphens"
+
+
 def test_help_formatter_write_usage_without_args_styled_prefix():
     """A downstream-styled prefix is preserved when ``args`` is empty:
     the ANSI escape sequences survive, only the trailing separator is

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -603,9 +603,9 @@ def test_write_usage_does_not_break_options_at_hyphens():
     rendered = f.getvalue()
     assert "--max-retry-count" in rendered
     assert "--disable-cache-mode" in rendered
-    assert not any(
-        line.rstrip().endswith("-") for line in rendered.splitlines()
-    ), "options must not be split at hyphens"
+    assert not any(line.rstrip().endswith("-") for line in rendered.splitlines()), (
+        "options must not be split at hyphens"
+    )
 
 
 def test_help_formatter_write_usage_without_args_styled_prefix():


### PR DESCRIPTION
## What

`HelpFormatter.write_usage()` wraps the argument string with `wrap_text`, which breaks long lines at hyphens by default. Usage lines for commands with many hyphenated options were rendered mid-option, e.g. at width 65:

```
Usage: program --output-file-path --max-retry-count --disable-
               cache-mode --config-file-location --verbose-
               logging-mode ...
```

Fixes #3362.

## Change

- `wrap_text` gains a `break_on_hyphens` parameter (default `True`, so `write_text` and other callers are unchanged).
- `write_usage` wraps usage arguments with `break_on_hyphens=False`, so wrapping happens on spaces only and options stay intact.

## Tests

- New `test_write_usage_does_not_break_options_at_hyphens` with the issue's repro (10 hyphenated options at width 65): options remain intact and no line ends with a dangling `-`. Fails on the previous implementation (verified) and passes with the fix.
- Full suite: 1992 passed, 24 skipped, 1 xfailed. ruff + mypy clean.