### PR TITLE
Add missing a reference for Windows and use the `kbd` role

### DIFF
--- a/docs/complex.md
+++ b/docs/complex.md
@@ -350,9 +350,9 @@ name is `cli`.
 2. Helptext rendering. In order to get the short help description of subcommands,
    `cli --help` will load `foo` and `bar`. Note that it will still not load
    `baz`.
-3. Shell completion. In order to get the subcommands of a lazy command, `cli <TAB>`
-   will need to resolve the subcommands of `cli`. This process will trigger the lazy
-   loads.
+3. Shell completion. In order to get the subcommands of a lazy command, completing
+   `cli` with {kbd}`Tab` will need to resolve the subcommands of `cli`. This process
+   will trigger the lazy loads.
 
 ### Further Deferring Imports
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -31,8 +31,8 @@ section describes.
 | It returns | Exit with code ``0`` | Return the value of {meth}`Command.invoke` |
 | It called {meth}`Context.exit` | Exit with the given code | Return the given code |
 | It raised a {exc}`ClickException` | Call {meth}`ClickException.show`, then exit with {attr}`ClickException.exit_code` | Propagate it |
-| The user pressed ``Ctrl-C``, which raises a {exc}`KeyboardInterrupt` | Print a blank line, then ``Aborted!`` to standard error, and exit with code ``1`` | Print a blank line, then raise {exc}`Abort` with the original exception as its ``__cause__`` |
-| The user pressed ``Ctrl-D``, which raises an {exc}`EOFError` | The same as ``Ctrl-C`` | The same as ``Ctrl-C`` |
+| The user pressed {kbd}`Ctrl+C`, which raises a {exc}`KeyboardInterrupt` | Print a blank line, then ``Aborted!`` to standard error, and exit with code ``1`` | Print a blank line, then raise {exc}`Abort` with the original exception as its ``__cause__`` |
+| The user pressed {kbd}`Ctrl+D`, or {kbd}`Ctrl+Z` on Windows, which raises an {exc}`EOFError` | The same as {kbd}`Ctrl+C` | The same as {kbd}`Ctrl+C` |
 | It raised an {exc}`Abort` | Print ``Aborted!`` to standard error, and exit with code ``1`` | Propagate it |
 | The output pipe closed early, which raises an {exc}`OSError` with ``EPIPE`` | Silence the flush errors, and exit with code ``1`` | The same |
 | It raised any other exception | Propagate it | Propagate it |

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -178,9 +178,9 @@ else:
 ```
 
 Note that this reads raw input, which means that things like arrow keys will show up in the platform's native escape
-format. The only characters translated are `^C` and `^D` which are converted into keyboard interrupts and end of file
-exceptions respectively. This is done because otherwise, it's too easy to forget about that and to create scripts that
-cannot be properly exited.
+format. The only characters translated are the ones produced by {kbd}`Ctrl+C` and {kbd}`Ctrl+D`, or {kbd}`Ctrl+Z` on
+Windows, which are converted into keyboard interrupts and end of file exceptions respectively. This is done because
+otherwise, it's too easy to forget about that and to create scripts that cannot be properly exited.
 
 ## Waiting for Key Press
 


### PR DESCRIPTION
While reviewing changes from documentation I introduced in #3818, I realized that I was missing a reference to `Ctrl+Z` on Windows. This PR adds it.

And while doing that change, I use the [`kbd` Sphinx role](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-kbd) to mark keystrokes sequences. Don't know if the theme currently use special CSS to render it, but that might be free styling if it supports it.