### PR TITLE
Fix race condition on `KeyboardInterrupt` in `Command.main()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 Unreleased
 
 - Fix `copy.deepcopy()` and `pickle` on a `Parameter`, `Option` or `Command`. {pr}`3805`
+- A `KeyboardInterrupt` arriving while `Command.main()` reports an abort or an error,
+  or while it exits, no longer escapes as an unhandled traceback. The command still
+  exits with the intended code; only the message may be lost. {issue}`3802`
 
 ## Version 8.5.0
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -19,19 +19,27 @@ like incorrect usage.
 
 Click's main error handling is happening in {meth}`Command.main`. In
 there it handles all subclasses of {exc}`ClickException` as well as the
-standard {exc}`EOFError` and {exc}`KeyboardInterrupt` exceptions. The
-latter are internally translated into an {exc}`Abort`.
+standard {exc}`EOFError` and {exc}`KeyboardInterrupt` exceptions.
 
-The logic applied is the following:
+The table below lists every way a command can end, and what Click does
+for each. The middle column is the default. The last column applies when
+{meth}`Command.main` runs with ``standalone_mode=False``, which the next
+section describes.
 
-1. If an {exc}`EOFError` or {exc}`KeyboardInterrupt` happens, reraise it
-   as {exc}`Abort`.
-2. If a {exc}`ClickException` is raised, invoke the
-   {meth}`ClickException.show` method on it to display it and then exit
-   the program with {attr}`ClickException.exit_code`.
-3. If an {exc}`Abort` exception is raised print the string ``Aborted!``
-   to standard error and exit the program with exit code ``1``.
-4. If it goes through well, exit the program with exit code ``0``.
+| How the command ends | Standalone mode | ``standalone_mode=False`` |
+| --- | --- | --- |
+| It returns | Exit with code ``0`` | Return the value of {meth}`Command.invoke` |
+| It called {meth}`Context.exit` | Exit with the given code | Return the given code |
+| It raised a {exc}`ClickException` | Call {meth}`ClickException.show`, then exit with {attr}`ClickException.exit_code` | Propagate it |
+| The user pressed ``Ctrl-C``, which raises a {exc}`KeyboardInterrupt` | Print a blank line, then ``Aborted!`` to standard error, and exit with code ``1`` | Print a blank line, then raise {exc}`Abort` with the original exception as its ``__cause__`` |
+| The user pressed ``Ctrl-D``, which raises an {exc}`EOFError` | The same as ``Ctrl-C`` | The same as ``Ctrl-C`` |
+| It raised an {exc}`Abort` | Print ``Aborted!`` to standard error, and exit with code ``1`` | Propagate it |
+| The output pipe closed early, which raises an {exc}`OSError` with ``EPIPE`` | Silence the flush errors, and exit with code ``1`` | The same |
+| It raised any other exception | Propagate it | Propagate it |
+
+Click writes the message and exits once that handling is done. An
+interrupt arriving during this last step cannot change the exit code the
+table gave. It can only cost the message.
 
 ## What if I Don't Want That?
 
@@ -59,6 +67,24 @@ command.main(
     ["command-name", "args", "go", "here"],
     standalone_mode=False,
 )
+```
+
+This is also how you replace the ``Aborted!`` message. Standalone mode
+turns off every row of the table above, so catch the cases you want to
+keep and write your own message for the rest:
+
+```python
+try:
+    command.main(
+        ["command-name", "args", "go", "here"],
+        standalone_mode=False,
+    )
+except click.Abort:
+    click.echo("Bye!", err=True)
+    raise SystemExit(1)
+except click.ClickException as e:
+    e.show()
+    raise SystemExit(e.exit_code)
 ```
 
 ## Which Exceptions Exist?

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -99,6 +99,11 @@ def _check_nested_chain(
     raise RuntimeError(message)
 
 
+def _echo_aborted() -> None:
+    """Write the final abort message to standard error."""
+    echo(_("Aborted!"), file=sys.stderr)
+
+
 def _format_deprecated_label(deprecated: bool | str) -> str:
     """Return the parenthesized deprecation label shown in help text."""
     label = _("deprecated").upper()
@@ -1546,6 +1551,15 @@ class Command:
         # Process shell completion requests and exit early.
         self._main_shell_completion(extra, prog_name, complete_var)
 
+        # Every handler below takes the same two steps: propagate when
+        # standalone mode is disabled, otherwise collect the message and the
+        # exit code, and leave both to the teardown after the ``try``. The
+        # teardown writes the message and exits, and the outermost handler
+        # holds one policy for every interrupt arriving that late: the
+        # message may be lost, the intended exit code still wins.
+        report: cabc.Callable[[], None] | None = None
+        exit_code = 1
+
         try:
             try:
                 with self.make_context(prog_name, args, **extra) as ctx:
@@ -1560,39 +1574,53 @@ class Command:
                     # even always obvious that `rv` indicates success/failure
                     # by its truthiness/falsiness
                     ctx.exit()
+            except Exit as e:
+                if not standalone_mode:
+                    # in non-standalone mode, return the exit code
+                    # note that this is only reached if `self.invoke` above raises
+                    # an Exit explicitly -- thus bypassing the check there which
+                    # would return its result
+                    # the results of non-standalone execution may therefore be
+                    # somewhat ambiguous: if there are codepaths which lead to
+                    # `ctx.exit(1)` and to `return 1`, the caller won't be able to
+                    # tell the difference between the two
+                    return e.exit_code
+
+                exit_code = e.exit_code
+            except Abort:
+                if not standalone_mode:
+                    raise
+
+                report = _echo_aborted
             except (EOFError, KeyboardInterrupt) as e:
+                # The blank line closes the terminal's ``^C`` echo.
                 echo(file=sys.stderr)
-                raise Abort() from e
+
+                if not standalone_mode:
+                    raise Abort() from e
+
+                report = _echo_aborted
             except ClickException as e:
                 if not standalone_mode:
                     raise
-                e.show()
-                sys.exit(e.exit_code)
+
+                report, exit_code = e.show, e.exit_code
             except OSError as e:
-                if e.errno == errno.EPIPE:
-                    sys.stdout = t.cast(t.TextIO, _PacifyFlushWrapper(sys.stdout))
-                    sys.stderr = t.cast(t.TextIO, _PacifyFlushWrapper(sys.stderr))
-                    sys.exit(1)
-                else:
+                if e.errno != errno.EPIPE:
                     raise
-        except Exit as e:
-            if standalone_mode:
-                sys.exit(e.exit_code)
-            else:
-                # in non-standalone mode, return the exit code
-                # note that this is only reached if `self.invoke` above raises
-                # an Exit explicitly -- thus bypassing the check there which
-                # would return its result
-                # the results of non-standalone execution may therefore be
-                # somewhat ambiguous: if there are codepaths which lead to
-                # `ctx.exit(1)` and to `return 1`, the caller won't be able to
-                # tell the difference between the two
-                return e.exit_code
-        except Abort:
+
+                sys.stdout = t.cast(t.TextIO, _PacifyFlushWrapper(sys.stdout))
+                sys.stderr = t.cast(t.TextIO, _PacifyFlushWrapper(sys.stderr))
+
+            if report is not None:
+                report()
+
+            sys.exit(exit_code)
+        except (EOFError, KeyboardInterrupt):
             if not standalone_mode:
                 raise
-            echo(_("Aborted!"), file=sys.stderr)
-            sys.exit(1)
+
+            sys.exit(exit_code)
 
     def _main_shell_completion(
         self,

--- a/tests/test_abort_interrupt.py
+++ b/tests/test_abort_interrupt.py
@@ -1,0 +1,179 @@
+"""A second Ctrl-C while ``Command.main()`` reported an abort or an error used
+to escape as an unhandled traceback: the message and the exit both ran in
+``except`` clauses, outside every ``try`` that caught ``KeyboardInterrupt``.
+https://github.com/pallets/click/issues/3802
+
+The fix holds one policy, the one the pager has followed since
+https://github.com/pallets/click/pull/351: a late interrupt must not replace
+the intended outcome. In standalone mode the collected exit code wins, for
+aborts, errors and success alike, and the message is best effort. Without
+standalone mode the interrupt propagates to the caller. Two settled contracts
+stay in place: the first interrupt reaches a non-standalone caller as
+``Abort`` (https://github.com/pallets/click/pull/2380), and the ``Aborted!``
+message stays as it is (declined in
+https://github.com/pallets/click/issues/1447 and
+https://github.com/pallets/click/issues/2584).
+"""
+
+import sys
+
+import pytest
+
+import click
+
+
+class RecordingStderr:
+    """A stderr stand-in that records what is written to it.
+
+    With ``interrupt_at=N``, the ``N``-th ``isatty()`` call raises
+    ``KeyboardInterrupt``. ``echo()`` calls ``isatty()`` before writing, which
+    is where the traceback in issue #3802 ended.
+    """
+
+    def __init__(self, interrupt_at=None):
+        self.text = ""
+        self.interrupt_at = interrupt_at
+        self.isatty_calls = 0
+
+    def isatty(self):
+        self.isatty_calls += 1
+
+        if self.isatty_calls == self.interrupt_at:
+            raise KeyboardInterrupt
+
+        return False
+
+    def write(self, value):
+        self.text += value
+        return len(value)
+
+    def flush(self):
+        pass
+
+
+def _interrupt_prompt(text):
+    """Stand in for ``input()`` when the user presses Ctrl-C at a prompt."""
+    raise KeyboardInterrupt
+
+
+def _prompting_command():
+    @click.command()
+    @click.option("--name", prompt="Name")
+    def cli(name):
+        click.echo(name)
+
+    return cli
+
+
+def _interrupting_command():
+    @click.command()
+    def cli():
+        raise KeyboardInterrupt
+
+    return cli
+
+
+def _exit_code(cli, stderr, monkeypatch):
+    """Run *cli* in standalone mode and return its exit code."""
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    try:
+        cli.main([], "cli")
+    except SystemExit as e:
+        return e.code
+    except KeyboardInterrupt:
+        pytest.fail("KeyboardInterrupt escaped Command.main()")
+
+    pytest.fail("Command.main() returned without exiting")
+
+
+@pytest.mark.parametrize(
+    ("source", "interrupt_at"),
+    [("prompt", None), ("prompt", 1), ("body", None), ("body", 1), ("body", 2)],
+)
+def test_interrupt_while_reporting_abort(monkeypatch, source, interrupt_at):
+    """Exit code 1 survives a second Ctrl-C; the message may not.
+
+    The counted ``isatty`` picks the window. A prompt converts the interrupt
+    to ``Abort`` itself, so the only window left in ``Command.main()`` is the
+    ``Aborted!`` message (``1``). An interrupt from the command body goes
+    through the conversion in ``Command.main()``, which writes a blank line
+    first (``1``), before the message (``2``).
+    """
+    if source == "prompt":
+        monkeypatch.setattr("click.termui.visible_prompt_func", _interrupt_prompt)
+        cli = _prompting_command()
+    else:
+        cli = _interrupting_command()
+
+    stderr = RecordingStderr(interrupt_at=interrupt_at)
+
+    assert _exit_code(cli, stderr, monkeypatch) == 1
+
+    if interrupt_at is None:
+        assert "Aborted!" in stderr.text
+
+
+def test_interrupt_while_reporting_error(monkeypatch):
+    """A Ctrl-C while Click writes an error keeps the error's exit code."""
+
+    class InterruptedReport(click.ClickException):
+        exit_code = 3
+
+        def show(self, file=None):
+            raise KeyboardInterrupt
+
+    @click.command()
+    def cli():
+        raise InterruptedReport("boom")
+
+    assert _exit_code(cli, RecordingStderr(), monkeypatch) == 3
+
+
+def test_late_interrupt_with_disabled_standalone_mode(monkeypatch):
+    """Without standalone mode, a late interrupt reaches the caller, not exit 1.
+
+    The patched ``Abort`` raises a second ``KeyboardInterrupt`` from its
+    constructor: it lands on the ``raise Abort() from e`` statement that
+    ``Command.main()`` only runs for non-standalone callers.
+    """
+
+    class InterruptedAbort(click.Abort):
+        def __init__(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(click.core, "Abort", InterruptedAbort)
+    cli = _interrupting_command()
+    monkeypatch.setattr(sys, "stderr", RecordingStderr())
+
+    with pytest.raises(KeyboardInterrupt):
+        cli.main([], "cli", standalone_mode=False)
+
+
+def test_interrupt_while_exiting_after_success(monkeypatch):
+    """A Ctrl-C while a successful exit propagates keeps exit code 0.
+
+    The uniform policy: the run completed before the interrupt arrived, so the
+    intended outcome wins for success exactly as it does for aborts and
+    errors.
+    """
+
+    @click.command()
+    def cli():
+        click.echo("done")
+
+    real_exit = sys.exit
+    codes = []
+
+    def interrupted_exit(code=None):
+        codes.append(code)
+
+        if len(codes) == 1:
+            raise KeyboardInterrupt
+
+        real_exit(code)
+
+    monkeypatch.setattr(sys, "exit", interrupted_exit)
+
+    assert _exit_code(cli, RecordingStderr(), monkeypatch) == 0
+    assert codes == [0, 0]


### PR DESCRIPTION
This PR address https://github.com/pallets/click/issues/3802 by unifying the policy that was already implemented elsewhere in the code.

This applies the policy the pager has had since #351, where a late interrupt must not replace the intended outcome:
https://github.com/pallets/click/blob/8b19813f2bfca99f1018a587a8cf54fc959f2e5d/src/click/_termui_impl.py#L618-L632

So now in `main()`, every handler takes the same two steps:
- propagate when standalone mode is off, or
- collect the message and the exit code.

A final step then prints the message and exits, so a late interrupt can only lose the message, not the code.

This save one nesting level in the `try...except` cascade of `main()`.

This is in accordance with older policy choices from:
- #2380: where we decided that the first interrupt still reaches non-standalone callers as `Abort`, and keeps the interrupt as its `__cause__`
- #2584: where we decided not to change the `Aborted!` message

With these changes, we do not crash anymore, and a late interrupt after a successful run now exits 0, instead of printing a traceback.

This PR also adds stress tests that introduce random delays in the execution so we can catch regression at different points in time with real SIGINTs.

Off course we can discuss the policy we rely on and I'm ready to change the code accordingly.