### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Unreleased
 
+- Document that ``launch(wait=True)`` avoids leaving a zombie ``xdg-open``
+  process when running under WSL. {issue}`2154`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -248,6 +248,9 @@ click.launch("https://click.palletsprojects.com/")
 click.launch("/my/downloaded/file.txt", locate=True)
 ```
 
+When running under WSL, pass ``wait=True`` to wait for ``xdg-open`` to exit
+and avoid leaving a zombie process.
+
 ## Printing Filenames
 
 Because filenames might not be Unicode, formatting them can be a bit tricky.

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -927,7 +927,8 @@ def launch(url: str, wait: bool = False, locate: bool = False) -> int:
     :param url: URL or filename of the thing to launch.
     :param wait: Wait for the program to exit before returning. This
         only works if the launched program blocks. In particular,
-        ``xdg-open`` on Linux does not block.
+        ``xdg-open`` on Linux does not block. Set this to ``True`` when
+        running under WSL to avoid leaving a zombie ``xdg-open`` process.
     :param locate: if this is set to `True` then instead of launching the
                    application associated with the URL it will attempt to
                    launch a file manager with the file located.  This


### PR DESCRIPTION
Closes #2154.

Clarify that launching files and URLs from WSL may require waiting for the Windows-side process, and document the behavior alongside the implementation note and changelog.