### PR TITLE
[rejected AI] Show repeated option metavars in help

### DIFF
--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2427,7 +2427,7 @@ class Parameter(ABC):
         if metavar is None:
             metavar = self.type.name.upper()
 
-        if self.nargs != 1:
+        if self.nargs != 1 or self.multiple:
             metavar += "..."
 
         return metavar

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -582,6 +582,18 @@ def test_multiple_default_help(runner):
     assert "1, 2" in result.output
 
 
+def test_multiple_option_help_shows_repeated_metavar(runner):
+    @click.command()
+    @click.option("--foo", multiple=True, help="A list of foo strings.")
+    def cmd(foo):
+        pass
+
+    result = runner.invoke(cmd, ["--help"])
+
+    assert not result.exception
+    assert "--foo TEXT...  A list of foo strings." in result.output
+
+
 def test_show_default_default_map(runner):
     @click.command()
     @click.option("--arg", default="a", show_default=True)


### PR DESCRIPTION
Fixes #3652.

Automatically append `...` to generated option metavars when `multiple=True`, so help output communicates that an option may be repeated (for example, `--foo TEXT...`). Added a help-output regression test.

Tests: `python -m pytest tests/test_options.py -q` (647 passed). The full suite also exposed two unrelated sandbox subprocess-handle failures.