### PR TITLE
Document type auto-conversion and test `set` and `frozenset`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
 - A `KeyboardInterrupt` arriving while `Command.main()` reports an abort or an error,
   or while it exits, no longer escapes as an unhandled traceback. The command still
   exits with the intended code; only the message may be lost. {issue}`3802`
+- Document which types are inferred from `default`, and what an unrecognized
+  `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
 
 ## Version 8.5.0
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -45,8 +45,10 @@ And from the command line:
 ```
 
 An argument may be assigned a {ref}`parameter type <parameter-types>`.
-If no type is provided, the type of the default value is used. If no
-default value is provided, the type is assumed to be {data}`STRING`.
+If no type is provided, the type of the default value is used if it is
+recognized, otherwise {data}`STRING` is used. If no default value is
+provided, the type is assumed to be {data}`STRING`. See
+{ref}`type-inference` for the types that are recognized.
 
 ```{admonition} Note on Required Arguments
 :class: note

--- a/docs/parameter-types.md
+++ b/docs/parameter-types.md
@@ -153,6 +153,58 @@ The supported parameter {ref}`click-api-types` are
        :noindex:
 ```
 
+(type-inference)=
+
+## How Click Infers a Type
+
+When `type` is not given, Click infers it from `default`. Only the defaults listed below
+are recognized. Every other default gives {data}`STRING`.
+
+| `default`                                        | Inferred type                                   |
+| ------------------------------------------------ | ----------------------------------------------- |
+| not given, or `None`                             | {data}`STRING`                                  |
+| `"git"`                                          | {data}`STRING`                                  |
+| `5`                                              | {data}`INT`                                     |
+| `1.5`                                            | {data}`FLOAT`                                   |
+| `True`                                           | {data}`BOOL`                                    |
+| `[]` or `()`                                     | {data}`STRING`                                  |
+| `[1, 2]` or `(1, 2)`                             | {data}`INT`                                     |
+| `[1.5, 2.5]`                                     | {data}`FLOAT`                                   |
+| `[1, "git"]`                                     | {data}`INT`                                     |
+| `[(1, "git")]`                                   | {class}`Tuple` of ({data}`INT`, {data}`STRING`) |
+| `{1, 2}` or `frozenset({1, 2})`                  | {data}`STRING`                                  |
+| `{"a": 1}`                                       | {data}`STRING`                                  |
+| {class}`uuid.UUID` or {class}`datetime.datetime` | {data}`STRING`                                  |
+| `b"git"`, or any other object                    | {data}`STRING`                                  |
+
+A `list` or `tuple` gives the type of its **first item only**, so `[1, "git"]` gives
+{data}`INT` and the second item is converted with it. A first item that is itself a
+`list` or `tuple` gives a {class}`Tuple`, which also sets `nargs`.
+
+A `set`, a `frozenset`, a `dict`, and a type Click ships but does not guess, such as
+{class}`uuid.UUID`, all land in the last group. Their default is converted with
+{data}`STRING`, so the command receives the `str()` form of the value.
+
+```{eval-rst}
+.. click:example::
+
+    @click.command()
+    @click.option('--count', default=5)
+    @click.option('--tag', default={'git'})
+    def show(count, tag):
+        click.echo(f"count is {type(count).__name__}, tag is {type(tag).__name__}")
+
+.. click:run::
+
+    invoke(show, args=[])
+```
+
+When `type` is given a callable Click does not recognize, that callable is called on the
+string coming from the command line, and a `ValueError` it raises is reported as a bad
+parameter. A container is rarely useful there, because calling it on a string splits the
+string: `set` turns `"git"` into `{"g", "i", "t"}`. Pass a {class}`ParamType` instead,
+as described in [](#how-to-implement-custom-types).
+
 ## How to Implement Custom Types
 
 To implement a custom type, you need to subclass the {class}`ParamType` class. For simple cases, passing a Python

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -182,6 +182,10 @@ def test_shared_param_prefers_first_default(runner):
         ({"key": 0}, "key", 0),
         ({"key": ""}, "key", ""),
         ({"key": False}, "key", False),
+        # Falsy containers are returned as-is too.
+        ({"key": set()}, "key", set()),
+        ({"key": frozenset()}, "key", frozenset()),
+        ({"key": {}}, "key", {}),
     ],
 )
 def test_lookup_default_returns_hides_sentinel(default_map, key, expected):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -430,6 +430,23 @@ def test_multiple_envvar(runner):
     assert not result.exception
     assert result.output == "foo|bar|baz\n"
 
