### PR TITLE
Always list all positional arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ Unreleased
 - Add {meth}`Option.get_help_spec`, which returns the option's left help
   column even when the option is hidden. {meth}`Option.get_help_record` still
   returns `None` for hidden options, so help screens are unchanged. {pr}`3821`
+- The `Positional arguments` help section lists every argument of the command,
+  not only the documented ones. An argument with no `help` gets an empty
+  description, the same way an option with no `help` does. {pr}`3860`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
 - `path_type` narrows the converted value's type for `convert` and `prompt`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Unreleased
 - The `Positional arguments` help section lists every argument of the command,
   not only the documented ones. An argument with no `help` gets an empty
   description, the same way an option with no `help` does. {pr}`3860`
+- {meth}`Argument.get_help_record` always returns a tuple. It used to return
+  `None` for an argument with no `help`. {pr}`3860`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
 - `path_type` narrows the converted value's type for `convert` and `prompt`.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -12,7 +12,8 @@ Arguments are:
   can take an arbitrary number of inputs
 * Can take an optional `help` string shown in the `Positional arguments`
   section of the help page, or be {ref}`documented in the command docstring
-  <documenting-arguments>`.
+  <documenting-arguments>`. One argument with a `help` makes the section list
+  all the arguments of the command.
 
 Useful and often used kwargs are:
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -118,6 +118,10 @@ the `Positional arguments` section of the help page. You can still document
 arguments in the command docstring, especially when you want to describe them
 in the main help text by name.
 
+The section shows up as soon as one argument of the command has a `help`. It
+then lists every argument, so it always matches the usage line. Arguments with
+no `help` are listed with an empty description.
+
 A brief example:
 
 ```{eval-rst}

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1310,16 +1310,20 @@ class Command:
                 formatter.write_dl(opts)
 
     def format_arguments(self, ctx: Context, formatter: HelpFormatter) -> None:
-        """Writes the arguments that have a help record into the formatter."""
-        args = []
-        for param in self.get_params(ctx):
-            rv = param.get_help_record(ctx)
-            if rv is not None and isinstance(param, Argument):
-                args.append(rv)
+        """Writes all arguments into the formatter, if at least one is documented.
 
-        if args:
+        An argument with no help gets an empty description, the same way an option
+        with no help does. That keeps the section an exhaustive list of the
+        positional arguments, matching the usage line.
+        """
+        args = [param for param in self.get_params(ctx) if isinstance(param, Argument)]
+
+        if any(arg.help is not None for arg in args):
+            records = [
+                arg.get_help_record(ctx) or (arg.make_metavar(ctx), "") for arg in args
+            ]
             with formatter.section(_("Positional arguments")):
-                formatter.write_dl(args)
+                formatter.write_dl(records)
 
     def format_epilog(self, ctx: Context, formatter: HelpFormatter) -> None:
         """Writes the epilog into the formatter if it exists."""

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1319,11 +1319,8 @@ class Command:
         args = [param for param in self.get_params(ctx) if isinstance(param, Argument)]
 
         if any(arg.help is not None for arg in args):
-            records = [
-                arg.get_help_record(ctx) or (arg.make_metavar(ctx), "") for arg in args
-            ]
             with formatter.section(_("Positional arguments")):
-                formatter.write_dl(records)
+                formatter.write_dl([arg.get_help_record(ctx) for arg in args])
 
     def format_epilog(self, ctx: Context, formatter: HelpFormatter) -> None:
         """Writes the epilog into the formatter if it exists."""
@@ -3803,11 +3800,18 @@ class Argument(Parameter):
     def get_usage_pieces(self, ctx: Context) -> list[str]:
         return [self.make_metavar(ctx)]
 
