### PR TITLE
[rejected AI] support FORCE_COLOR, NO_COLOR, and PYTHON_COLORS environment variables

### DIFF
--- a/src/click/_compat.py
+++ b/src/click/_compat.py
@@ -503,6 +503,18 @@ def should_strip_ansi(
     stream: t.IO[t.Any] | None = None, color: bool | None = None
 ) -> bool:
     if color is None:
+        if "NO_COLOR" in os.environ and os.environ["NO_COLOR"] != "":
+            return True
+        if os.environ.get("PYTHON_COLORS") == "0":
+            return True
+        if "FORCE_COLOR" in os.environ:
+            val = os.environ["FORCE_COLOR"]
+            if val != "0" and val.lower() != "false":
+                return False
+            return True
+        if os.environ.get("PYTHON_COLORS") == "1":
+            return False
+
         if stream is None:
             stream = sys.stdin
         elif hasattr(stream, "color"):

--- a/src/click/globals.py
+++ b/src/click/globals.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import typing as t
 from threading import local
 
@@ -7,6 +8,25 @@ if t.TYPE_CHECKING:
     from .core import Context
 
 _local = local()
+
+
+def _is_forced_color() -> bool:
+    if "FORCE_COLOR" in os.environ:
+        val = os.environ["FORCE_COLOR"]
+        return val != "0" and val.lower() != "false"
+    if os.environ.get("PYTHON_COLORS") == "1":
+        return True
+    return False
+
+
+def _is_no_color() -> bool:
+    if "NO_COLOR" in os.environ and os.environ["NO_COLOR"] != "":
+        return True
+    if os.environ.get("PYTHON_COLORS") == "0":
+        return True
+    if os.environ.get("FORCE_COLOR") in ("0", "false", "FALSE"):
+        return True
+    return False
 
 
 @t.overload
@@ -54,14 +74,20 @@ def pop_context() -> None:
 def resolve_color_default(color: bool | None = None) -> bool | None:
     """Internal helper to get the default value of the color flag.  If a
     value is passed it's returned unchanged, otherwise it's looked up from
-    the current context.
+    the current context, or environment variables (``NO_COLOR``,
+    ``FORCE_COLOR``, ``PYTHON_COLORS``).
     """
     if color is not None:
         return color
 
     ctx = get_current_context(silent=True)
 
-    if ctx is not None:
+    if ctx is not None and ctx.color is not None:
         return ctx.color
+
+    if _is_no_color():
+        return False
+    if _is_forced_color():
+        return True
 
     return None

--- a/src/click/testing.py
+++ b/src/click/testing.py
@@ -507,6 +507,17 @@ class CliRunner:
             stream: t.IO[t.Any] | None = None, color: bool | None = None
         ) -> bool:
             if color is None:
+                if "NO_COLOR" in os.environ and os.environ["NO_COLOR"] != "":
+                    return True
+                if os.environ.get("PYTHON_COLORS") == "0":
+                    return True
+                if "FORCE_COLOR" in os.environ:
+                    val = os.environ["FORCE_COLOR"]
+                    if val != "0" and val.lower() != "false":
+                        return False
+                    return True
+                if os.environ.get("PYTHON_COLORS") == "1":
+                    return False
                 return not default_color
             return not color
 

--- a/tests/test_utils/test_echo.py
+++ b/tests/test_utils/test_echo.py
@@ -88,6 +88,104 @@ def test_echo_color_flag(monkeypatch, capfd):
     assert out == f"{styled_text}\n"
 
 
