### PR TITLE
[rejected AI] Fix `BOOL` conversion of `0` and `1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Unreleased
 
+- `BOOL` converts `0` and `1` to `False` and `True` again instead of raising
+  `AttributeError`. Regression introduced in `8.2.2` by {pr}`2956`.
+  {issue}`3846`
+
 ## Version 8.5.0
 
 Released 2026-08-24

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -852,9 +852,9 @@ class BoolParamType(ParamType[bool]):
 
         Returns `None` if the value does not match any known boolean state.
         """
-        if isinstance(value, bool):
-            return value
-        return BoolParamType.bool_states.get(value.strip().lower())
+        if value in {False, True}:
+            return bool(value)
+        return BoolParamType.bool_states.get(str(value).strip().lower())
 
     def convert(
         self, value: t.Any, param: Parameter | None, ctx: Context | None

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -321,6 +321,8 @@ def test_boolean_switch(runner, args, default, expect):
         (True, [], True),
         (False, ["--f"], True),
         (False, [], False),
+        (1, [], True),
+        (0, [], False),
         # Boolean flags have a 3-states logic.
         # See: https://github.com/pallets/click/issues/3024#issue-3285556668
         (None, ["--f"], True),


### PR DESCRIPTION
`BOOL` raises `AttributeError: 'int' object has no attribute 'strip'` when it
receives a number instead of a string. This happens for a boolean option with
`default=1` or `default=0`, for a `default_map` loaded from a config file
where a boolean came through as a number, and for `click.prompt(type=bool)`
with a numeric default.

```python
import click
click.BOOL(1)
```

Click 8.0 through 8.2.1 accepted `0` and `1` through the `value in {False, True}`
guard added in e79c2b4. #2956 (8.2.2) replaced it with `isinstance(value, bool)`
while reworking `str_to_bool`, so numbers now fall through to the string path.

This restores the guard and passes the value through `str()` before the
lookup, so `0` and `1` convert to `False` and `True` again and any other
non-string input produces the usual "is not a valid boolean" error instead of
a traceback.

fixes #3846