-    def get_help_record(self, ctx: Context) -> tuple[str, str] | None:
-        if self.help is None:
-            return None
+    def get_help_record(self, ctx: Context) -> tuple[str, str]:
+        """Returns the argument's help row: its metavar and its help text.
 
-        return self.make_metavar(ctx), self.help
+        Unlike :meth:`Option.get_help_record`, this never returns ``None``. An
+        argument cannot be hidden, so an undocumented one still gets a row, with
+        an empty description.
+
+        .. versionchanged:: 8.5.1
+            Always returns a tuple. It used to return ``None`` when ``help`` was
+            not set.
+        """
+        return self.make_metavar(ctx), self.help or ""
 
     def get_error_hint(self, ctx: Context | None) -> str:
         if ctx is not None:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -402,6 +402,21 @@ def test_argument_help_empty_string_lists_all(runner):
     ]
 
 
+@pytest.mark.parametrize(
+    ("help_text", "expected"),
+    [
+        pytest.param(None, ("SRC", ""), id="None"),
+        pytest.param("", ("SRC", ""), id="empty"),
+        pytest.param("Source path", ("SRC", "Source path"), id="documented"),
+    ],
+)
+def test_argument_get_help_record_never_none(help_text, expected):
+    """Every argument gets a row, even an undocumented one."""
+    arg = click.Argument(["src"], help=help_text)
+    ctx = click.Context(click.Command("cli"))
+    assert arg.get_help_record(ctx) == expected
+
+
 def test_argument_help_optional_metavar(runner):
     @click.command()
     @click.argument("name", required=False, default="", help="The name to print")

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -324,6 +324,84 @@ def test_argument_help_options_only_no_arguments_section(runner):
     assert "number of greetings" in result.output
 
 
+def test_argument_help_lists_undocumented_arguments(runner):
+    """One documented argument makes the section list all of them."""
+
+    @click.command()
+    @click.argument("src", help="Source path")
+    @click.argument("dst")
+    @click.argument("extra", nargs=-1)
+    def cli(src, dst, extra):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    start = lines.index("Positional arguments:")
+    assert lines[start : start + 4] == [
+        "Positional arguments:",
+        "  SRC         Source path",
+        "  DST",
+        "  [EXTRA]...",
+    ]
+
+
+def test_argument_help_undocumented_arguments_only_no_section(runner):
+    """Arguments alone produce no section: at least one needs a help."""
+
+    @click.command()
+    @click.argument("src")
+    @click.argument("dst")
+    def cli(src, dst):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "Positional arguments:" not in result.output
+
+
+def test_argument_help_deprecated_without_help_lists_all(runner):
+    """A deprecation label counts as help and brings every argument into view."""
+
+    @click.command()
+    @click.argument("src", required=False, deprecated=True)
+    @click.argument("dst")
+    def cli(src, dst):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    start = lines.index("Positional arguments:")
+    assert lines[start : start + 3] == [
+        "Positional arguments:",
+        "  [SRC!]  (DEPRECATED)",
+        "  DST",
+    ]
+
+
+def test_argument_help_empty_string_lists_all(runner):
+    """An explicit empty help opens the section, the same way an empty option help
+    keeps its option listed.
+    """
+
+    @click.command()
+    @click.argument("src", help="")
+    @click.argument("dst")
+    def cli(src, dst):
+        pass
+
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    start = lines.index("Positional arguments:")
+    assert lines[start : start + 3] == [
+        "Positional arguments:",
+        "  SRC",
+        "  DST",
+    ]
+
+
 def test_argument_help_optional_metavar(runner):
     @click.command()
     @click.argument("name", required=False, default="", help="The name to print")


### PR DESCRIPTION
This is inconsistent with the way options are displayed, as every options are displayed including those without help.

The reason to display all arguments in the `Positional arguments` section is to not introduce subtle confusion, as an argument without help would only be noticeable in the usage line.

Cloup already renders the section this way (see https://github.com/janluke/cloup/issues/210) and is the source discussion with @janluke for that bug fix.

In this implementation, I refrained to always display the `Positional arguments` section. So I made the decision to not print the `Positional arguments` section in full if and only if at least one of its argument has an `help`. This decision is open to discussion.

This is a follow up on https://github.com/pallets/click/pull/3473