### PR TITLE
AI junk

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1079,6 +1079,7 @@ class Command:
     def to_info_dict(self, ctx: Context) -> dict[str, t.Any]:
         return {
             "name": self.name,
+            "usage": self.get_usage(ctx),
             "params": [param.to_info_dict() for param in self.get_params(ctx)],
             "help": self.help,
             "epilog": self.epilog,

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -253,12 +253,21 @@ def test_parameter(obj, expect):
 def test_command(obj, expect):
     ctx = click.Context(obj)
     out = obj.to_info_dict(ctx)
+
+    def remove_usage(info):
+        usage = info.pop("usage")
+        assert usage.startswith("Usage: ")
+        for command in info.get("commands", {}).values():
+            remove_usage(command)
+
+    remove_usage(out)
     assert out == expect
 
 
 def test_context():
     ctx = click.Context(HELLO_COMMAND[0])
     out = ctx.to_info_dict()
+    usage = out["command"].pop("usage")
     assert out == {
         "command": HELLO_COMMAND[1],
         "info_name": None,
@@ -267,6 +276,8 @@ def test_context():
         "ignore_unknown_options": False,
         "auto_envvar_prefix": None,
     }
+
+    assert usage == "Usage:  [OPTIONS]"
 
 
 def test_paramtype_no_name():


### PR DESCRIPTION
Fixes pallets/click#2992.

## Background

`Command.to_info_dict()` exposes command metadata for documentation tooling, but omits the usage string. Consumers must reconstruct the command context and call `get_usage()` themselves, which is especially difficult for nested command trees.

## Changes

Include the context-specific result of `get_usage(ctx)` under the `usage` key for every command in `to_info_dict()` output. Existing metadata and command behavior remain unchanged.

## Validation

- `PYTHONPATH=src python -m pytest -q --basetemp D:\\project\\tscodex\\github_pr\\tasks\\click-2992-basetemp` — 1907 passed, 108 skipped, 1 xfailed.
- `ruff format --check src tests` — passed.
- `ruff check src tests` — passed.
- `git diff --check` — passed.