+
+def test_envvar_container_type(runner):
+    """Env vars are plain strings, so a container type splits them character-wise.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+
+    @click.command()
+    @click.option("--x", envvar="X", type=frozenset)
+    def cli(x):
+        assert isinstance(x, frozenset)
+        click.echo("".join(sorted(x)))
+
+    result = runner.invoke(cli, [], env={"X": "git"})
+    assert not result.exception
+    assert result.output == "git\n"
+
     @click.command()
     @click.option("--arg", multiple=True, envvar="X")
     def cmd(arg):
@@ -594,6 +611,25 @@ def test_show_default_default_map(runner):
     assert "[default: b]" in result.output
 
 
+def test_show_default_container_defaults(runner):
+    """Container defaults are rendered through ``str()`` in the help output.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+
+    @click.command()
+    @click.option("--a", default=frozenset(["git"]), type=frozenset, show_default=True)
+    @click.option("--b", default={"a": 1}, type=dict, show_default=True)
+    @click.option("--c", default={"git"}, type=set, show_default=True)
+    def cli(a, b, c):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert "[default: frozenset({'git'})]" in result.output
+    assert "[default: {'a': 1}]" in result.output
+    assert "[default: {'git'}]" in result.output
+
+
 def test_multiple_default_type():
     opt = click.Option(["-a"], multiple=True, default=(1, 2))
     assert opt.nargs == 1
@@ -611,6 +647,29 @@ def test_multiple_default_composite_type():
     assert opt.type.types == [click.INT, click.STRING]
     ctx = click.Context(click.Command("test"))
     assert opt.type_cast_value(ctx, opt.get_default(ctx)) == ((1, "a"),)
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        set(),
+        {1, 2},
+        frozenset(),
+        frozenset(["git"]),
+        {},
+        {"a": 1},
+    ],
+)
+def test_type_from_default_container(default):
+    """Container defaults have no native Click type and fall back to STRING.
+
+    The documented "if no type is provided, the type of the default value is
+    used" rule does not apply to ``set``, ``frozenset`` or ``dict`` defaults.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    opt = click.Option(["-a"], default=default)
+    assert opt.type is click.STRING
 
 
 def test_parse_multiple_default_composite_type(runner):
@@ -1424,6 +1483,10 @@ def test_type_from_flag_value():
     param = click.Option(["-c", "x"], flag_value=EngineType.OSS)
     assert param.type is click.UNPROCESSED
     param = click.Option(["-d", "x"], flag_value=frozenset())
+    assert param.type is click.UNPROCESSED
+    param = click.Option(["-e", "x"], flag_value=set())
+    assert param.type is click.UNPROCESSED
+    param = click.Option(["-f", "x"], flag_value={})
     assert param.type is click.UNPROCESSED
 
 
@@ -2536,8 +2599,25 @@ def test_flag_value_not_stringified_for_custom_types(runner):
     assert result.output == repr(EngineType.PRO)
 
 
-def test_custom_type_frozenset_flag_value(runner):
-    """Check that frozenset is correctly handled as a type, a flag value and a default.
+@pytest.mark.parametrize(
+    ("container_type", "flag_value", "default", "default_output", "flag_output"),
+    [
+        (set, set(), {"git"}, "{'git'}", "set()"),
+        (
+            frozenset,
+            frozenset(),
+            frozenset(["git"]),
+            "frozenset({'git'})",
+            "frozenset()",
+        ),
+        (dict, dict(), {"git": True}, "{'git': True}", "{}"),
+    ],
+)
+def test_custom_type_container_flag_value(
+    runner, container_type, flag_value, default, default_output, flag_output
+):
+    """Check that container types are correctly handled as a type, a flag value
+    and a default.
 
     Reproduces https://github.com/pallets/click/issues/2610
     """
@@ -2547,19 +2627,19 @@ def test_custom_type_frozenset_flag_value(runner):
         "--without-scm-ignore-files",
         "scm_ignore_files",
         is_flag=True,
-        type=frozenset,
-        flag_value=frozenset(),
-        default=frozenset(["git"]),
+        type=container_type,
+        flag_value=flag_value,
+        default=default,
     )
     def rcli(scm_ignore_files):
         click.echo(repr(scm_ignore_files), nl=False)
 
     result = runner.invoke(rcli)
-    assert result.stdout == "frozenset({'git'})"
+    assert result.stdout == default_output
     assert result.exit_code == 0
 
     result = runner.invoke(rcli, ["--without-scm-ignore-files"])
-    assert result.stdout == "frozenset()"
+    assert result.stdout == flag_output
     assert result.exit_code == 0
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,4 @@
+import datetime
 import os.path
 import pathlib
 import platform
@@ -5,11 +6,14 @@ import subprocess
 import sys
 import tempfile
 import typing as t
