### PR TITLE
Added safe formatting of user input in some error messages fix #3832

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1391,7 +1391,7 @@ class Command:
                     "Got unexpected extra argument ({args})",
                     "Got unexpected extra arguments ({args})",
                     len(args),
-                ).format(args=" ".join(map(str, args)))
+                ).format(args=" ".join(map(repr, args)))
             )
 
         ctx.args = args

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1010,7 +1010,7 @@ class File(ParamType[t.IO[t.Any]]):
             return f
         except OSError as e:
             self.fail(
-                f"'{format_filename(value)!r}': {e.strerror}",
+                f"{format_filename(value)!r}: {e.strerror}",
                 param,
                 ctx,
             )

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -1010,7 +1010,7 @@ class File(ParamType[t.IO[t.Any]]):
             return f
         except OSError as e:
             self.fail(
-                f"'{format_filename(value)}': {e.strerror}",
+                f"'{format_filename(value)!r}': {e.strerror}",
                 param,
                 ctx,
             )

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -76,7 +76,7 @@ def test_nargs_err(runner):
 
     result = runner.invoke(copy, ["foo", "bar"])
     assert result.exit_code == 2
-    assert "Got unexpected extra argument (bar)" in result.output
+    assert "Got unexpected extra argument ('bar')" in result.output
 
 
 def test_bytes_args(runner, monkeypatch):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -473,7 +473,7 @@ def test_file_lazy_mode(runner, tmp_path):
     non_lazy.mkdir()
     result_in = runner.invoke(input_non_lazy, [f"--file={non_lazy}"])
     assert result_in.exit_code == 2
-    assert f"Invalid value for '--file': '{non_lazy}'" in result_in.output
+    assert f"Invalid value for '--file': {str(non_lazy)!r}" in result_in.output
 
 
 def test_path_option(runner, tmp_path):


### PR DESCRIPTION
This PR adds safe formatting to user input interpolated in two error messages to avoid escape-sequence injections.
It also changes one test to match the new emitted output that contains single quotes.
