### PR TITLE
[rejected AI] Don't wrap usage lines in the middle of hyphenated option names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Unreleased
 
+- {meth}`HelpFormatter.write_usage` no longer wraps hyphenated option
+  names in the middle. {issue}`3362`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,7 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +53,14 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then wrapping may break
+                             words after hyphens. Disable this for usage
+                             lines so option names like ``--max-retry``
+                             stay intact.
+
+    .. versionchanged:: 8.5.1
+        Added ``break_on_hyphens``. :meth:`HelpFormatter.write_usage`
+        disables it so hyphenated option names are not split across lines.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +76,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +196,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +206,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,3 +630,26 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_write_usage_does_not_break_hyphenated_options():
+    """Issue #3362: usage wrapping must not split option names at hyphens."""
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    f = click.HelpFormatter(width=65)
+    f.write_usage("program", " ".join(options))
+    rendered = f.getvalue()
+    for opt in options:
+        assert opt in rendered, f"{opt!r} was split across lines:\n{rendered}"
+    for line in rendered.splitlines():
+        assert not line.endswith("-"), f"line wrapped on a hyphen:\n{rendered}"


### PR DESCRIPTION
## Summary

`HelpFormatter.write_usage` wraps usage arguments with `textwrap.TextWrapper`, which defaults to `break_on_hyphens=True`. Hyphenated option names such as `--max-retry-count` were therefore split across lines:

```
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode --config-file-
               location ...
```

`write_usage` now passes `break_on_hyphens=False` so wrapping only happens at spaces. Help-text wrapping is unchanged.

Fixes #3362.

## Test plan

- [x] New regression test using the example from #3362 (`width=65`) asserts every option name is intact and no usage line ends with a hyphen.
- [x] Existing `tests/test_formatting.py` (38 tests) pass.
- [x] Full suite minus environment-specific pager tests: 1931 passed.
- [x] `ruff check` / `ruff format` on the touched files.