### PR TITLE
[rejected AI] Reject incomplete envvar batches for multiple+nargs options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 Unreleased
 
+-   Options with `multiple=True` and `nargs > 1` no longer silently drop
+    trailing tokens when an environment variable value's token count is
+    not a multiple of `nargs`. Incomplete envvar values now raise
+    `BadParameter`, matching arity checks for non-multiple `nargs`
+    options. {issue}`3843`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -3580,6 +3580,19 @@ class Option(Parameter):
         if value_depth > 0:
             multi_rv = self.type.split_envvar_value(rv)
             if self.multiple and self.nargs != 1:
+                # batch() uses zip(strict=False) and would silently drop a
+                # trailing incomplete group. Reject incomplete envvar values
+                # the same way type_cast_value rejects wrong-arity groups.
+                if len(multi_rv) % self.nargs != 0:
+                    raise BadParameter(
+                        ngettext(
+                            "Takes {nargs} values but 1 was given.",
+                            "Takes {nargs} values but {len} were given.",
+                            len(multi_rv),
+                        ).format(nargs=self.nargs, len=len(multi_rv)),
+                        ctx=ctx,
+                        param=self,
+                    )
                 multi_rv = batch(multi_rv, self.nargs)  # type: ignore[assignment]
 
             return multi_rv

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -755,6 +755,32 @@ def test_nargs_envvar(runner):
     assert result.output == "x|1\ny|2\n"
 
 
+@pytest.mark.parametrize(
+    ("env_value", "token_count"),
+    [
+        ("a b c", 3),
+        ("a b c d e", 5),
+    ],
+)
+def test_multiple_nargs_envvar_rejects_incomplete_batch(
+    runner, env_value, token_count
+):
+    """Envvar values for multiple+nargs options must not silently drop tokens.
+
+    ``batch()`` uses ``zip(..., strict=False)``, so without an explicit check
+    a trailing incomplete group would be discarded and the command would exit 0.
+    """
+
+    @click.command()
+    @click.option("--arg", nargs=2, multiple=True, envvar="ARG")
+    def cmd(arg):
+        return arg
+
+    result = runner.invoke(cmd, [], env={"ARG": env_value}, standalone_mode=False)
+    assert isinstance(result.exception, click.BadParameter)
+    assert f"Takes 2 values but {token_count} were given." in str(result.exception)
+
+
 def test_show_envvar(runner):
     @click.command()
     @click.option("--arg1", envvar="ARG1", show_envvar=True)


### PR DESCRIPTION
For options with `multiple=True` and `nargs > 1`, environment-variable values whose token count is not a multiple of `nargs` were silently truncated by `batch()` (`zip(..., strict=False)`), so incomplete values exited 0 and dropped trailing tokens. CLI parsing rejects the same incomplete input.

This change validates that the split envvar token count is a multiple of `nargs` in `Option.value_from_envvar()` and raises `BadParameter` (same message family as non-multiple `nargs` envvar checks) before batching.

**AI assistance disclosure:** Developed with assistance from Cursor (AI coding agent). I reproduced the bug, reviewed the fix/tests, and validated locally.

fixes #3843

- [x] Tests added (`test_multiple_nargs_envvar_rejects_incomplete_batch`)
- [x] `CHANGES.md` entry added for 8.5.1
- [x] No docs/`versionchanged` needed (bugfix aligning envvar path with existing arity errors)
