### PR TITLE
[rejected AI] Fix completion for attached option values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 Unreleased
 
 - Fix `copy.deepcopy()` and `pickle` on a `Parameter`, `Option` or `Command`. {pr}`3805`
+- Shell completion for option values attached with `=` preserves the option
+  prefix, allowing Bash and Zsh to replace the complete word. {issue}`2847`
 
 ## Version 8.5.0
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -362,8 +362,21 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
-        obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        obj, incomplete, completion_prefix = _resolve_incomplete(ctx, args, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            completions = [
+                CompletionItem(
+                    f"{completion_prefix}{item.value}",
+                    type=item.type,
+                    help=item.help,
+                    **item._info,
+                )
+                for item in completions
+            ]
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the
@@ -756,9 +769,10 @@ def _resolve_context(
 
 def _resolve_incomplete(
     ctx: Context, args: list[str], incomplete: str
-) -> tuple[Command | Parameter, str]:
+) -> tuple[Command | Parameter, str, str]:
     """Find the Click object that will handle the completion of the
-    incomplete value. Return the object and the incomplete value.
+    incomplete value. Return the object, incomplete value, and any prefix
+    that the shell will replace along with the value.
 
     :param ctx: Invocation context for the command represented by
         the parsed complete args.
@@ -769,18 +783,21 @@ def _resolve_incomplete(
     # value differently. Might keep the value joined, return the "="
     # as a separate item, or return the split name and value. Always
     # split and discard the "=" to make completion easier.
+    completion_prefix = ""
+
     if incomplete == "=":
         incomplete = ""
     elif "=" in incomplete and _start_of_option(ctx, incomplete):
         name, _, incomplete = incomplete.partition("=")
         args.append(name)
+        completion_prefix = f"{name}="
 
     # The "--" marker tells Click to stop treating values as options
     # even if they start with the option character. If it hasn't been
     # given and the incomplete arg looks like an option, the current
     # command will provide option name completions.
     if "--" not in args and _start_of_option(ctx, incomplete):
-        return ctx.command, incomplete
+        return ctx.command, incomplete, ""
 
     params = ctx.command.get_params(ctx)
 
@@ -788,14 +805,14 @@ def _resolve_incomplete(
     # value, the option will provide value completions.
     for param in params:
         if _is_incomplete_option(ctx, args, param):
-            return param, incomplete
+            return param, incomplete, completion_prefix
 
     # It's not an option name or value. The first argument without a
     # parsed value will provide value completions.
     for param in params:
         if _is_incomplete_argument(ctx, param):
-            return param, incomplete
+            return param, incomplete, ""
 
     # There were no unparsed arguments, the command may be a group that
     # will provide command name completions.
-    return ctx.command, incomplete
+    return ctx.command, incomplete, ""

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -150,6 +150,21 @@ def test_type_choice():
     assert _get_words(cli, ["-c"], "a2") == ["a2"]
 
 
+@pytest.mark.parametrize(
+    ("incomplete", "expect"),
+    [
+        ("--color=", ["--color=auto", "--color=always", "--color=never"]),
+        ("--color=al", ["--color=always"]),
+    ],
+)
+def test_attached_option_value_completion(incomplete, expect):
+    cli = Command(
+        "cli",
+        params=[Option(["--color"], type=Choice(["auto", "always", "never"]))],
+    )
+    assert _get_words(cli, [], incomplete) == expect
+
+
 def test_choice_special_characters():
     cli = Command("cli", params=[Option(["-c"], type=Choice(["!1", "!2", "+3"]))])
     assert _get_words(cli, ["-c"], "") == ["!1", "!2", "+3"]


### PR DESCRIPTION
When an incomplete value is joined to a long option with `=`, `_resolve_incomplete` strips the option prefix so the parameter can complete only the value. Bash and Zsh replace the entire current word, though, so returning `always` for `--color=al` drops the option name.

Preserve the stripped prefix and reattach it to completion items only after the input resolves to an option that accepts a value. Rebuild each item with its original type, help, and custom metadata so custom completion behavior remains intact. Add regression coverage for both an empty and a partial attached value, plus a changelog entry.

Fixes #2847

Tests:

- `uv run pytest`
- `uv run mypy`
- `uv run pre-commit run --files CHANGES.md src/click/shell_completion.py tests/test_shell_completion.py`