### PR TITLE
[rejected AI] Deprecate public names for internal type helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ Unreleased
   returns `None` for hidden options, so help screens are unchanged. {pr}`3821`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
+- `FuncParamType` and `convert_type` were never intentionally public and are
+  now private (`_`-prefixed). The old names remain available with a
+  `DeprecationWarning` until Click 9.0. {issue}`3847`
 
 ## Version 8.5.0
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2356,7 +2356,7 @@ class Parameter(ABC):
         self.name, self.opts, self.secondary_opts = self._parse_decls(
             param_decls or (), expose_value
         )
-        self.type: types.ParamType[t.Any] = types.convert_type(type, default)
+        self.type: types.ParamType[t.Any] = types._convert_type(type, default)
 
         # Default nargs to what the type tells us if we have that
         # information available.
@@ -3139,7 +3139,7 @@ class Option(Parameter):
         if flag_value is UNSET or isinstance(flag_value, bool):
             return types.BoolParamType()
 
-        guessed: types.ParamType[t.Any] = types.convert_type(None, flag_value)
+        guessed: types.ParamType[t.Any] = types._convert_type(None, flag_value)
         if (
             isinstance(guessed, types.StringParamType)
             and not isinstance(flag_value, str)

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -18,8 +18,8 @@ from ._compat import strip_ansi
 from .exceptions import Abort
 from .exceptions import UsageError
 from .globals import resolve_color_default
+from .types import _convert_type
 from .types import Choice
-from .types import convert_type
 from .types import ParamType
 from .utils import _LazyFile
 from .utils import echo
@@ -245,7 +245,7 @@ def prompt(
             raise Abort() from None
 
     if value_proc is None:
-        value_proc = convert_type(type, default)
+        value_proc = _convert_type(type, default)
 
     prompt = _build_prompt(
         text, prompt_suffix, show_default, default, show_choices, type

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -250,7 +250,7 @@ else:
         func: t.Callable[[t.Any], t.Any]
 
 
-class FuncParamType(ParamType[_ValueT_co], t.Generic[_ValueT_contra, _ValueT_co]):
+class _FuncParamType(ParamType[_ValueT_co], t.Generic[_ValueT_contra, _ValueT_co]):
     name: str
     func: t.Callable[[_ValueT_contra], _ValueT_co]
 
@@ -259,7 +259,9 @@ class FuncParamType(ParamType[_ValueT_co], t.Generic[_ValueT_contra, _ValueT_co]
         self.func = func
 
     def to_info_dict(self) -> FuncParamTypeInfoDict[_ValueT_contra, _ValueT_co]:
-        return {"func": self.func, **super().to_info_dict()}
+        info = super().to_info_dict()
+        info["param_type"] = "Func"
+        return {"func": self.func, **info}
 
     def convert(
         self, value: _ValueT_contra, param: Parameter | None, ctx: Context | None
@@ -415,7 +417,7 @@ class Choice(ParamType[_ValueT_co], t.Generic[_ValueT_co]):
     def get_metavar(self, param: Parameter, ctx: Context) -> str | None:
         if param.param_type_name == "option" and not param.show_choices:  # type: ignore[attr-defined]
             choice_metavars = [
-                convert_type(type(choice)).name.upper() for choice in self.choices
+                _convert_type(type(choice)).name.upper() for choice in self.choices
             ]
             choices_str = "|".join([*dict.fromkeys(choice_metavars)])
         else:
@@ -1255,7 +1257,9 @@ class Tuple(CompositeParamType[tuple[t.Any, ...]]):
     """
 
     def __init__(self, types: cabc.Sequence[type[t.Any] | ParamType[t.Any]]) -> None:
-        self.types: cabc.Sequence[ParamType[t.Any]] = [convert_type(ty) for ty in types]
+        self.types: cabc.Sequence[ParamType[t.Any]] = [
+            _convert_type(ty) for ty in types
+        ]
 
     def to_info_dict(self) -> TupleInfoDict:
         return {
@@ -1312,7 +1316,7 @@ def _guess_type(
     if not isinstance(default, (tuple, list)):
         return type(default)
 
-    # If the default is empty, return None so convert_type falls
+    # If the default is empty, return None so _convert_type falls
     # through to STRING.
     if not default:
         return None
@@ -1320,7 +1324,7 @@ def _guess_type(
     item = default[0]
 
     # A sequence of iterables needs to detect the inner types.
-    # Can't call convert_type recursively because that would
+    # Can't call _convert_type recursively because that would
     # incorrectly unwind the tuple to a single type.
     if isinstance(item, (tuple, list)):
         return tuple(map(type, item))
@@ -1329,16 +1333,16 @@ def _guess_type(
 
 
 @t.overload
-def convert_type(ty: None, default: None = None) -> StringParamType: ...
+def _convert_type(ty: None, default: None = None) -> StringParamType: ...
 @t.overload
-def convert_type(
+def _convert_type(
     ty: type | ParamType[t.Any], default: t.Any | None = None
 ) -> ParamType[t.Any]: ...
 @t.overload
-def convert_type(
+def _convert_type(
     ty: t.Any | None, default: t.Any | None = None
 ) -> ParamType[t.Any]: ...
-def convert_type(
+def _convert_type(
     ty: t.Any | None = None, default: t.Any | None = None
 ) -> ParamType[t.Any]:
     """Find the most appropriate :class:`ParamType` for the given Python
@@ -1379,7 +1383,7 @@ def convert_type(
             # guessed is an instance (correct), so issubclass fails.
             pass
 
-    return FuncParamType(guessed)
+    return _FuncParamType(guessed)
 
 
 #: A dummy parameter type that just does nothing.  From a user's
@@ -1420,3 +1424,17 @@ class OptionHelpExtra(t.TypedDict, total=False):
     default: str
     range: str
     required: str
+
+
+def __getattr__(name: str) -> object:
+    import warnings
+
+    if name in {"FuncParamType", "convert_type"}:
+        warnings.warn(
+            f"'click.types.{name}' is deprecated and will be removed in Click 9.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[f"_{name}"]
+
+    raise AttributeError(name)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -38,6 +38,9 @@ import click.utils
         (click.utils, "make_default_short_help", click.utils._make_default_short_help),
         (click.utils, "PacifyFlushWrapper", click.utils._PacifyFlushWrapper),
         (click.utils, "safecall", click.utils._safecall),
+        # Type helpers that were never exported from the top-level namespace.
+        (click.types, "FuncParamType", click.types._FuncParamType),
+        (click.types, "convert_type", click.types._convert_type),
         # Version metadata attribute.
         (click, "__version__", importlib.metadata.version("click")),
     ],
@@ -52,7 +55,7 @@ def test_attr_deprecated(module, name, target):
 
 @pytest.mark.parametrize(
     "module",
-    [click, click.core, click.parser, click.utils],
+    [click, click.core, click.parser, click.types, click.utils],
     ids=lambda m: m.__name__,
 )
 def test_unknown_attribute_raises(module):

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -96,7 +96,7 @@ HELLO_GROUP = (
     ("obj", "expect"),
     [
         pytest.param(
-            click.types.FuncParamType(range),
+            click.types._FuncParamType(range),
             {"param_type": "Func", "name": "range", "func": range},
             id="Func ParamType",
         ),

--- a/tests/test_types/test_FuncParamType.py
+++ b/tests/test_types/test_FuncParamType.py
@@ -14,7 +14,7 @@ def test_func_param_type_uses_value_error_message(error_message, expected):
     def parse(value):
         raise ValueError(error_message if error_message else "")
 
-    func_type = click.types.FuncParamType(parse)
+    func_type = click.types._FuncParamType(parse)
 
     with pytest.raises(click.BadParameter) as exc_info:
         func_type.convert("nope", None, None)

--- a/tests/test_types/test_convert_type.py
+++ b/tests/test_types/test_convert_type.py
@@ -27,7 +27,7 @@ def test_convert_type_from_container_default(default):
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    assert click.types.convert_type(None, default) is click.STRING
+    assert click.types._convert_type(None, default) is click.STRING
 
 
 @pytest.mark.parametrize(
@@ -39,12 +39,12 @@ def test_convert_type_from_container_default(default):
 )
 def test_explicit_container_type_splits_string(container_type, value, expected):
     """An explicit ``set`` or ``frozenset`` type wraps the builtin in a
-    ``FuncParamType``, which splits CLI strings character-wise.
+    ``_FuncParamType``, which splits CLI strings character-wise.
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(container_type)
-    assert isinstance(param_type, click.types.FuncParamType)
+    param_type = click.types._convert_type(container_type)
+    assert isinstance(param_type, click.types._FuncParamType)
     assert param_type.convert(value, None, None) == expected
 
 
@@ -82,7 +82,7 @@ def test_type_inferred_from_default(default, expected):
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    assert click.types.convert_type(None, default) is expected
+    assert click.types._convert_type(None, default) is expected
 
 
 def test_type_inferred_from_nested_sequence_default():
@@ -92,7 +92,7 @@ def test_type_inferred_from_nested_sequence_default():
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(None, [(1, "git")])
+    param_type = click.types._convert_type(None, [(1, "git")])
     assert isinstance(param_type, click.Tuple)
     assert param_type.types == [click.INT, click.STRING]
 
@@ -102,7 +102,7 @@ def test_explicit_dict_type_rejects_string():
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(dict)
-    assert isinstance(param_type, click.types.FuncParamType)
+    param_type = click.types._convert_type(dict)
+    assert isinstance(param_type, click.types._FuncParamType)
     with pytest.raises(click.BadParameter):
         param_type.convert("abc", None, None)


### PR DESCRIPTION
Rename the internal implementations to `_FuncParamType` and `_convert_type`, while keeping the old module attributes available through `__getattr__` with a deprecation warning until Click 9.0. Internal call sites and tests now use the private names.

The existing `to_info_dict()` output remains compatible (`param_type` is still `Func`).

Validation:
- `uv run pytest` (2062 passed, 24 skipped, 1 xfailed)
- `uv run tox run -e style,typing`

Developed with assistance from OpenAI Codex.

Fixes #3847