### PR TITLE
[rejected AI] Make click.Path generic on path_type (#3822)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Unreleased
 
+- {class}`Path` is generic on `path_type`, preserving the converted return type in static type checkers. {issue}`3822`
+
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -45,6 +45,13 @@ else:
 _FloatValueT = t.TypeVar("_FloatValueT", bound=float)
 _FloatValueT_co = t.TypeVar("_FloatValueT_co", bound=float, covariant=True)
 
+if t.TYPE_CHECKING:
+    _PathType = te.TypeVar("_PathType", default=str)
+elif sys.version_info >= (3, 13):
+    _PathType = t.TypeVar("_PathType", default=str)
+else:
+    _PathType = t.TypeVar("_PathType")
+
 
 class ParamTypeInfoDict(t.TypedDict):
     param_type: str
@@ -1045,7 +1052,7 @@ class PathInfoDict(ParamTypeInfoDict):
     allow_dash: bool
 
 
-class Path(ParamType[str | bytes | os.PathLike[str]]):
+class Path(ParamType[_PathType], t.Generic[_PathType]):
     """The ``Path`` type is similar to the :class:`File` type, but
     returns the filename instead of an open file. Various checks can be
     enabled to validate the type of file and permissions.
@@ -1067,6 +1074,9 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
     :param path_type: Convert the incoming path value to this type. If
         ``None``, keep Python's default, which is ``str``. Useful to
         convert to :class:`pathlib.Path`.
+
+    .. versionchanged:: 8.5.1
+        Now generic on ``path_type``.
 
     .. versionchanged:: 8.1
         Added the ``executable`` parameter.
@@ -1090,6 +1100,34 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
     allow_dash: bool
     name: str
 
+    @t.overload
+    def __init__(
+        self: Path[str],
+        exists: bool = False,
+        file_okay: bool = True,
+        dir_okay: bool = True,
+        writable: bool = False,
+        readable: bool = True,
+        resolve_path: bool = False,
+        allow_dash: bool = False,
+        path_type: None = None,
+        executable: bool = False,
+    ) -> None: ...
+
+    @t.overload
+    def __init__(
+        self: Path[_PathType],
+        exists: bool = False,
+        file_okay: bool = True,
+        dir_okay: bool = True,
+        writable: bool = False,
+        readable: bool = True,
+        resolve_path: bool = False,
+        allow_dash: bool = False,
+        path_type: type[_PathType] = ...,
+        executable: bool = False,
+    ) -> None: ...
+
     def __init__(
         self,
         exists: bool = False,
@@ -1099,7 +1137,7 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
         readable: bool = True,
         resolve_path: bool = False,
         allow_dash: bool = False,
-        path_type: type | None = None,
+        path_type: type[_PathType] | None = None,
         executable: bool = False,
     ) -> None:
         self.exists = exists
@@ -1110,7 +1148,7 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
         self.executable = executable
         self.resolve_path = resolve_path
         self.allow_dash = allow_dash
-        self.type: type | None = path_type
+        self.type: type[_PathType] | None = path_type
 
         if self.file_okay and not self.dir_okay:
             self.name = _("file")
@@ -1130,25 +1168,23 @@ class Path(ParamType[str | bytes | os.PathLike[str]]):
             **super().to_info_dict(),
         }
 
-    def coerce_path_result(
-        self, value: str | os.PathLike[str]
-    ) -> str | bytes | os.PathLike[str]:
+    def coerce_path_result(self, value: str | os.PathLike[str]) -> _PathType:
         if self.type is not None and not isinstance(value, self.type):
             if self.type is str:
-                return os.fsdecode(value)
+                return t.cast(_PathType, os.fsdecode(value))
             elif self.type is bytes:
-                return os.fsencode(value)
+                return t.cast(_PathType, os.fsencode(value))
             else:
-                return t.cast("os.PathLike[str]", self.type(value))
+                return t.cast(t.Callable[[t.Any], _PathType], self.type)(value)
 
-        return value
+        return t.cast(_PathType, value)
 
     def convert(
         self,
         value: str | os.PathLike[str],
         param: Parameter | None,
         ctx: Context | None,
-    ) -> str | bytes | os.PathLike[str]:
+    ) -> _PathType:
         rv = value
 
         dash = b"-" if isinstance(rv, bytes) else "-"

--- a/tests/typing/typing_prompt.py
+++ b/tests/typing/typing_prompt.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from typing_extensions import assert_type
 
 import click
@@ -13,6 +15,13 @@ assert_type(click.prompt("Age", type=click.INT), int)
 assert_type(click.prompt("Age", type=click.IntRange(0, 130), default=18), int)
 assert_type(click.prompt("Age", type=int), int)
 assert_type(click.prompt("Age", type=int, default="100"), int)
+assert_type(click.prompt("Path", type=click.Path()), str)
+assert_type(click.prompt("Path", type=click.Path(path_type=pathlib.Path)), pathlib.Path)
+assert_type(click.prompt("Path", type=click.Path(path_type=bytes)), bytes)
+assert_type(click.Path(), click.Path[str])
+assert_type(click.Path(path_type=pathlib.Path), click.Path[pathlib.Path])
+assert_type(click.Path(path_type=bytes), click.Path[bytes])
+
 
 # The return type is narrowed by the ``value_proc`` argument.
 


### PR DESCRIPTION
Fixes #3822.

### Description
In Click 8.5.0, `ParamType` and `click.prompt` were made generic so that static type checkers can infer the actual converted type. However, `click.Path` was typed strictly as `ParamType[str | bytes | os.PathLike[str]]`, regardless of the `path_type` parameter (e.g. `path_type=pathlib.Path`). Consequently, `click.prompt("...", type=click.Path(path_type=pathlib.Path))` and options typed with `click.Path` lost their specialized return type in mypy, pyright, and other type checkers.

### Changes
- Makes `click.Path` generic: `class Path(ParamType[_PathType], t.Generic[_PathType]):`
- Uses `te.TypeVar("_PathType", default=str)` (PEP 696) with Python 3.13+ runtime support so `click.Path` defaults to `Path[str]`.
- Adds `@t.overload` signatures for `Path.__init__`:
  - Default / `path_type: None = None` -> `Path[str]`
  - `path_type: type[_PathType]` (e.g. `pathlib.Path`) -> `Path[_PathType]`
- Updates return types of `coerce_path_result` and `convert` to return `_PathType`.
- Adds static typing assertions in `tests/typing/typing_prompt.py` covering default, `pathlib.Path`, and `bytes`.
- Updates docstrings with `.. versionchanged:: 8.5.1` and updates `CHANGES.md`.
