### PR TITLE
Fix short help abbreviation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ Unreleased
 - {class}`Parameter` accepts a new `help` argument and {class}`Option` and {class}`Argument`
   inherits it. {meth}`Parameter.to_info_dict` now reports `help` for every kind of parameter.
   {pr}`3861`
+- A command's short help no longer stops at an abbreviation such as `vs.` or `e.g.`
+  inside the first sentence. A period ends the sentence only when it closes the text
+  or the next word does not start in lowercase. {pr}`3865`
 
 ## Version 8.5.0
 

--- a/src/click/utils.py
+++ b/src/click/utils.py
@@ -64,52 +64,40 @@ def _make_default_short_help(help: str, max_length: int = 45) -> str:
 
     :meta private:
     """
-    # Consider only the first paragraph.
-    paragraph_end = help.find("\n\n")
+    # Consider only the first paragraph and collapse newlines, tabs and spaces.
+    words = help.partition("\n\n")[0].split()
 
-    if paragraph_end != -1:
-        help = help[:paragraph_end]
-
-    # Collapse newlines, tabs, and spaces.
-    words = help.split()
+    # The first paragraph started with a "no rewrap" marker, ignore it.
+    if words and words[0] == "\b":
+        words = words[1:]
 
     if not words:
         return ""
 
-    # The first paragraph started with a "no rewrap" marker, ignore it.
-    if words[0] == "\b":
-        words = words[1:]
-
-    total_length = 0
     last_index = len(words) - 1
 
+    # A period ends a sentence when it closes the text, or when the next word
+    # does not start in lowercase. A lowercase word continues the sentence, so
+    # the period belongs to an abbreviation such as "vs.".
     for i, word in enumerate(words):
-        total_length += len(word) + (i > 0)
-
-        if total_length > max_length:  # too long, truncate
+        if word.endswith(".") and (i == last_index or not words[i + 1][0].islower()):
+            words = words[: i + 1]
             break
 
-        if word[-1] == ".":  # sentence end, truncate without "..."
-            return " ".join(words[: i + 1])
+    text = " ".join(words)
 
-        if total_length == max_length and i != last_index:
-            break  # not at sentence end, truncate with "..."
-    else:
-        return " ".join(words)  # no truncation needed
+    if len(text) <= max_length:
+        return text
 
-    # Account for the length of the suffix.
-    total_length += len("...")
+    # The suffix alone does not fit, and shorten() rejects such a width.
+    if max_length < len("..."):
+        return "..."
 
-    # remove words until the length is short enough
-    while i > 0:
-        total_length -= len(words[i]) + (i > 0)
+    # Imported late to keep the import footprint small.
+    import textwrap
 
-        if total_length <= max_length:
-            break
-
-        i -= 1
-
-    return " ".join(words[:i]) + "..."
+    # Do not split hyphenated words.
+    return textwrap.shorten(text, max_length, placeholder="...", break_on_hyphens=False)
 
 
 class _LazyFile:

--- a/tests/test_utils/test_make_default_short_help.py
+++ b/tests/test_utils/test_make_default_short_help.py
@@ -8,7 +8,8 @@ import click
     [
         pytest.param("", 10, "", id="empty"),
         pytest.param("123 567 90", 10, "123 567 90", id="equal length, no dot"),
-        pytest.param("123 567 9. aaaa bbb", 10, "123 567 9.", id="sentence < max"),
+        pytest.param("123 567 9. Aaaa bbb", 10, "123 567 9.", id="sentence < max"),
+        pytest.param("123 567 9.", 10, "123 567 9.", id="dot ends text"),
         pytest.param("123 567\n\n 9. aaaa bbb", 10, "123 567", id="paragraph < max"),
         pytest.param("123 567 90123.", 10, "123 567...", id="truncate"),
         pytest.param("123 5678 xxxxxx", 10, "123...", id="length includes suffix"),
@@ -18,6 +19,28 @@ import click
             "token in ~/.netrc...",
             id="ignore dot in word",
         ),
+        pytest.param(
+            "Weigh apples vs. pears.",
+            30,
+            "Weigh apples vs. pears.",
+            id="abbreviation inside sentence",
+        ),
+        pytest.param(
+            "Weigh apples vs. pears and plums.",
+            20,
+            "Weigh apples vs....",
+            id="abbreviation inside truncated sentence",
+        ),
+        pytest.param("123 567 9. aaaa bbb", 10, "123 567...", id="lowercase after dot"),
+        pytest.param(
+            "Pick a fruit. 3 remain.", 20, "Pick a fruit.", id="digit after dot"
+        ),
+        pytest.param("well-behaved.", 8, "...", id="never split a hyphenated word"),
+        pytest.param("supercalifragilistic", 10, "...", id="never split a long word"),
+        pytest.param("ab cd", 3, "...", id="width fits the suffix only"),
+        pytest.param("ab cd", 2, "...", id="width below the suffix"),
+        pytest.param("ab", 2, "ab", id="text shorter than the suffix"),
+        pytest.param("ab cd", -1, "...", id="negative width"),
     ],
 )
 @pytest.mark.parametrize(
@@ -30,7 +53,8 @@ import click
     ],
 )
 def test_make_default_short_help(value, max_length, alter, expect):
-    assert len(expect) <= max_length
+    # A width too narrow for the suffix still returns the whole suffix.
+    assert len(expect) <= max(max_length, len("..."))
 
     if alter:
         value = alter(value)


### PR DESCRIPTION
Just a small bug I encountered in my CLIs, where as `vs.` or `e.g.` was prematurely ending the shorten version of a help message produced by `_make_default_short_help`.

Also use the opportunity to simplify the calculations and depends on Python's `textwrap.shorten`.