### PR TITLE
Fix `copy`, `deepcopy` and `pickle` of `Sentinel` members

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 8.5.1
+
+Unreleased
+
+- Fix `copy.deepcopy()` and `pickle` on a `Parameter`, `Option` or `Command`. {pr}`3805`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/_utils.py
+++ b/src/click/_utils.py
@@ -18,6 +18,15 @@ class Sentinel(enum.Enum):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
 
+    def __copy__(self) -> Sentinel:
+        return self
+
+    def __deepcopy__(self, memo: dict[int, t.Any]) -> Sentinel:
+        return self
+
+    def __reduce_ex__(self, protocol: object) -> tuple[t.Any, ...]:
+        return getattr, (self.__class__, self.name)
+
 
 UNSET: t.Literal[Sentinel.UNSET] = Sentinel.UNSET
 """Sentinel used to indicate that a value is not set."""

--- a/tests/test_utils/test_sentinel.py
+++ b/tests/test_utils/test_sentinel.py
@@ -1,6 +1,12 @@
+import copy
+import pickle
 from decimal import Decimal
 from fractions import Fraction
 
+import pytest
+
+import click
+from click._utils import Sentinel
 from click._utils import UNSET
 
 
@@ -50,3 +56,42 @@ def test_unset_sentinel():
         assert value is not real_value
 
     assert value not in real_values
+
+
+@pytest.mark.parametrize("sentinel", tuple(Sentinel))
+@pytest.mark.parametrize(
+    "duplicate",
+    (
+        copy.copy,
+        copy.deepcopy,
+        lambda value: pickle.loads(pickle.dumps(value)),
+    ),
+    ids=("copy", "deepcopy", "pickle"),
+)
+def test_sentinel_duplication_preserves_identity(sentinel, duplicate):
+    """Sentinels are singletons: copying or pickling one returns the member.
+
+    The default ``Enum`` reduction is ``(cls, (member.value,))``, which cannot
+    round-trip a bare ``object()`` value: the copy or the unpickled value is a
+    new object and ``Sentinel()`` rejects it.
+    """
+    assert duplicate(sentinel) is sentinel
+
+
+@pytest.mark.parametrize(
+    "duplicate",
+    (
+        copy.copy,
+        copy.deepcopy,
+        lambda value: pickle.loads(pickle.dumps(value)),
+    ),
+    ids=("copy", "deepcopy", "pickle"),
+)
+def test_parameter_duplication(duplicate):
+    """Every ``Parameter`` holds ``UNSET`` in ``default`` unless one is given."""
+    option = click.Option(["--name"])
+    assert option.default is UNSET
+
+    duplicated = duplicate(option)
+    assert duplicated.default is UNSET
+    assert duplicated.name == "name"


### PR DESCRIPTION
Just a small issue I encountered on Python 3.10, where `Enum` has no `__deepcopy__`. Now that every parameter have a sentinel, `copy.deepcopy()` of any `Option`, `Argument` or `Command` fails on Python 3.10. And `pickle` fails on every Python version. This PR fix this issue.