### PR TITLE
[rejected AI] Don't break usage-line options at a hyphen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- The usage line no longer breaks long option names or metavars at a hyphen
+  when wrapping. Hyphenated tokens such as `--max-retry-count` stay intact and
+  wrapping happens only at the spaces between them. {issue}`3362`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,12 +53,19 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: whether words may be broken after a hyphen. This
+                             defaults to ``True`` to match the standard library
+                             behaviour. Set it to ``False`` to keep hyphenated
+                             tokens such as ``--option-name`` intact.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
         ``text``, ``initial_indent``, or ``subsequent_indent`` no longer
         count toward the width budget, so styled input wraps based on what
         the user sees instead of raw byte length.
+
+    .. versionchanged:: 8.5.1
+        Added the ``break_on_hyphens`` parameter.
     """
     from ._textwrap import TextWrapper
 
@@ -67,6 +75,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +195,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +205,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -517,6 +517,42 @@ def test_write_usage_styled_prefix_keeps_options_on_one_line():
     assert visible == "Usage: cli [OPTIONS]\n"
 
 
+def test_write_usage_does_not_break_options_at_hyphen():
+    """Issue #3362: hyphenated tokens on the usage line (e.g. long option
+    names or metavars) must not be split at a hyphen when wrapping. They may
+    only wrap at the spaces between tokens.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+    rendered = formatter.getvalue()
+
+    # The break must never fall inside a token: every option name survives
+    # intact on one of the wrapped lines.
+    for option in options:
+        assert any(option in line for line in rendered.splitlines())
+
+    assert rendered == (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+
+
 @pytest.mark.parametrize(
     ("formatter_kwargs", "current_indent", "prog", "args", "prefix", "expected"),
     [


### PR DESCRIPTION
Fixes #3362

## The bug

When `HelpFormatter.write_usage` wraps the usage line, an option name or metavar containing hyphens can be split at one of those hyphens if it lands at the wrap boundary. For example:

```python
import click

options = [
    "--enable-verbose-logging", "--output-file-path", "--max-retry-count",
    "--disable-cache-mode", "--config-file-location", "--user-auth-token",
    "--auto-update-interval", "--force-overwrite-existing",
    "--network-timeout-seconds", "--debug-trace-enabled",
]
f = click.HelpFormatter(width=65)
f.write_usage("program", " ".join(options))
print(f.getvalue())
```

produces broken option names:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location ...
```

## Root cause

`write_usage` wraps the arguments through `wrap_text`, which builds a `TextWrapper`. `textwrap.TextWrapper` defaults to `break_on_hyphens=True`, so it treats each hyphen inside a token as an allowed break point and can wrap mid-option. There was no way for the caller to influence this.

## The fix

- Add a `break_on_hyphens` parameter to `wrap_text`, defaulting to `True` so existing behavior (help/prose wrapping) is unchanged.
- Pass `break_on_hyphens=False` from `write_usage`, so usage tokens only ever wrap at the spaces between them.

The wide-character/ANSI-aware wrapping and every other code path are untouched. Output now matches the expected result from the issue:

```
Usage: program --enable-verbose-logging --output-file-path
               --max-retry-count --disable-cache-mode
               --config-file-location --user-auth-token
               --auto-update-interval --force-overwrite-existing
               --network-timeout-seconds --debug-trace-enabled
```

## Testing

- Added `test_write_usage_does_not_break_options_at_hyphen` in `tests/test_formatting.py`. It fails on `main` (options split at hyphens) and passes with this change.
- Full suite: `1991 passed, 25 skipped, 1 xfailed`.
- `ruff check`, `ruff format --check`, and `mypy src/click/formatting.py` are all clean.
- Added a `CHANGES.md` entry and `.. versionchanged::` note in the `wrap_text` docstring.