### PR TITLE
AI junk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- Handle a second `KeyboardInterrupt` while printing `Aborted!` after
+  `prompt()` is cancelled with Ctrl-C. Previously that interrupt could
+  escape `Command.main` as an unhandled exception. {issue}`3802`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1561,7 +1561,10 @@ class Command:
                     # by its truthiness/falsiness
                     ctx.exit()
             except (EOFError, KeyboardInterrupt) as e:
-                echo(file=sys.stderr)
+                try:
+                    echo(file=sys.stderr)
+                except KeyboardInterrupt:
+                    pass
                 raise Abort() from e
             except ClickException as e:
                 if not standalone_mode:
@@ -1591,7 +1594,10 @@ class Command:
         except Abort:
             if not standalone_mode:
                 raise
-            echo(_("Aborted!"), file=sys.stderr)
+            try:
+                echo(_("Aborted!"), file=sys.stderr)
+            except KeyboardInterrupt:
+                pass
             sys.exit(1)
 
     def _main_shell_completion(

--- a/tests/test_utils/test_prompt.py
+++ b/tests/test_utils/test_prompt.py
@@ -87,6 +87,38 @@ def test_full_prompt_passed_to_readline(monkeypatch, call, expected_prompt):
     assert received == [expected_prompt]
 
 
+def test_prompt_abort_echo_survives_keyboard_interrupt(monkeypatch):
+    """Ctrl-C at a prompt becomes Abort. A second KeyboardInterrupt
+    during the Aborted! echo (echo -> isatty) must still exit 1.
+
+    https://github.com/pallets/click/issues/3802
+    """
+
+    @click.command()
+    def cli():
+        click.prompt("name")
+
+    def interrupt(_text):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("click.termui.visible_prompt_func", interrupt)
+
+    stderr = StringIO()
+
+    def interrupt_isatty():
+        raise KeyboardInterrupt()
+
+    stderr.isatty = interrupt_isatty  # type: ignore[method-assign]
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    try:
+        cli.main([])
+    except SystemExit as e:
+        assert e.code == 1
+    except KeyboardInterrupt:
+        pytest.fail("KeyboardInterrupt escaped Command.main during abort")
+
+
 def test_prompts_eof(runner):
     """If too few lines of input are given, prompt should exit, not hang."""
 


### PR DESCRIPTION
Fixes #3802

Ctrl-C during click.prompt() becomes Abort, then Command.main echoes Aborted. A second SIGINT in isatty() leaks because KeyboardInterrupt is a BaseException. Catch KeyboardInterrupt around that abort echo and still sys.exit(1).

Adds test_prompt_abort_echo_survives_keyboard_interrupt. 1931 tests passed.