### PR TITLE
[rejected AI] Do not break hyphenated tokens when wrapping help text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- Help text is only wrapped at whitespace. Hyphenated names such as
+  `--option-name` are no longer split at a hyphen when a usage line or
+  help paragraph is wrapped. {issue}`3362`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -53,6 +53,10 @@ def wrap_text(
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
 
+    .. versionchanged:: 8.5.1
+        Text is only wrapped at whitespace. Hyphenated tokens such as
+        ``--option-name`` are no longer split at a hyphen.
+
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
         ``text``, ``initial_indent``, or ``subsequent_indent`` no longer
@@ -67,6 +71,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=False,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -517,6 +517,42 @@ def test_write_usage_styled_prefix_keeps_options_on_one_line():
     assert visible == "Usage: cli [OPTIONS]\n"
 
 
+def test_write_usage_does_not_break_options_at_hyphens():
+    """Issue #3362: wrapping a usage line must not split a hyphenated
+    option name at a hyphen, only at whitespace between tokens.
+    """
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+    ]
+
+    formatter = click.HelpFormatter(width=65)
+    formatter.write_usage("program", " ".join(options))
+
+    assert formatter.getvalue().splitlines() == [
+        "Usage: program --enable-verbose-logging --output-file-path",
+        "               --max-retry-count --disable-cache-mode",
+        "               --config-file-location",
+    ]
+
+
+def test_write_text_does_not_break_words_at_hyphens():
+    """Issue #3362: hyphenated tokens in help text, such as option names
+    mentioned in prose, stay intact when the text is rewrapped.
+    """
+    formatter = click.HelpFormatter(width=30)
+    formatter.write_text("Deprecated, use --enable-verbose-logging instead.")
+
+    assert formatter.getvalue().splitlines() == [
+        "Deprecated, use",
+        "--enable-verbose-logging",
+        "instead.",
+    ]
+
+
 @pytest.mark.parametrize(
     ("formatter_kwargs", "current_indent", "prog", "args", "prefix", "expected"),
     [


### PR DESCRIPTION


`wrap_text` builds click's `TextWrapper` without overriding `textwrap.TextWrapper`'s default `break_on_hyphens=True`, so when a usage line or help paragraph has to wrap, an option name can be split at a hyphen:

    Usage: program --enable-verbose-logging --output-file-path --max-
                   retry-count --disable-cache-mode

This change disables `break_on_hyphens` so text wraps only at whitespace, keeping names like `--max-retry-count` intact. This also applies to help paragraphs (`write_text`), where prose mentioning an option (e.g. "use `--enable-verbose-logging` instead") had the same problem; the trade-off is that ordinary hyphenated English words are also no longer split, which is the conventional choice for terminal help output. Long tokens that cannot fit on a line by themselves are still hard-broken as a last resort, unchanged.

Added two regression tests (both fail without the fix), a changelog entry, and a `versionchanged` note on `wrap_text`.

fixes #3362