+def test_echo_force_color(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: False)
+
+    text = "foo"
+    styled_text = click.style(text, fg="red")
+
+    # Default without FORCE_COLOR on non-tty strips color
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("PYTHON_COLORS", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{text}\n"
+
+    # FORCE_COLOR=1 forces color
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+    # FORCE_COLOR=true forces color
+    monkeypatch.setenv("FORCE_COLOR", "true")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+    # FORCE_COLOR=0 disables color
+    monkeypatch.setenv("FORCE_COLOR", "0")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{text}\n"
+
+    # PYTHON_COLORS=1 forces color
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("PYTHON_COLORS", "1")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+    # PYTHON_COLORS=0 disables color
+    monkeypatch.setenv("PYTHON_COLORS", "0")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{text}\n"
+
+    # Explicit color=False overrides FORCE_COLOR=1
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    click.echo(styled_text, color=False)
+    out, _ = capfd.readouterr()
+    assert out == f"{text}\n"
+
+
+def test_echo_no_color(monkeypatch, capfd):
+    monkeypatch.setattr(click._compat, "isatty", lambda x: True)
+
+    text = "foo"
+    styled_text = click.style(text, fg="red")
+
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("PYTHON_COLORS", raising=False)
+
+    # NO_COLOR=1 strips color even on TTY
+    monkeypatch.setenv("NO_COLOR", "1")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{text}\n"
+
+    # NO_COLOR="" (empty) does not disable color
+    monkeypatch.setenv("NO_COLOR", "")
+    click.echo(styled_text)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+    # Explicit color=True overrides NO_COLOR
+    monkeypatch.setenv("NO_COLOR", "1")
+    click.echo(styled_text, color=True)
+    out, _ = capfd.readouterr()
+    assert out == f"{styled_text}\n"
+
+
+def test_echo_runner_env_color(runner):
+    @click.command()
+    def cli():
+        click.echo(click.style("hello", fg="green"))
+
+    # Default runner has no color
+    result = runner.invoke(cli)
+    assert result.output == "hello\n"
+
+    # FORCE_COLOR=1 enables color in runner
+    result = runner.invoke(cli, env={"FORCE_COLOR": "1"})
+    assert result.output == f"{click.style('hello', fg='green')}\n"
+
+    # NO_COLOR=1 disables color in runner even if runner color=True
+    result = runner.invoke(cli, color=True, env={"NO_COLOR": "1"})
+    assert result.output == "hello\n"
+
+
 @pytest.mark.skipif(WIN, reason="Test too complex to make work windows.")
 def test_echo_writing_to_standard_error(capfd, monkeypatch):
     def emulate_input(text):


### PR DESCRIPTION
## Description

Currently, Click only determines the default color preference by checking whether the output stream is a physical TTY (`isatty(stream)`). In CI/CD environments (GitHub Actions, GitLab CI, Jenkins) and automated build logs, output streams are pipes/files where `isatty()` is False, which strips color and ANSI styling unless `color=True` is explicitly passed.

Standards like [NO_COLOR](https://no-color.org), [FORCE_COLOR](https://force-color.org), and Python 3.13's standard `PYTHON_COLORS` allow users and build environments to control ANSI color output globally.

### Changes
1. **`src/click/globals.py`**:
   - Extended `resolve_color_default()` to inspect `NO_COLOR`, `FORCE_COLOR`, and `PYTHON_COLORS` when no explicit `color` flag or `ctx.color` is configured:
     - `NO_COLOR` (non-empty) or `PYTHON_COLORS="0"` / `FORCE_COLOR="0"` -> returns `False` (disable color).
     - `FORCE_COLOR` (non-zero/true) or `PYTHON_COLORS="1"` -> returns `True` (enable color).
2. **`src/click/_compat.py`**:
   - Updated `should_strip_ansi()` to respect `NO_COLOR`, `FORCE_COLOR`, and `PYTHON_COLORS` when `color is None`.
3. **`src/click/testing.py`**:
   - Updated `CliRunner.isolation()`'s `should_strip_ansi` mock to evaluate environment variables during test runs.
4. **`tests/test_utils/test_echo.py`**:
   - Added `test_echo_force_color` testing `FORCE_COLOR=1`, `FORCE_COLOR=true`, `FORCE_COLOR=0`, `PYTHON_COLORS=1`, `PYTHON_COLORS=0`, and explicit `color=False` override on non-TTY streams.
   - Added `test_echo_no_color` testing `NO_COLOR=1`, `NO_COLOR=""`, and explicit `color=True` override on TTY streams.
   - Added `test_echo_runner_env_color` testing `CliRunner` invocations with environment variables.

Closes #3022