+import uuid
 
 import pytest
 
 import click
 from click import FileError
+from click.types import convert_type
+from click.types import FuncParamType
 
 
 @pytest.mark.parametrize(
@@ -330,3 +334,105 @@ def test_param_type_subclass_omitting_input_parameter():
     doubling = DoublingType()
     assert doubling("21") == 42
     assert doubling(None) is None
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        # Empty sequences fall back to STRING because ``_guess_type`` returns None.
+        [],
+        (),
+        # Container types are guessed from the default but are not natively
+        # supported, so they reach STRING through a different code path.
+        set(),
+        {1, 2},
+        frozenset(),
+        frozenset(["git"]),
+        {},
+        {"a": 1},
+    ],
+)
+def test_convert_type_from_container_default(default):
+    """Container defaults are not natively supported and fall back to STRING.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    assert convert_type(None, default) is click.STRING
+
+
+@pytest.mark.parametrize(
+    ("container_type", "value", "expected"),
+    [
+        (set, "a,b,c", {"a", ",", "b", "c"}),
+        (frozenset, "abc", frozenset({"a", "b", "c"})),
+    ],
+)
+def test_explicit_container_type_splits_string(container_type, value, expected):
+    """An explicit ``set`` or ``frozenset`` type wraps the builtin in a
+    ``FuncParamType``, which splits CLI strings character-wise.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    param_type = convert_type(container_type)
+    assert isinstance(param_type, FuncParamType)
+    assert param_type.convert(value, None, None) == expected
+
+
+def test_explicit_dict_type_rejects_string():
+    """An explicit ``dict`` type cannot convert a plain CLI string at all.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    param_type = convert_type(dict)
+    assert isinstance(param_type, FuncParamType)
+    with pytest.raises(click.BadParameter):
+        param_type.convert("abc", None, None)
+
+
+@pytest.mark.parametrize(
+    ("default", "expected"),
+    [
+        # Recognized scalars.
+        (None, click.STRING),
+        ("git", click.STRING),
+        (5, click.INT),
+        (1.5, click.FLOAT),
+        (True, click.BOOL),
+        # An empty sequence gives no item to read.
+        ([], click.STRING),
+        ((), click.STRING),
+        # A sequence gives the type of its first item only.
+        ([1, 2], click.INT),
+        ((1, 2), click.INT),
+        ([1.5, 2.5], click.FLOAT),
+        ([1, "git"], click.INT),
+        # Everything else falls back to STRING, including types Click ships.
+        ({1, 2}, click.STRING),
+        (frozenset({1, 2}), click.STRING),
+        ({"a": 1}, click.STRING),
+        (uuid.UUID(int=0), click.STRING),
+        (datetime.datetime(2026, 1, 1), click.STRING),
+        (b"git", click.STRING),
+        (object(), click.STRING),
+    ],
+)
+def test_type_inferred_from_default(default, expected):
+    """Every row of the type-inference table in ``docs/parameter-types.md``.
+
+    Keep the two in step: a change here is a change to documented behavior.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    assert convert_type(None, default) is expected
+
+
+def test_type_inferred_from_nested_sequence_default():
+    """A sequence of sequences gives a composite ``Tuple`` of the inner types.
+
+    This is the one table row that is not a singleton ``ParamType``.
+
+    Refs: https://github.com/pallets/click/issues/3036
+    """
+    param_type = convert_type(None, [(1, "git")])
+    assert isinstance(param_type, click.Tuple)
+    assert param_type.types == [click.INT, click.STRING]


### PR DESCRIPTION
This is an ongoing exploration of usage of `set` and `frozenset` types in various places in the public API. It addresses the suspicion I had for a long time about inconsistent behavior, as detailed in https://github.com/pallets/click/issues/3036.

These tests for the moment only freeze the current behavior of Click. But reveals inconsistent or awkward behavior that are left to be discussed and decided upon for eventual bug fixes.

1. A `set`, `frozenset` or `dict` default is guessed as a `STRING`, not a container type (`test_type_from_default_container`, `test_convert_type_from_container_default`). This contradicts the documented rule of *"If no type is provided, the type of the default value is used"* Should we change that so we guess a container type instead of the current `STRING`?

2. An explicit `type=set` or `type=frozenset` is splitting the value provided to it (see `test_explicit_container_type_splits_string`). This looks like a bug we want to fix. My instinct is to split on commas, which overlaps an older discussion at: https://github.com/pallets/click/issues/2771#issuecomment-4750207191 and my preference for it. Also dug out an old proposal at: https://github.com/pallets/click/pull/422.

Also note that this also affects the envvars as demonstrated by my tests.

Closes #3036.