### PR TITLE
Move common `help` argument from `Option` and `Argument` to `Parameter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Unreleased
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
 - `path_type` narrows the converted value's type for `convert` and `prompt`.
   {issue}`3822` {pr}`3858`
+- {class}`Parameter` accepts a new `help` argument and {class}`Option` and {class}`Argument`
+  inherits it. {meth}`Parameter.to_info_dict` now reports `help` for every kind of parameter.
+  {pr}`3861`
 
 ## Version 8.5.0
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2259,6 +2259,12 @@ class Parameter(ABC):
                         its deprecation in --help. The message can be customized
                         by using a string as the value. A deprecated parameter
                         cannot be required, a ValueError will be raised otherwise.
+    :param help: the help string. It is dedented and get a deprecated label if
+        appropriate.
+
+    .. versionchanged:: 8.5.1
+        New ``help`` parameter to replace the one from :class:`Option` and
+        :class:`Argument`.
 
     .. versionchanged:: 8.2.0
         Introduction of ``deprecated``.
@@ -2323,6 +2329,7 @@ class Parameter(ABC):
         t.Callable[[Context, Parameter, str], list[CompletionItem] | list[str]] | None
     )
     deprecated: bool | str
+    help: str | None
 
     def __init__(
         self,
@@ -2352,6 +2359,7 @@ class Parameter(ABC):
         ]
         | None = None,
         deprecated: bool | str = False,
+        help: str | None = None,
     ) -> None:
         self.name, self.opts, self.secondary_opts = self._parse_decls(
             param_decls or (), expose_value
@@ -2383,6 +2391,15 @@ class Parameter(ABC):
         self.envvar = envvar
         self._custom_shell_complete = shell_complete
         self.deprecated = deprecated
+
+        if help:
+            help = inspect.cleandoc(help)
+
+        if deprecated:
+            label = _format_deprecated_label(deprecated)
+            help = f"{help} {label}" if help else label
+
+        self.help = help
 
         if __debug__:
             if self.type.is_composite and nargs != self.type.arity:
@@ -2429,6 +2446,7 @@ class Parameter(ABC):
             "multiple": self.multiple,
             "default": self._hide_unset(self.default),
             "envvar": self.envvar,
+            "help": self.help,
         }
 
     def __repr__(self) -> str:
@@ -2971,7 +2989,6 @@ class Option(Parameter):
 
     count: bool
     allow_from_autoenv: bool
-    help: str | None
     show_default: bool | str | None
     show_choices: bool
     show_envvar: bool
@@ -2997,11 +3014,13 @@ class Option(Parameter):
         deprecated: bool | str = False,
         **attrs: t.Any,
     ) -> None:
-        if help:
-            help = inspect.cleandoc(help)
-
         super().__init__(
-            param_decls, type=type, multiple=multiple, deprecated=deprecated, **attrs
+            param_decls,
+            type=type,
+            multiple=multiple,
+            deprecated=deprecated,
+            help=help,
+            **attrs,
         )
 
         # Phase 1: prompt-related attributes. ``_infer_flag_kind`` reads ``self.prompt``
@@ -3015,10 +3034,6 @@ class Option(Parameter):
             prompt_text = None
         else:
             prompt_text = prompt
-
-        if deprecated:
-            label = _format_deprecated_label(deprecated)
-            help = f"{help} {label}" if help else label
 
         self.prompt = prompt_text
         self.confirmation_prompt = confirmation_prompt
@@ -3049,7 +3064,6 @@ class Option(Parameter):
             self.default = 0
 
         self.allow_from_autoenv = allow_from_autoenv
-        self.help = help
         self.show_default = show_default
         self.show_choices = show_choices
         self.show_envvar = show_envvar
@@ -3211,7 +3225,6 @@ class Option(Parameter):
         info_dict = super().to_info_dict()
         info_dict.update(
             default=self._hide_unset(self._resolve_lazy_default(self.default)),
-            help=self.help,
             prompt=self.prompt,
             is_flag=self.is_flag,
             flag_value=self.flag_activation_value,
@@ -3734,23 +3747,7 @@ class Argument(Parameter):
         if "multiple" in attrs:
             raise TypeError("__init__() got an unexpected keyword argument 'multiple'.")
 
-        deprecated = attrs.get("deprecated", False)
-
-        if help:
-            help = inspect.cleandoc(help)
-
-        if deprecated:
-            label = _format_deprecated_label(deprecated)
-            help = f"{help} {label}" if help else label
-
-        self.help = help
-
-        super().__init__(param_decls, required=required, **attrs)
-
-    def to_info_dict(self) -> dict[str, t.Any]:
-        info_dict = super().to_info_dict()
-        info_dict.update(help=self.help)
-        return info_dict
+        super().__init__(param_decls, required=required, help=help, **attrs)
 
     @property
     def human_readable_name(self) -> str:

--- a/tests/test_info_dict.py
+++ b/tests/test_info_dict.py
@@ -276,6 +276,14 @@ def test_paramtype_no_name():
     assert TestType().to_info_dict()["name"] == "TestType"
 
 
+PARAM_KINDS = [
+    pytest.param(lambda **kwargs: click.Option(["--name"], **kwargs), id="option"),
+    pytest.param(lambda **kwargs: click.Argument(["name"], **kwargs), id="argument"),
+]
+"""Both concrete kinds of parameter, built from the same keyword arguments."""
+
+
+@pytest.mark.parametrize("make_param", PARAM_KINDS)
 @pytest.mark.parametrize(
     ("help_in", "help_out"),
     [
@@ -289,9 +297,31 @@ def test_paramtype_no_name():
         ),
     ],
 )
-def test_argument_to_info_dict_help(help_in, help_out):
-    arg = click.Argument(["name"], help=help_in)
-    assert arg.to_info_dict()["help"] == help_out
+def test_param_to_info_dict_help(make_param, help_in, help_out):
+    """`Parameter` owns the help string, so every kind dedents it the same way."""
+    assert make_param(help=help_in).to_info_dict()["help"] == help_out
+
+
+@pytest.mark.parametrize("make_param", PARAM_KINDS)
+@pytest.mark.parametrize(
+    ("help_in", "deprecated", "help_out"),
+    [
+        pytest.param(None, True, "(DEPRECATED)", id="no-help"),
+        pytest.param(
+            "Pack the basket.", True, "Pack the basket. (DEPRECATED)", id="help"
+        ),
+        pytest.param(
+            "Pack the basket.",
+            "USE THE CRATE",
+            "Pack the basket. (DEPRECATED: USE THE CRATE)",
+            id="custom-label",
+        ),
+    ],
+)
+def test_param_to_info_dict_deprecated_help(make_param, help_in, deprecated, help_out):
+    """A deprecated parameter of any kind gets the same label appended."""
+    param = make_param(help=help_in, required=False, deprecated=deprecated)
+    assert param.to_info_dict()["help"] == help_out
 
 
 def test_argument_to_info_dict_nargs():


### PR DESCRIPTION
This is a small refactor which deduplicate the management of `help` argument from `Option` and `Argument` and move it to the common `Parameter` parent class.

Its only side effect is that `Parameter.to_info_dict` now reports it.

This is a follow up on #3860.