### PR TITLE
[rejected AI] privatize convert_type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ Unreleased
   returns `None` for hidden options, so help screens are unchanged. {pr}`3821`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
+- `convert_type` in `click.types` was never intentionally public and is now
+  private (`_convert_type`). The old name remains available with a
+  `DeprecationWarning` until Click 9.0. {issue}`3847`
 
 ## Version 8.5.0
 

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -2356,7 +2356,7 @@ class Parameter(ABC):
         self.name, self.opts, self.secondary_opts = self._parse_decls(
             param_decls or (), expose_value
         )
-        self.type: types.ParamType[t.Any] = types.convert_type(type, default)
+        self.type: types.ParamType[t.Any] = types._convert_type(type, default)
 
         # Default nargs to what the type tells us if we have that
         # information available.
@@ -3139,7 +3139,7 @@ class Option(Parameter):
         if flag_value is UNSET or isinstance(flag_value, bool):
             return types.BoolParamType()
 
-        guessed: types.ParamType[t.Any] = types.convert_type(None, flag_value)
+        guessed: types.ParamType[t.Any] = types._convert_type(None, flag_value)
         if (
             isinstance(guessed, types.StringParamType)
             and not isinstance(flag_value, str)

--- a/src/click/termui.py
+++ b/src/click/termui.py
@@ -18,8 +18,8 @@ from ._compat import strip_ansi
 from .exceptions import Abort
 from .exceptions import UsageError
 from .globals import resolve_color_default
+from .types import _convert_type
 from .types import Choice
-from .types import convert_type
 from .types import ParamType
 from .utils import _LazyFile
 from .utils import echo
@@ -245,7 +245,7 @@ def prompt(
             raise Abort() from None
 
     if value_proc is None:
-        value_proc = convert_type(type, default)
+        value_proc = _convert_type(type, default)
 
     prompt = _build_prompt(
         text, prompt_suffix, show_default, default, show_choices, type

--- a/src/click/types.py
+++ b/src/click/types.py
@@ -415,7 +415,7 @@ class Choice(ParamType[_ValueT_co], t.Generic[_ValueT_co]):
     def get_metavar(self, param: Parameter, ctx: Context) -> str | None:
         if param.param_type_name == "option" and not param.show_choices:  # type: ignore[attr-defined]
             choice_metavars = [
-                convert_type(type(choice)).name.upper() for choice in self.choices
+                _convert_type(type(choice)).name.upper() for choice in self.choices
             ]
             choices_str = "|".join([*dict.fromkeys(choice_metavars)])
         else:
@@ -1255,7 +1255,9 @@ class Tuple(CompositeParamType[tuple[t.Any, ...]]):
     """
 
     def __init__(self, types: cabc.Sequence[type[t.Any] | ParamType[t.Any]]) -> None:
-        self.types: cabc.Sequence[ParamType[t.Any]] = [convert_type(ty) for ty in types]
+        self.types: cabc.Sequence[ParamType[t.Any]] = [
+            _convert_type(ty) for ty in types
+        ]
 
     def to_info_dict(self) -> TupleInfoDict:
         return {
@@ -1312,7 +1314,7 @@ def _guess_type(
     if not isinstance(default, (tuple, list)):
         return type(default)
 
-    # If the default is empty, return None so convert_type falls
+    # If the default is empty, return None so _convert_type falls
     # through to STRING.
     if not default:
         return None
@@ -1320,7 +1322,7 @@ def _guess_type(
     item = default[0]
 
     # A sequence of iterables needs to detect the inner types.
-    # Can't call convert_type recursively because that would
+    # Can't call _convert_type recursively because that would
     # incorrectly unwind the tuple to a single type.
     if isinstance(item, (tuple, list)):
         return tuple(map(type, item))
@@ -1329,21 +1331,25 @@ def _guess_type(
 
 
 @t.overload
-def convert_type(ty: None, default: None = None) -> StringParamType: ...
+def _convert_type(ty: None, default: None = None) -> StringParamType: ...
 @t.overload
-def convert_type(
+def _convert_type(
     ty: type | ParamType[t.Any], default: t.Any | None = None
 ) -> ParamType[t.Any]: ...
 @t.overload
-def convert_type(
+def _convert_type(
     ty: t.Any | None, default: t.Any | None = None
 ) -> ParamType[t.Any]: ...
-def convert_type(
+def _convert_type(
     ty: t.Any | None = None, default: t.Any | None = None
 ) -> ParamType[t.Any]:
     """Find the most appropriate :class:`ParamType` for the given Python
     type. If the type isn't provided, it can be inferred from a default
     value.
+
+    .. versionchanged:: 8.5.1
+        Renamed from ``convert_type``. The old name remains as a
+        deprecated alias.
     """
     guessed = _guess_type(ty, default)
     is_guessed = guessed is not ty
@@ -1380,6 +1386,27 @@ def convert_type(
             pass
 
     return FuncParamType(guessed)
+
+
+def convert_type(
+    ty: t.Any | None = None, default: t.Any | None = None
+) -> ParamType[t.Any]:
+    """Find the most appropriate :class:`ParamType` for the given Python
+    type. If the type isn't provided, it can be inferred from a default
+    value.
+
+    .. deprecated:: 8.5.1
+        Use :func:`_convert_type` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "'convert_type' is deprecated and will be removed in Click 9.0."
+        " Use '_convert_type' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _convert_type(ty, default)
 
 
 #: A dummy parameter type that just does nothing.  From a user's

--- a/tests/test_types/test_convert_type.py
+++ b/tests/test_types/test_convert_type.py
@@ -27,7 +27,7 @@ def test_convert_type_from_container_default(default):
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    assert click.types.convert_type(None, default) is click.STRING
+    assert click.types._convert_type(None, default) is click.STRING
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_explicit_container_type_splits_string(container_type, value, expected):
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(container_type)
+    param_type = click.types._convert_type(container_type)
     assert isinstance(param_type, click.types.FuncParamType)
     assert param_type.convert(value, None, None) == expected
 
@@ -82,7 +82,7 @@ def test_type_inferred_from_default(default, expected):
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    assert click.types.convert_type(None, default) is expected
+    assert click.types._convert_type(None, default) is expected
 
 
 def test_type_inferred_from_nested_sequence_default():
@@ -92,7 +92,7 @@ def test_type_inferred_from_nested_sequence_default():
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(None, [(1, "git")])
+    param_type = click.types._convert_type(None, [(1, "git")])
     assert isinstance(param_type, click.Tuple)
     assert param_type.types == [click.INT, click.STRING]
 
@@ -102,7 +102,19 @@ def test_explicit_dict_type_rejects_string():
 
     Refs: https://github.com/pallets/click/issues/3036
     """
-    param_type = click.types.convert_type(dict)
+    param_type = click.types._convert_type(dict)
     assert isinstance(param_type, click.types.FuncParamType)
     with pytest.raises(click.BadParameter):
         param_type.convert("abc", None, None)
+
+
+def test_convert_type_privatized_with_deprecated_alias():
+    """``convert_type`` is private (``_convert_type``); the old name warns.
+
+    Refs: https://github.com/pallets/click/issues/3847
+    """
+    assert hasattr(click.types, "_convert_type"), "expected private _convert_type"
+    assert click.types._convert_type(int) is click.INT
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        assert click.types.convert_type(int) is click.INT


### PR DESCRIPTION
Closes #3847.

Renames \click.types.convert_type\ to \_convert_type\; the old name remains as a deprecated shim emitting \DeprecationWarning\ (removed in Click 9.0). Internal callers in \	ypes.py\ (\Choice.get_metavar\, \Tuple\), \core.py\ (\Parameter\, \Option\), and \	ermui.py\ (\prompt\) now use \_convert_type\.

\FuncParamType\ audit: no top-level import in \click/__init__.py\, left unchanged to keep scope minimal.

Tests:
- New regression \	est_convert_type_privatized_with_deprecated_alias\ in \	ests/test_types/test_convert_type.py\: watched FAIL before fix (\hasattr(click.types, '_convert_type')\ AssertionError), PASS after.
- Existing behavior tests switched to canonical \_convert_type\ (required: pytest \ilterwarnings=error\).
- \pytest tests\ (PYTHONPATH=src): 1976 passed, 108 skipped, 1 xfailed.
- \uff check\ + \uff format --check\: clean. \mypy\ (strict): no errors in touched files (7 pre-existing errors in untouched \_termui_impl.py\/\	esting.py\, identical on baseline).

Note: run with \PYTEST_DISABLE_PLUGIN_AUTOLOAD=1\ + \PYTHONPATH=src\ because the sandbox interpreter has a broken global pytest plugin (langsmith/pydantic-core mismatch) and a non-editable click 8.5.0 install.