### PR TITLE
[rejected AI] Fix shell completion for equals-separated option values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Unreleased
   returns `None` for hidden options, so help screens are unchanged. {pr}`3821`
 - Document which types are inferred from `default`, and what an unrecognized
   `type` callable does to a command-line value. {issue}`3036` {pr}`3808`
+- Fix Bash and Zsh completion for option values separated by `=`. {issue}`2847`
 
 ## Version 8.5.0
 

--- a/src/click/shell_completion.py
+++ b/src/click/shell_completion.py
@@ -362,8 +362,19 @@ class ShellComplete:
         :param incomplete: Value being completed. May be empty.
         """
         ctx = _resolve_context(self.cli, self.ctx_args, self.prog_name, args)
+        completion_prefix = ""
+
+        if "=" in incomplete and _start_of_option(ctx, incomplete):
+            completion_prefix = incomplete.partition("=")[0] + "="
+
         obj, incomplete = _resolve_incomplete(ctx, args, incomplete)
-        return obj.shell_complete(ctx, incomplete)
+        completions = obj.shell_complete(ctx, incomplete)
+
+        if completion_prefix:
+            for item in completions:
+                item.value = f"{completion_prefix}{item.value}"
+
+        return completions
 
     def format_completion(self, item: CompletionItem[str]) -> str:
         """Format a completion item into the form recognized by the

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -492,6 +492,29 @@ def test_context_settings(runner):
     assert result.output == "plain,a\nplain,b\n"
 
 
+@pytest.mark.parametrize(
+    ("shell", "expect"),
+    [
+        ("bash", "plain,--color=auto\nplain,--color=always\n"),
+        ("zsh", "plain\n--color=auto\n_\nplain\n--color=always\n_\n"),
+    ],
+)
+@pytest.mark.usefixtures("_patch_for_completion")
+def test_option_value_completion_with_equals(runner, shell, expect):
+    cli = Command(
+        "cli", params=[Option(["--color"], type=Choice(["auto", "always"]))]
+    )
+    result = runner.invoke(
+        cli,
+        env={
+            "COMP_WORDS": "cli --color=",
+            "COMP_CWORD": "1",
+            "_CLI_COMPLETE": f"{shell}_complete",
+        },
+    )
+    assert result.output == expect
+
+
 # case_sensitive=False normalizes values to lowercase, matching remains case insensitive
 @pytest.mark.parametrize(("value", "expect"), [(False, ["au", "al"]), (True, ["al"])])
 def test_choice_case_sensitive(value, expect):


### PR DESCRIPTION
Fixes #2847

## Summary
- preserve the option prefix when completing values entered as `--option=value`
- add regression coverage for Bash and Zsh completion output
- document the fix in the unreleased changes

## Tests
- `uv run pytest -q`
- `uv run ruff check src/click/shell_completion.py tests/test_shell_completion.py