### PR TITLE
[rejected AI] Fix editor command mangling on Windows in `edit()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@ Unreleased
   returns `None` for hidden options, so help screens are unchanged. {pr}`3821`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
+- `edit()` no longer splits the editor command with POSIX `shlex` rules on
+  Windows. That treated backslashes as escape characters, mangling Windows
+  paths (`C:\Windows\System32\notepad.exe` became
+  `C:WindowsSystem32notepad.exe`) into program names `CreateProcess` could
+  not resolve, with errors like `WinError 87` or `14001`. The editor string
+  is passed to `subprocess` verbatim as the command line, and only the
+  appended filenames are quoted. Behavior on other platforms is unchanged.
+  {issue}`3840`
 
 ## Version 8.5.0
 

--- a/src/click/_termui_impl.py
+++ b/src/click/_termui_impl.py
@@ -722,12 +722,30 @@ class Editor:
             environ = os.environ.copy()
             environ.update(self.env)
 
-        try:
+        filenames = list(filenames)
+
+        if WIN:
+            # The editor string is a command line in Windows syntax:
+            # backslashes are path separators, not escape characters, and
+            # double quotes group paths with spaces. Splitting it with
+            # POSIX shlex rules eats backslashes and splits unquoted
+            # paths, producing a program name CreateProcess cannot
+            # resolve. Pass the editor string verbatim as the command
+            # line and quote only the appended filenames.
+            args: str | list[str] = editor
+
+            if filenames:
+                quoted = subprocess.list2cmdline([os.fspath(f) for f in filenames])
+                args = f"{editor} {quoted}"
+        else:
             # Split in POSIX mode (the default) for the same reasons as
             # in pager(): strips quotes from tokens and preserves quoted
             # Windows paths.
+            args = shlex.split(editor) + filenames
+
+        try:
             c = subprocess.Popen(
-                args=shlex.split(editor) + list(filenames),
+                args=args,
                 env=environ,
             )
             exit_code = c.wait()

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -555,6 +555,7 @@ def test_edit_pathlib(runner, tmp_path, use_iterable):
         ),
     ],
 )
+@pytest.mark.skipif(WIN, reason="Windows passes the editor string through verbatim.")
 def test_editor_path_normalization(editor_cmd, filenames, expected_args):
     with patch("subprocess.Popen") as mock_popen:
         mock_popen.return_value.wait.return_value = 0
@@ -568,30 +569,72 @@ def test_editor_path_normalization(editor_cmd, filenames, expected_args):
 
 @pytest.mark.skipif(not WIN, reason="Windows-specific editor paths")
 @pytest.mark.parametrize(
-    ("editor_cmd", "expected_cmd"),
+    ("editor_cmd", "filenames", "expected_cmd"),
     [
         pytest.param(
             "notepad",
-            ["notepad"],
+            ["f.txt"],
+            "notepad f.txt",
             id="plain notepad",
         ),
         pytest.param(
             '"C:\\Program Files\\Sublime Text 3\\sublime_text.exe" --wait',
-            ["C:\\Program Files\\Sublime Text 3\\sublime_text.exe", "--wait"],
+            ["f.txt"],
+            '"C:\\Program Files\\Sublime Text 3\\sublime_text.exe" --wait f.txt',
             id="quoted path with flag",
+        ),
+        pytest.param(
+            "C:\\Windows\\System32\\notepad.exe",
+            ["f.txt"],
+            "C:\\Windows\\System32\\notepad.exe f.txt",
+            id="unquoted absolute path keeps backslashes",
+        ),
+        pytest.param(
+            "C:\\Program Files\\My Editor\\edit.exe --wait",
+            ["f.txt"],
+            "C:\\Program Files\\My Editor\\edit.exe --wait f.txt",
+            id="unquoted path with spaces stays a single command line",
+        ),
+        pytest.param(
+            "notepad",
+            ["file 1.txt", "file 2.txt"],
+            'notepad "file 1.txt" "file 2.txt"',
+            id="filenames with spaces are quoted",
         ),
     ],
 )
-def test_editor_windows_path_normalization(editor_cmd, expected_cmd):
-    """Windows-specific tests: verify ``Popen`` receives unquoted paths that
-    ``subprocess.list2cmdline`` can re-quote for ``CreateProcess``."""
+def test_editor_windows_path_normalization(editor_cmd, filenames, expected_cmd):
+    """Windows-specific tests: the editor string is a command line in
+    Windows syntax, so it is passed to ``Popen`` verbatim; only the
+    appended filenames are quoted with ``subprocess.list2cmdline``.
+
+    Splitting it with POSIX shlex rules eats backslashes and splits
+    unquoted paths (``C:\\Windows\\System32\\notepad.exe`` became
+    ``C:WindowsSystem32notepad.exe``), producing a program name
+    ``CreateProcess`` cannot resolve (issue #3840).
+    """
     with patch("subprocess.Popen") as mock_popen:
         mock_popen.return_value.wait.return_value = 0
-        Editor(editor=editor_cmd).edit_files(["f.txt"])
+        Editor(editor=editor_cmd).edit_files(filenames)
 
         args = mock_popen.call_args[1].get("args") or mock_popen.call_args[0][0]
-        assert args == expected_cmd + ["f.txt"]
+        assert args == expected_cmd
         assert mock_popen.call_args[1].get("shell") is None
+
+
+@pytest.mark.skipif(not WIN, reason="Uses cmd.exe as a stand-in editor.")
+def test_editor_launches_on_windows(tmp_path):
+    """A fully-qualified editor path must reach ``CreateProcess`` intact.
+
+    ``cmd.exe /d /c exit 0`` stands in for a real editor: it never blocks
+    and exits successfully, while its backslash path is exactly what the
+    former POSIX splitting mangled (issue #3840).
+    """
+    f = tmp_path / "f.txt"
+    f.write_text("hello", encoding="utf-8")
+    editor = f"{os.environ['SystemRoot']}\\System32\\cmd.exe /d /c exit 0"
+
+    Editor(editor=editor).edit_files([f])
 
 
 def test_editor_env_passed_through():
@@ -1308,6 +1351,7 @@ def test_tempfile_pager_closes_file_before_unlink(monkeypatch):
     )
 
 
+@pytest.mark.skipif(WIN, reason="Windows passes the editor string through verbatim.")
 def test_editor_unclosed_quote():
     """An unclosed quote in the editor command raises ValueError."""
     with pytest.raises(ValueError, match="No closing quotation"):


### PR DESCRIPTION
`Editor.edit_files()` built `subprocess.Popen` arguments on all platforms by running the editor string through `shlex.split` in POSIX mode, where backslashes are escape characters. On Windows the editor setting is a command line in Windows syntax — backslashes are path separators — so POSIX splitting ate them and split unquoted paths: `C:\Windows\System32\notepad.exe` became the drive-relative `C:WindowsSystem32notepad.exe`, and `C:\Program Files\My Editor\edit.exe --wait` collapsed into three garbage tokens. `Popen` then handed `CreateProcess` a command line whose program token could not be resolved, surfacing as the intermittent `WinError 87`/`14001` failures reported in the issue instead of the editor launching.

On Windows the editor string is now passed to `subprocess` verbatim as the command line (CPython passes a string `args` straight through as `lpCommandLine`), and only the appended filenames are quoted with `subprocess.list2cmdline`, matching how `cmd.exe` itself would invoke the editor. Non-Windows behavior is unchanged. Covered by mocked argument-construction tests plus a Windows CI test that launches a fully-qualified, immediately-exiting stand-in editor through the fixed path.

Fixes #3840
