### PR TITLE
prevent HelpFormatter.write_usage from breaking options at hyphens (fixes #3362)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Unreleased
 
+- Prevent {func}`HelpFormatter.write_usage` from breaking options at hyphens.
+  {issue}`3362` {pr}`3837`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/formatting.py
+++ b/src/click/formatting.py
@@ -34,6 +34,8 @@ def wrap_text(
     initial_indent: str = "",
     subsequent_indent: str = "",
     preserve_paragraphs: bool = False,
+    *,
+    break_on_hyphens: bool = True,
 ) -> str:
     """A helper function that intelligently wraps text.  By default, it
     assumes that it operates on a single paragraph of text but if the
@@ -52,6 +54,8 @@ def wrap_text(
                               each consecutive line.
     :param preserve_paragraphs: if this flag is set then the wrapping will
                                 intelligently handle paragraphs.
+    :param break_on_hyphens: if this flag is set then hyphens in words will
+                             be treated as wrap points.
 
     .. versionchanged:: 8.4.0
         Width is measured in visible characters. ANSI escape sequences in
@@ -67,6 +71,7 @@ def wrap_text(
         initial_indent=initial_indent,
         subsequent_indent=subsequent_indent,
         replace_whitespace=False,
+        break_on_hyphens=break_on_hyphens,
     )
     if not preserve_paragraphs:
         return wrapper.fill(text)
@@ -186,6 +191,7 @@ class HelpFormatter:
                     text_width,
                     initial_indent=usage_prefix,
                     subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
         else:
@@ -195,7 +201,11 @@ class HelpFormatter:
             indent = " " * (max(self.current_indent, term_len(prefix)) + 4)
             self.write(
                 wrap_text(
-                    args, text_width, initial_indent=indent, subsequent_indent=indent
+                    args,
+                    text_width,
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    break_on_hyphens=False,
                 )
             )
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -630,3 +630,40 @@ def test_command_write_usage_no_args(runner, command_kwargs, expected_usage_line
     cli = click.Command("cli", **command_kwargs)
     result = runner.invoke(cli, ["--help"])
     assert result.output.splitlines()[0] == expected_usage_line
+
+
+def test_write_usage_does_not_break_options_at_hyphen():
+    """Issue #3362: options containing hyphens should not be split across lines."""
+    options = [
+        "--enable-verbose-logging",
+        "--output-file-path",
+        "--max-retry-count",
+        "--disable-cache-mode",
+        "--config-file-location",
+        "--user-auth-token",
+        "--auto-update-interval",
+        "--force-overwrite-existing",
+        "--network-timeout-seconds",
+        "--debug-trace-enabled",
+    ]
+    f = click.HelpFormatter(width=65)
+    f.write_usage("program", " ".join(options))
+    expected = (
+        "Usage: program --enable-verbose-logging --output-file-path\n"
+        "               --max-retry-count --disable-cache-mode\n"
+        "               --config-file-location --user-auth-token\n"
+        "               --auto-update-interval --force-overwrite-existing\n"
+        "               --network-timeout-seconds --debug-trace-enabled\n"
+    )
+    assert f.getvalue() == expected
+
+
+def test_wrap_text_break_on_hyphens():
+    """wrap_text with break_on_hyphens=False should not break hyphenated words."""
+    text = "word1 word2 long-hyphenated-identifier word3"
+    # width=35 forces wrap after word2 when break_on_hyphens=False
+    wrapped_no_break = click.wrap_text(text, width=35, break_on_hyphens=False)
+    assert wrapped_no_break == "word1 word2\nlong-hyphenated-identifier word3"
+
+    wrapped_default = click.wrap_text(text, width=35)
+    assert wrapped_default == "word1 word2 long-hyphenated-\nidentifier word3"


### PR DESCRIPTION
### Summary of Changes

When `HelpFormatter.write_usage(prog, args)` formats usage lines containing hyphenated options (such as `--output-file-path` or `--max-retry-count`), long option names that fall near the line margin were being split across lines at the hyphen:

```text
Usage: program --enable-verbose-logging --output-file-path --max-
               retry-count --disable-cache-mode ...
```

This PR prevents breaking CLI options and arguments at hyphens:

1. Added `break_on_hyphens: bool = True` parameter to `click.formatting.wrap_text()`, forwarding it to `TextWrapper`.
2. Passed `break_on_hyphens=False` in `HelpFormatter.write_usage()` so that tokens like `--max-retry-count` are preserved intact and moved to the next line as a single unit.
3. Added unit tests in `tests/test_formatting.py` covering hyphen preservation in usage lines and `wrap_text()`.
4. Added changelog entry in `CHANGES.md` under 8.5.1 and documented the new parameter in `src/click/formatting.py`.

Fixes #3362

### Checklist
- [x] **tests**: Added unit tests in `tests/test_formatting.py` verifying fix and parameter behavior.
- [x] **docs**: Added entry in `CHANGES.md` and updated docstrings in `src/click/formatting.py`.
