### PR TITLE
Remove unused bindings and constants from `_winconsole`

### DIFF
--- a/src/click/_winconsole.py
+++ b/src/click/_winconsole.py
@@ -45,7 +45,6 @@ ReadConsoleW = kernel32.ReadConsoleW
 WriteConsoleW = kernel32.WriteConsoleW
 GetConsoleMode = kernel32.GetConsoleMode
 GetLastError = kernel32.GetLastError
-GetCommandLineW = WINFUNCTYPE(LPWSTR)(("GetCommandLineW", windll.kernel32))
 CommandLineToArgvW = WINFUNCTYPE(POINTER(LPWSTR), LPCWSTR, POINTER(c_int))(
     ("CommandLineToArgvW", windll.shell32)
 )
@@ -61,10 +60,6 @@ PyBUF_WRITABLE = 1
 ERROR_SUCCESS = 0
 ERROR_NOT_ENOUGH_MEMORY = 8
 ERROR_OPERATION_ABORTED = 995
-
-STDIN_FILENO = 0
-STDOUT_FILENO = 1
-STDERR_FILENO = 2
 
 EOF = b"\x1a"
 MAX_BYTES_WRITTEN = 32767


### PR DESCRIPTION
These constants are not used anywhere, so I would classify them as left-over from the previous Python 2 cleanup that was performed by @Rowlando13 in https://github.com/pallets/click/pull/3695 or @davidism in 00883dd3d0a29f68f375cab5e21cef0669941aba.

These were introduced 11 years ago in Click 6.x (see https://github.com/pallets/click/commit/bcf8feceb41b3f75f3cd07eb851734fa96cd1991) for Python 2 compatibility and not touched since then.

And because this module is private, I choose not to add a changelog. Just tell me if you think it needs one and I will update this PR.